### PR TITLE
Add data traits and interfaces

### DIFF
--- a/formwork/src/Data/AssociativeCollection.php
+++ b/formwork/src/Data/AssociativeCollection.php
@@ -2,23 +2,9 @@
 
 namespace Formwork\Data;
 
-use Formwork\Utils\Arr;
+use Formwork\Data\Traits\DataGetter;
 
 class AssociativeCollection extends Collection
 {
-    /**
-     * Get data by key returning a default value if key is not present
-     */
-    public function get(string $key, $default = null)
-    {
-        return Arr::get($this->items, $key, $default);
-    }
-
-    /**
-     * Return whether a key is present
-     */
-    public function has(string $key): bool
-    {
-        return Arr::has($this->items, $key);
-    }
+    use DataGetter;
 }

--- a/formwork/src/Data/Collection.php
+++ b/formwork/src/Data/Collection.php
@@ -2,82 +2,24 @@
 
 namespace Formwork\Data;
 
-use Formwork\Utils\Arr;
 use Countable;
+use Formwork\Data\Contracts\Arrayable;
+use Formwork\Utils\Arr;
+use Formwork\Data\Traits\DataArrayable;
+use Formwork\Data\Traits\DataCountableIterator;
 use Iterator;
-use ReturnTypeWillChange;
 
-class Collection implements Countable, Iterator
+class Collection implements Arrayable, Countable, Iterator
 {
-    /**
-     * Array containing collection items
-     */
-    protected array $items = [];
+    use DataArrayable;
+    use DataCountableIterator;
 
     /**
      * Create a new Collection instance
      */
-    public function __construct(array $items = [])
+    public function __construct(array $data = [])
     {
-        $this->items = $items;
-    }
-
-    /**
-     * Rewind the iterator to the first element
-     */
-    public function rewind(): void
-    {
-        reset($this->items);
-    }
-
-    /**
-     * Return the current element
-     */
-    #[ReturnTypeWillChange]
-    public function current()
-    {
-        return current($this->items);
-    }
-
-    /**
-     * Return the key of the current element
-     */
-    #[ReturnTypeWillChange]
-    public function key()
-    {
-        return key($this->items);
-    }
-
-    /**
-     * Move forward to next element
-     */
-    public function next(): void
-    {
-        next($this->items);
-    }
-
-    /**
-     * Check if current position is valid
-     */
-    public function valid(): bool
-    {
-        return $this->key() !== null;
-    }
-
-    /**
-     * Return the number of items
-     */
-    public function count(): int
-    {
-        return count($this->items);
-    }
-
-    /**
-     * Return an array containing collection items
-     */
-    public function toArray(): array
-    {
-        return $this->items;
+        $this->data = $data;
     }
 
     /**
@@ -87,7 +29,7 @@ class Collection implements Countable, Iterator
      */
     public function first()
     {
-        return $this->items[0] ?? null;
+        return $this->data[0] ?? null;
     }
 
     /**
@@ -97,7 +39,7 @@ class Collection implements Countable, Iterator
      */
     public function last()
     {
-        return $this->items[$this->count() - 1] ?? null;
+        return $this->data[$this->count() - 1] ?? null;
     }
 
     /**
@@ -105,7 +47,7 @@ class Collection implements Countable, Iterator
      */
     public function random($default = null)
     {
-        return Arr::random($this->items, $default);
+        return Arr::random($this->data, $default);
     }
 
     /**
@@ -113,6 +55,6 @@ class Collection implements Countable, Iterator
      */
     public function isEmpty(): bool
     {
-        return empty($this->items);
+        return empty($this->data);
     }
 }

--- a/formwork/src/Data/Contracts/ArraySerializable.php
+++ b/formwork/src/Data/Contracts/ArraySerializable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Formwork\Data\Contracts;
+
+interface ArraySerializable extends Arrayable
+{
+    /**
+     * Create instance from array
+     */
+    public static function fromArray(array $data): static;
+}

--- a/formwork/src/Data/Contracts/Arrayable.php
+++ b/formwork/src/Data/Contracts/Arrayable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Formwork\Data\Contracts;
+
+interface Arrayable
+{
+    /**
+     * Return an array containing data
+     */
+    public function toArray(): array;
+}

--- a/formwork/src/Data/DataGetter.php
+++ b/formwork/src/Data/DataGetter.php
@@ -2,14 +2,14 @@
 
 namespace Formwork\Data;
 
-use Formwork\Utils\Arr;
+use Formwork\Data\Contracts\Arrayable;
+use Formwork\Data\Traits\DataArrayable;
+use Formwork\Data\Traits\DataMultipleGetter;
 
-class DataGetter
+class DataGetter implements Arrayable
 {
-    /**
-     * Array containing data
-     */
-    protected array $data = [];
+    use DataArrayable;
+    use DataMultipleGetter;
 
     /**
      * Create a new instance
@@ -20,48 +20,11 @@ class DataGetter
     }
 
     /**
-     * Get data by key returning a default value if key is not present
-     */
-    public function get(string $key, $default = null)
-    {
-        return Arr::get($this->data, $key, $default);
-    }
-
-    /**
-     * Return whether a key is present
-     */
-    public function has(string $key): bool
-    {
-        return Arr::has($this->data, $key);
-    }
-
-    /**
-     * Return whether multiple keys are present
-     */
-    public function hasMultiple(array $key): bool
-    {
-        foreach ($key as $k) {
-            if (!$this->has($k)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
      * Return whether data is present
      */
     public function isEmpty(): bool
     {
         return empty($this->data);
-    }
-
-    /**
-     * Return an array containing data
-     */
-    public function toArray(): array
-    {
-        return $this->data;
     }
 
     /**

--- a/formwork/src/Data/DataSetter.php
+++ b/formwork/src/Data/DataSetter.php
@@ -2,23 +2,9 @@
 
 namespace Formwork\Data;
 
-use Formwork\Utils\Arr;
+use Formwork\Data\Traits\DataMultipleSetter;
 
 class DataSetter extends DataGetter
 {
-    /**
-     * Set a data value by key
-     */
-    public function set(string $key, $value): void
-    {
-        Arr::set($this->data, $key, $value);
-    }
-
-    /**
-     * Remove a data value by key
-     */
-    public function remove(string $key): void
-    {
-        Arr::remove($this->data, $key);
-    }
+    use DataMultipleSetter;
 }

--- a/formwork/src/Data/Traits/DataArrayable.php
+++ b/formwork/src/Data/Traits/DataArrayable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Formwork\Data\Traits;
+
+trait DataArrayable // implements Formwork\Data\Contracts\Arrayable
+{
+    protected array $data = [];
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+}

--- a/formwork/src/Data/Traits/DataCountable.php
+++ b/formwork/src/Data/Traits/DataCountable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Formwork\Data\Traits;
+
+trait DataCountable // implements \Countable
+{
+    protected array $data = [];
+
+    public function count()
+    {
+        return count($this->data);
+    }
+}

--- a/formwork/src/Data/Traits/DataCountableIterator.php
+++ b/formwork/src/Data/Traits/DataCountableIterator.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Formwork\Data\Traits;
+
+trait DataCountableIterator
+{
+    use DataCountable;
+    use DataIterator;
+}

--- a/formwork/src/Data/Traits/DataGetter.php
+++ b/formwork/src/Data/Traits/DataGetter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Formwork\Data\Traits;
+
+use Formwork\Utils\Arr;
+
+trait DataGetter
+{
+    protected array $data = [];
+
+    /**
+     * Return whether a key is present
+     */
+    public function has(string $key): bool
+    {
+        return Arr::has($this->data, $key);
+    }
+
+    /**
+     * Get data by key returning a default value if key is not present
+     */
+    public function get(string $key, $default = null)
+    {
+        return Arr::get($this->data, $key, $default);
+    }
+}

--- a/formwork/src/Data/Traits/DataIterator.php
+++ b/formwork/src/Data/Traits/DataIterator.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Formwork\Data\Traits;
+
+trait DataIterator // implements \Iterator
+{
+    protected array $data = [];
+
+    public function rewind(): void
+    {
+        reset($this->data);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function current()
+    {
+        return current($this->data);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function key()
+    {
+        return key($this->data);
+    }
+
+    public function next(): void
+    {
+        next($this->data);
+    }
+
+    public function valid(): bool
+    {
+        return $this->key() !== null;
+    }
+}

--- a/formwork/src/Data/Traits/DataMultipleGetter.php
+++ b/formwork/src/Data/Traits/DataMultipleGetter.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Formwork\Data\Traits;
+
+trait DataMultipleGetter
+{
+    use DataGetter;
+
+    /**
+     * Return whether multiple keys are present
+     */
+    public function hasMultiple(array $keys): bool
+    {
+        foreach ($keys as $key) {
+            if (!$this->has($key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get an array containing multiple values
+     */
+    public function getMultiple(array $keys, $default = null): array
+    {
+        $result = [];
+
+        foreach ($keys as $key) {
+            $result[$key] = $this->get($key, $default);
+        }
+
+        return $result;
+    }
+}

--- a/formwork/src/Data/Traits/DataMultipleSetter.php
+++ b/formwork/src/Data/Traits/DataMultipleSetter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Formwork\Data\Traits;
+
+trait DataMultipleSetter
+{
+    use DataSetter;
+
+    /**
+     * Set multiple values
+     */
+    public function setMultiple(array $keysAndValues): void
+    {
+        foreach ($keysAndValues as $key => $value) {
+            $this->set($key, $value);
+        }
+    }
+
+    /**
+     * Remove multiple values
+     */
+    public function removeMultiple(array $keys): void
+    {
+        foreach ($keys as $key) {
+            $this->remove($key);
+        }
+    }
+}

--- a/formwork/src/Data/Traits/DataSetter.php
+++ b/formwork/src/Data/Traits/DataSetter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Formwork\Data\Traits;
+
+use Formwork\Utils\Arr;
+
+trait DataSetter
+{
+    protected array $data = [];
+
+    /**
+     * Set a data value by key
+     */
+    public function set(string $key, $value): void
+    {
+        Arr::set($this->data, $key, $value);
+    }
+
+    /**
+     * Remove a data value by key
+     */
+    public function remove(string $key): void
+    {
+        Arr::remove($this->data, $key);
+    }
+}

--- a/formwork/src/Fields/Fields.php
+++ b/formwork/src/Fields/Fields.php
@@ -23,9 +23,9 @@ class Fields extends AssociativeCollection
                 if (is_int($key)) {
                     $key = $value->name();
                 }
-                $this->items[$key] = $value;
+                $this->data[$key] = $value;
             } else {
-                $this->items[$key] = new Field($key, $value);
+                $this->data[$key] = new Field($key, $value);
             }
         }
     }
@@ -37,9 +37,9 @@ class Fields extends AssociativeCollection
      */
     public function find(string $field): ?Field
     {
-        foreach ($this->items as $key => $value) {
+        foreach ($this->data as $key => $value) {
             if ($key === $field) {
-                return $this->items[$key];
+                return $this->data[$key];
             }
             if ($value->has('fields')) {
                 $found = $value->get('fields')->find($field);
@@ -59,10 +59,10 @@ class Fields extends AssociativeCollection
     public function toArray(bool $flatten = false): array
     {
         if (!$flatten) {
-            return $this->items;
+            return $this->data;
         }
         $result = [];
-        foreach ($this->items as $key => $value) {
+        foreach ($this->data as $key => $value) {
             if ($value->has('fields')) {
                 $result = array_merge($result, $value->get('fields')->toArray(true));
             } else {
@@ -83,6 +83,6 @@ class Fields extends AssociativeCollection
 
     public function __debugInfo(): array
     {
-        return $this->items;
+        return $this->data;
     }
 }

--- a/formwork/src/Files/Files.php
+++ b/formwork/src/Files/Files.php
@@ -13,7 +13,7 @@ class Files extends AssociativeCollection
     public function filterByType(string $type): self
     {
         $files = clone $this;
-        $files->items = array_filter($files->items, static fn (File $item): bool => $item->type() === $type);
+        $files->data = array_filter($files->data, static fn (File $item): bool => $item->type() === $type);
         return $files;
     }
 

--- a/formwork/src/Metadata/Metadata.php
+++ b/formwork/src/Metadata/Metadata.php
@@ -9,10 +9,10 @@ class Metadata extends AssociativeCollection
     /**
      * Create a new Metadata instance
      */
-    public function __construct(array $items)
+    public function __construct(array $data)
     {
         parent::__construct();
-        $this->setMultiple($items);
+        $this->setMultiple($data);
     }
 
     /**
@@ -20,15 +20,15 @@ class Metadata extends AssociativeCollection
      */
     public function set(string $name, string $content): void
     {
-        $this->items[$name] = new Metadatum($name, $content);
+        $this->data[$name] = new Metadatum($name, $content);
     }
 
     /**
      * Set multiple metadata
      */
-    public function setMultiple(array $items): void
+    public function setMultiple(array $data): void
     {
-        foreach ($items as $name => $content) {
+        foreach ($data as $name => $content) {
             $this->set($name, $content);
         }
     }

--- a/formwork/src/PageCollection.php
+++ b/formwork/src/PageCollection.php
@@ -34,7 +34,7 @@ class PageCollection extends Collection
     public function reverse(): self
     {
         $pageCollection = clone $this;
-        $pageCollection->items = array_reverse($pageCollection->items);
+        $pageCollection->data = array_reverse($pageCollection->data);
         return $pageCollection;
     }
 
@@ -47,7 +47,7 @@ class PageCollection extends Collection
     public function slice(int $offset, int $length = null): self
     {
         $pageCollection = clone $this;
-        $pageCollection->items = array_slice($pageCollection->items, $offset, $length);
+        $pageCollection->data = array_slice($pageCollection->data, $offset, $length);
         return $pageCollection;
     }
 
@@ -57,9 +57,9 @@ class PageCollection extends Collection
     public function remove(Page $element): self
     {
         $pageCollection = clone $this;
-        foreach ($pageCollection->items as $key => $item) {
+        foreach ($pageCollection->data as $key => $item) {
             if ($item->path() === $element->path()) {
-                unset($pageCollection->items[$key]);
+                unset($pageCollection->data[$key]);
             }
         }
         return $pageCollection;
@@ -89,7 +89,7 @@ class PageCollection extends Collection
     {
         $pageCollection = clone $this;
 
-        $pageCollection->items = array_filter($pageCollection->items, static function (Page $item) use ($property, $value, $process): bool {
+        $pageCollection->data = array_filter($pageCollection->data, static function (Page $item) use ($property, $value, $process): bool {
             if ($item->has($property)) {
                 $propertyValue = $item->get($property);
 
@@ -131,7 +131,7 @@ class PageCollection extends Collection
             throw new InvalidArgumentException('Invalid sorting direction. Use SORT_ASC or 1 for ascending order, SORT_DESC or -1 for descending');
         }
 
-        usort($pageCollection->items, static fn (Page $item1, Page $item2): int => $direction * strnatcasecmp($item1->get($property), $item2->get($property)));
+        usort($pageCollection->data, static fn (Page $item1, Page $item2): int => $direction * strnatcasecmp($item1->get($property), $item2->get($property)));
 
         return $pageCollection;
     }
@@ -142,7 +142,7 @@ class PageCollection extends Collection
     public function shuffle(): self
     {
         $pageCollection = clone $this;
-        $pageCollection->items = Arr::shuffle($pageCollection->items);
+        $pageCollection->data = Arr::shuffle($pageCollection->data);
         return $pageCollection;
     }
 
@@ -176,7 +176,7 @@ class PageCollection extends Collection
 
         $pageCollection = clone $this;
 
-        foreach ($pageCollection->items as $page) {
+        foreach ($pageCollection->data as $page) {
             $score = 0;
             foreach (array_keys($scores) as $key) {
                 $value = Str::removeHTML((string) $page->get($key));
@@ -227,7 +227,7 @@ class PageCollection extends Collection
     public function __debugInfo(): array
     {
         return [
-            'items' => $this->items
+            'items' => $this->data
         ];
     }
 }

--- a/formwork/src/Router/RouteCollection.php
+++ b/formwork/src/Router/RouteCollection.php
@@ -11,6 +11,6 @@ class RouteCollection extends AssociativeCollection
      */
     public function add(Route $route): Route
     {
-        return $this->items[$route->getName()] = $route;
+        return $this->data[$route->getName()] = $route;
     }
 }

--- a/formwork/src/Router/RouteFilterCollection.php
+++ b/formwork/src/Router/RouteFilterCollection.php
@@ -11,6 +11,6 @@ class RouteFilterCollection extends AssociativeCollection
      */
     public function add(RouteFilter $filter): RouteFilter
     {
-        return $this->items[$filter->getName()] = $filter;
+        return $this->data[$filter->getName()] = $filter;
     }
 }

--- a/formwork/src/Schemes/Schemes.php
+++ b/formwork/src/Schemes/Schemes.php
@@ -20,7 +20,7 @@ class Schemes extends Collection
     {
         if (FileSystem::isReadable($path) && FileSystem::extension($path) === 'yml') {
             $name = FileSystem::name($path);
-            $this->items[$type][$name] = $path;
+            $this->data[$type][$name] = $path;
             unset($this->storage[$type][$name]);
         }
     }
@@ -40,7 +40,7 @@ class Schemes extends Collection
      */
     public function has(string $type, string $name): bool
     {
-        return isset($this->items[$type][$name]);
+        return isset($this->data[$type][$name]);
     }
 
     /**
@@ -56,7 +56,7 @@ class Schemes extends Collection
             return $this->storage[$type][$name];
         }
 
-        return $this->storage[$type][$name] = new Scheme($type, $this->items[$type][$name]);
+        return $this->storage[$type][$name] = new Scheme($type, $this->data[$type][$name]);
     }
 
     /**

--- a/formwork/src/Translations/Translations.php
+++ b/formwork/src/Translations/Translations.php
@@ -27,7 +27,7 @@ class Translations extends Collection
     {
         if (FileSystem::isReadable($path) && FileSystem::extension($path) === 'yml') {
             $code = FileSystem::name($path);
-            $this->items[$code][] = $path;
+            $this->data[$code][] = $path;
             unset($this->storage[$code]);
         }
     }
@@ -47,7 +47,7 @@ class Translations extends Collection
      */
     public function has(string $code): bool
     {
-        return isset($this->items[$code]);
+        return isset($this->data[$code]);
     }
 
     /**
@@ -68,7 +68,7 @@ class Translations extends Collection
 
         $data = [];
 
-        foreach ($this->items[$code] as $file) {
+        foreach ($this->data[$code] as $file) {
             $data = array_merge($data, YAML::parseFile($file));
         }
 


### PR DESCRIPTION
This PR changes how Formwork handles data classes, using traits and interfaces to add and enforce behavior.

All the new traits enforce a `$data` as:
```php
protected array $data = [];
```

## New interfaces
* `Arrayable` used in classes that export data to arrays
* `ArraySerializable` enforces a static method `fromArray()` to generate class instances, will be used in future in `Formwork\Parsers\PHP`

## New traits
* `DataArrayable` implements `toArray()` method returning `$data` as an array, required by `Arrayable`
* `DataCountable` implements a `count()` method returning the count of `$data`, required by `\Countable` interface (see https://www.php.net/manual/en/class.countable.php)
* `DataIterator` implements an iterator on `$data` elements, required by `\Iterator` interface (see https://www.php.net/manual/en/class.iterator.php)
* `DataCountableIterator` is a composition of `DataCountable` and `DataIterator`
* `DataGetter` implements `has()` and `get()` methods
* `DataSetter` implements `set()` and `remove()` methods
* `DataMultipleGetter` implements `hasMultiple()` and `getMultiple()` extending `DataGetter`
* `DataMultipleSetter` implements `setMultiple()` and `removeMultiple()` extending `DataSetter`