### PR TITLE
Add SemVer parsing to ensure no future BC breaks occur with Updater

### DIFF
--- a/admin/src/Updater.php
+++ b/admin/src/Updater.php
@@ -3,6 +3,7 @@
 namespace Formwork\Admin;
 
 use Formwork\Admin\Utils\Registry;
+use Formwork\Admin\Utils\SemVer;
 use Formwork\Core\Formwork;
 use Formwork\Utils\FileSystem;
 use Formwork\Utils\Str;
@@ -141,7 +142,7 @@ class Updater
 
         $this->registry->set('last-check', time());
 
-        if (version_compare(Formwork::VERSION, $this->release['tag']) >= 0) {
+        if (!$this->isVersionInstallable($this->release['tag'])) {
             $this->registry->set('up-to-date', true);
             $this->registry->save();
             return true;
@@ -277,6 +278,16 @@ class Updater
             return $this->headers;
         }
         return $this->headers = get_headers($this->release['archive'], 1, $this->context);
+    }
+
+    /**
+     * Return whether a version is installable based on the current version of Formwork
+     */
+    protected function isVersionInstallable(string $version): bool
+    {
+        $current = SemVer::fromString(Formwork::VERSION);
+        $new = SemVer::fromString($version);
+        return !$new->isPrerelease() && $current->compareWith($new, '!=') && $current->compareWith($new, '^');
     }
 
     /**

--- a/admin/src/Utils/SemVer.php
+++ b/admin/src/Utils/SemVer.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace Formwork\Admin\Utils;
+
+use InvalidArgumentException;
+
+class SemVer
+{
+    /**
+     * Regex matching version components
+     *
+     * @var string
+     */
+    protected const SEMVER_REGEX = '/^(?<major>0|(?:[1-9]\d*))(?:\.(?<minor>0|(?:[1-9]\d*))?(?:\.(?<patch>0|(?:[1-9]\d*)))?(?:\-(?<prerelease>[0-9A-Z\.-]+))?(?:\+(?<metadata>[0-9A-Z\.-]+))?)?$/i';
+
+    /**
+     * Valid operators to compare versions
+     *
+     * @var array
+     */
+    protected const COMPARISON_OPERATORS = ['<', '<=', '==', '>=', '>', '!=', '~', '^'];
+
+    /**
+     * Valid prerelease tags, compatible with version_compare()
+     *
+     * @var array
+     */
+    protected const PRERELEASE_TAGS = ['dev', 'alpha', 'beta', 'RC', 'pl'];
+
+    /**
+     * Major version number
+     *
+     * @var int
+     */
+    protected $major = 0;
+
+    /**
+     * Minor version number
+     *
+     * @var int
+     */
+    protected $minor = 0;
+
+    /**
+     * Patch version number
+     *
+     * @var int
+     */
+    protected $patch = 0;
+
+    /**
+     * Version prerelease stability
+     *
+     * @var string
+     */
+    protected $prerelease;
+
+    /**
+     * Version metadata string
+     *
+     * @var string
+     */
+    protected $metadata;
+
+    /**
+     * Create a new SemVer instance
+     */
+    public function __construct(int $major, int $minor, int $patch, string $prerelease = null, string $metadata = null)
+    {
+        if ($major < 0 || $minor < 0 || $patch < 0) {
+            throw new InvalidArgumentException('$major, $minor and $patch arguments must be non-negative integers');
+        }
+        if ($prerelease !== null) {
+            $prerelease = $this->normalizePrerelease($prerelease);
+        }
+        $this->major = $major;
+        $this->minor = $minor;
+        $this->patch = $patch;
+        $this->prerelease = $prerelease;
+        $this->metadata = $metadata;
+    }
+
+    /**
+     * Get major version number
+     */
+    public function major(): int
+    {
+        return $this->major;
+    }
+
+    /**
+     * Get minor version number
+     */
+    public function minor(): int
+    {
+        return $this->minor;
+    }
+
+    /**
+     * Get patch version number
+     */
+    public function patch(): int
+    {
+        return $this->patch;
+    }
+
+    /**
+     * Get version prerelease stability
+     */
+    public function prerelease(): ?string
+    {
+        return $this->prerelease();
+    }
+
+    /**
+     * Get version version metadata string
+     */
+    public function metadata(): ?string
+    {
+        return $this->metadata();
+    }
+
+    /**
+     * Return an instance with only major, minor and patch numbers
+     */
+    public function onlyNumbers(): self
+    {
+        return new static($this->major, $this->minor, $this->patch);
+    }
+
+    /**
+     * Return whether the version is a prerelease
+     */
+    public function isPrerelease(): bool
+    {
+        return $this->prerelease !== null;
+    }
+
+    /**
+     * Return an instance without version prerelease stability
+     */
+    public function withoutPrerelease(): self
+    {
+        return new static($this->major, $this->minor, $this->patch, null, $this->metadata);
+    }
+
+    /**
+     * Return whether the version has metadata
+     */
+    public function hasMetadata(): bool
+    {
+        return $this->metadata !== null;
+    }
+
+    /**
+     * Return an instance without version metadata
+     */
+    public function withoutMetadata(): self
+    {
+        return new static($this->major, $this->minor, $this->patch, $this->prerelease);
+    }
+
+    /**
+     * Return an instance representing the next major version
+     */
+    public function nextMajor(): self
+    {
+        return new static($this->major + 1, 0, 0);
+    }
+
+    /**
+     * Return an instance representing the next minor version
+     */
+    public function nextMinor(): self
+    {
+        return new static($this->major, $this->minor + 1, 0);
+    }
+
+    /**
+     * Return an instance representing the next patch version
+     */
+    public function nextPatch(): self
+    {
+        return new static($this->major, $this->minor, $this->patch + 1);
+    }
+
+    /**
+     * Return the version as a string that can be used with version_compare()
+     */
+    public function toComparableString(): string
+    {
+        return (string) $this->withoutMetadata();
+    }
+
+    /**
+     * Compare this instance with another
+     */
+    public function compareWith(self $version, string $operator): bool
+    {
+        if (!in_array($operator, self::COMPARISON_OPERATORS)) {
+            throw new InvalidArgumentException('Invalid operator for version comparison: "' . $operator . '". Use one of the following: "' . implode('", "', self::COMPARISON_OPERATORS) . '"');
+        }
+        if ($operator === '~') {
+            return $this->compareWith($version, '<=') && $this->nextMinor()->compareWith($version->onlyNumbers(), '>');
+        }
+        if ($operator === '^') {
+            return $this->compareWith($version, '<=') && $this->nextMajor()->compareWith($version->onlyNumbers(), '>');
+        }
+        return version_compare($this->toComparableString(), $version->toComparableString(), $operator);
+    }
+
+    /**
+     * Compare this instance with a version from a string
+     */
+    public function compareWithString(string $version, string $operator): bool
+    {
+        return $this->compareWith(static::fromString($version), $operator);
+    }
+
+    /**
+     * Create a new SemVer instance from a string
+     */
+    public static function fromString(string $version): self
+    {
+        if (!preg_match(self::SEMVER_REGEX, $version, $matches, PREG_UNMATCHED_AS_NULL)) {
+            throw new InvalidArgumentException('Invalid version string: "' . $version . '"');
+        }
+        return new static(
+            (int) $matches['major'],
+            (int) $matches['minor'],
+            (int) $matches['patch'],
+            $matches['prerelease'],
+            $matches['metadata']
+        );
+    }
+
+    /**
+     * Normalize prerelease tag
+     */
+    protected function normalizePrerelease(string $prerelease): string
+    {
+        $parts = explode('.', $prerelease, 2);
+
+        switch ($parts[0]) {
+            case 'a':
+                $parts[0] = 'alpha';
+                break;
+            case 'b':
+                $parts[0] = 'beta';
+                break;
+            case 'rc':
+                $parts[0] = 'RC';
+                break;
+            case 'p':
+            case 'patch':
+                $parts[0] = 'pl';
+                break;
+        }
+
+        if (!in_array($parts[0], self::PRERELEASE_TAGS, true)) {
+            throw new InvalidArgumentException('Invalid prerelease tag: "' . $parts[0] . '". Use one of the following: "' . implode('", "', self::PRERELEASE_TAGS) . '"');
+        }
+
+        return implode('.', $parts);
+    }
+
+    public function __toString(): string
+    {
+        return sprintf(
+            '%u.%u.%u%s%s',
+            $this->major,
+            $this->minor,
+            $this->patch,
+            $this->prerelease !== null ? '-' . $this->prerelease : '',
+            $this->metadata !== null ? '+' . $this->metadata : ''
+        );
+    }
+}


### PR DESCRIPTION
Avoid naively checking that a version is installable with `version_compare()`, parse version instead according to semantic versioning.