### PR TITLE
Add JSON parser (wrapper around `json_encode()` and `json_decode()`)

### DIFF
--- a/admin/src/Controllers/Options.php
+++ b/admin/src/Controllers/Options.php
@@ -7,6 +7,7 @@ use Formwork\Admin\Fields\Fields;
 use Formwork\Admin\Fields\Validator;
 use Formwork\Core\Formwork;
 use Formwork\Data\DataGetter;
+use Formwork\Parsers\JSON;
 use Formwork\Parsers\YAML;
 use Formwork\Utils\FileSystem;
 use Formwork\Utils\HTTPRequest;
@@ -278,7 +279,7 @@ class Options extends AbstractController
     {
         $dependencies = [];
         if (FileSystem::exists(ROOT_PATH . 'composer.lock')) {
-            $composerLock = json_decode(FileSystem::read(ROOT_PATH . 'composer.lock'), true);
+            $composerLock = JSON::parseFile(ROOT_PATH . 'composer.lock');
             foreach ($composerLock['packages'] as $package) {
                 $dependencies[$package['name']] = $package;
             }

--- a/admin/src/Updater.php
+++ b/admin/src/Updater.php
@@ -4,6 +4,7 @@ namespace Formwork\Admin;
 
 use Formwork\Admin\Utils\Registry;
 use Formwork\Core\Formwork;
+use Formwork\Parsers\JSON;
 use Formwork\Utils\FileSystem;
 use Formwork\Utils\Str;
 use RuntimeException;
@@ -245,7 +246,7 @@ class Updater
             return;
         }
 
-        $data = json_decode(FileSystem::fetch(self::API_RELEASE_URI, $this->context), true);
+        $data = JSON::parse(FileSystem::fetch(self::API_RELEASE_URI, $this->context));
 
         if (!$data) {
             throw new RuntimeException('Cannot fetch latest Formwork release data');

--- a/admin/src/Utils/JSONResponse.php
+++ b/admin/src/Utils/JSONResponse.php
@@ -2,6 +2,7 @@
 
 namespace Formwork\Admin\Utils;
 
+use Formwork\Parsers\JSON;
 use Formwork\Utils\Header;
 
 class JSONResponse
@@ -38,7 +39,7 @@ class JSONResponse
         if ($this->status !== 200) {
             Header::status($this->status);
         }
-        echo json_encode($this->data);
+        echo JSON::encode($this->data);
         exit;
     }
 

--- a/admin/src/Utils/Registry.php
+++ b/admin/src/Utils/Registry.php
@@ -2,6 +2,7 @@
 
 namespace Formwork\Admin\Utils;
 
+use Formwork\Parsers\JSON;
 use Formwork\Utils\FileSystem;
 
 class Registry
@@ -34,7 +35,7 @@ class Registry
     {
         $this->filename = $filename;
         if (FileSystem::exists($this->filename)) {
-            $this->storage = (array) json_decode(FileSystem::read($filename), true);
+            $this->storage = JSON::parseFile($filename);
             $this->saved = true;
         }
     }
@@ -82,7 +83,7 @@ class Registry
      */
     public function save(): void
     {
-        FileSystem::write($this->filename, json_encode($this->storage));
+        JSON::encodeToFile($this->storage, $this->filename);
         $this->saved = true;
     }
 

--- a/admin/views/admin.php
+++ b/admin/views/admin.php
@@ -22,7 +22,7 @@
     <link rel="alternate icon" href="<?= $this->assets()->uri('images/icon.png') ?>">
     <link rel="stylesheet" href="<?= $this->assets()->uri('css/admin.min.css', true) ?>">
     <script src="<?= $this->assets()->uri('js/app.min.js', true) ?>"></script>
-    <script>Formwork.config = <?= json_encode($appConfig) ?>;</script>
+    <script>Formwork.config = <?= Formwork\Parsers\JSON::encode($appConfig) ?>;</script>
 </head>
 <body>
     <button type="button" class="toggle-navigation hide-from-s"><i class="i-bars"></i></button>

--- a/admin/views/dashboard/index.php
+++ b/admin/views/dashboard/index.php
@@ -44,7 +44,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="ct-chart" data-chart-data="<?= $this->escape(json_encode($statistics)); ?>"></div>
+                <div class="ct-chart" data-chart-data="<?= $this->escape(Formwork\Parsers\JSON::encode($statistics)); ?>"></div>
             </div>
         </div>
     </div>

--- a/admin/views/fields/tags.php
+++ b/admin/views/fields/tags.php
@@ -8,5 +8,5 @@
     'required'     => $field->isRequired(),
     'disabled'     => $field->isDisabled(),
     'data-field'   => 'tags',
-    'data-options' => $field->has('options') ? $this->escape(json_encode((array) $field->get('options'))) : null
+    'data-options' => $field->has('options') ? $this->escape(Formwork\Parsers\JSON::encode((array) $field->get('options'))) : null
 ]) ?>>

--- a/formwork/Parsers/JSON.php
+++ b/formwork/Parsers/JSON.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Formwork\Parsers;
+
+class JSON extends AbstractEncoder
+{
+    /**
+     * Default flags used to parse JSON
+     *
+     * @var int
+     */
+    protected const DEFAULT_PARSE_FLAGS = JSON_THROW_ON_ERROR;
+
+    /**
+     * Default flags used to encode JSON
+     *
+     * @var int
+     */
+    protected const DEFAULT_ENCODE_FLAGS = JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR;
+
+    /**
+     * Default options used to encode JSON
+     *
+     * @var array
+     */
+    protected const DEFAULT_ENCODE_OPTIONS = [
+        'forceObject'   => false,
+        'prettyPrint'   => false,
+        'escapeUnicode' => false
+    ];
+
+    /**
+     * Parse a JSON string
+     */
+    public static function parse(string $input, array $options = []): array
+    {
+        return (array) json_decode($input, true, 512, self::DEFAULT_PARSE_FLAGS);
+    }
+
+    /**
+     * Encode data to JSON format
+     */
+    public static function encode(array $data, array $options = []): string
+    {
+        $options = array_merge(self::DEFAULT_ENCODE_OPTIONS, $options);
+        $flags = self::DEFAULT_ENCODE_FLAGS;
+        if ($options['prettyPrint']) {
+            $flags |= JSON_PRETTY_PRINT;
+        }
+        if (!$options['escapeUnicode']) {
+            $flags |= JSON_UNESCAPED_UNICODE;
+        }
+        if ($data === [] || $options['forceObject']) {
+            $flags |= JSON_FORCE_OBJECT;
+        }
+        return json_encode($data, $flags);
+    }
+}


### PR DESCRIPTION
Add `Formwork\Parsers\JSON` as a wrapper around `json_encode()` and `json_decode()` to enforce consistent behavior like the returning of an associative array instead of an object, throwing exceptions on error, opt-in Unicode escape and so on.