### PR TITLE
Add closure-based template Renderer

### DIFF
--- a/admin/src/Controllers/AbstractController.php
+++ b/admin/src/Controllers/AbstractController.php
@@ -12,6 +12,7 @@ use Formwork\Admin\Users\User;
 use Formwork\Core\Assets;
 use Formwork\Core\Formwork;
 use Formwork\Core\Site;
+use Formwork\Template\Renderer;
 use Formwork\Utils\FileSystem;
 use Formwork\Utils\Str;
 
@@ -220,27 +221,12 @@ abstract class AbstractController
     {
         $file = VIEWS_PATH . str_replace('.', DS, $view) . '.php';
         FileSystem::assert($file);
-        $output = $this->renderToString($file, array_merge($this->defaults(), $data));
-        if ($render) {
-            echo $output;
-        } else {
-            return $output;
-        }
-    }
-
-    /**
-     * Render a script
-     *
-     * @param string $file Path to the script
-     * @param array  $data Data to pass to the view
-     *
-     * @return string
-     */
-    private function renderToString($file, array $data)
-    {
         ob_start();
-        extract($data);
-        include $file;
-        return ob_get_clean();
+        Renderer::load($file, array_merge($this->defaults(), $data), $this, static::class);
+        if ($render) {
+            ob_end_flush();
+        } else {
+            return ob_get_clean();
+        }
     }
 }

--- a/formwork/Template/Layout.php
+++ b/formwork/Template/Layout.php
@@ -54,7 +54,7 @@ class Layout extends Template
      *
      * @return string|null
      */
-    protected function content()
+    public function content()
     {
         return $this->content;
     }

--- a/formwork/Template/Renderer.php
+++ b/formwork/Template/Renderer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Formwork\Template;
+
+use Closure;
+
+class Renderer
+{
+    /**
+     * Renderer instance
+     *
+     * @var Renderer
+     */
+    protected static $instance;
+
+    /**
+     * Load a script passing variables and binding to given instance and context
+     *
+     * @param string      $filename
+     * @param array       $vars
+     * @param object      $instance
+     * @param string|null $context
+     *
+     * @return mixed
+     */
+    public static function load($filename, array $vars, $instance, $context = null)
+    {
+        if (is_null(static::$instance)) {
+            static::$instance = new static();
+        }
+        $closure = static::$instance->getClosure($instance, $context);
+        return $closure($filename, $vars);
+    }
+
+    /**
+     * Return rendering closure bound to given instance and context
+     *
+     * @param object      $instance
+     * @param string|null $context
+     *
+     * @return Closure
+     */
+    protected function getClosure($instance, $context = null)
+    {
+        return Closure::bind(function ($_filename, array $_vars) {
+            extract($_vars);
+            return include $_filename;
+        }, $instance, $context);
+    }
+}

--- a/formwork/Template/Template.php
+++ b/formwork/Template/Template.php
@@ -125,6 +125,58 @@ class Template
     }
 
     /**
+     * Get Assets instance
+     *
+     * @return Assets
+     */
+    public function assets()
+    {
+        if (!is_null($this->assets)) {
+            return $this->assets;
+        }
+        return $this->assets = new Assets(
+            $this->path() . 'assets' . DS,
+            Formwork::instance()->site()->uri('/templates/assets/', false)
+        );
+    }
+
+    /**
+     * Set template layout
+     *
+     * @param string $name
+     */
+    public function layout($name)
+    {
+        if (!is_null($this->layout)) {
+            throw new RuntimeException('The layout for ' . $this->name . ' template is already set');
+        }
+        $this->layout = new Layout($name, $this->page, $this);
+    }
+
+    /**
+     * Insert a template
+     *
+     * @param string $name
+     * @param array  $vars
+     */
+    public function insert($name, array $vars = array())
+    {
+        if ($name[0] === '_') {
+            $name = 'partials' . DS . substr($name, 1);
+        }
+
+        $filename = $this->path() . $name . $this->extension;
+
+        if (!FileSystem::exists($filename)) {
+            throw new RuntimeException('Template ' . $name . ' not found');
+        }
+
+        extract(array_merge($this->vars, $vars));
+
+        include $filename;
+    }
+
+    /**
      * Render template
      *
      * @param bool  $return Whether to return rendered content or not
@@ -202,58 +254,6 @@ class Template
             extract($this->vars);
             $this->vars = array_merge($this->vars, (array) include $controllerFile);
         }
-    }
-
-    /**
-     * Get Assets instance
-     *
-     * @return Assets
-     */
-    protected function assets()
-    {
-        if (!is_null($this->assets)) {
-            return $this->assets;
-        }
-        return $this->assets = new Assets(
-            $this->path() . 'assets' . DS,
-            Formwork::instance()->site()->uri('/templates/assets/', false)
-        );
-    }
-
-    /**
-     * Set template layout
-     *
-     * @param string $name
-     */
-    protected function layout($name)
-    {
-        if (!is_null($this->layout)) {
-            throw new RuntimeException('The layout for ' . $this->name . ' template is already set');
-        }
-        $this->layout = new Layout($name, $this->page, $this);
-    }
-
-    /**
-     * Insert a template
-     *
-     * @param string $name
-     * @param array  $vars
-     */
-    protected function insert($name, array $vars = array())
-    {
-        if ($name[0] === '_') {
-            $name = 'partials' . DS . substr($name, 1);
-        }
-
-        $filename = $this->path() . $name . $this->extension;
-
-        if (!FileSystem::exists($filename)) {
-            throw new RuntimeException('Template ' . $name . ' not found');
-        }
-
-        extract(array_merge($this->vars, $vars));
-
-        include $filename;
     }
 
     public function __call($name, $arguments)


### PR DESCRIPTION
Using a closure in which templates are rendered is the most flexible approach to bind a `$this` object and decide, providing a context, which properties and methods can be accessed, so the API can be thoroughly stabilized for release 1.0.0.