### PR TITLE
`final` data classes

### DIFF
--- a/formwork/src/Admin/Controllers/OptionsController.php
+++ b/formwork/src/Admin/Controllers/OptionsController.php
@@ -55,7 +55,7 @@ class OptionsController extends AbstractController
             return $this->admin()->redirect('/options/system/');
         }
 
-        $fields->validate(Formwork::instance()->config());
+        $fields->validate(new DataGetter(Formwork::instance()->config()->toArray()));
 
         $this->modal('changes');
 

--- a/formwork/src/Config.php
+++ b/formwork/src/Config.php
@@ -2,8 +2,17 @@
 
 namespace Formwork;
 
-use Formwork\Data\DataGetter;
+use Formwork\Data\Contracts\Arrayable;
+use Formwork\Data\Traits\DataArrayable;
+use Formwork\Data\Traits\DataGetter;
 
-class Config extends DataGetter
+class Config implements Arrayable
 {
+    use DataArrayable;
+    use DataGetter;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
 }

--- a/formwork/src/Data/DataGetter.php
+++ b/formwork/src/Data/DataGetter.php
@@ -6,7 +6,7 @@ use Formwork\Data\Contracts\Arrayable;
 use Formwork\Data\Traits\DataArrayable;
 use Formwork\Data\Traits\DataMultipleGetter;
 
-class DataGetter implements Arrayable
+final class DataGetter implements Arrayable
 {
     use DataArrayable;
     use DataMultipleGetter;

--- a/formwork/src/Data/DataSetter.php
+++ b/formwork/src/Data/DataSetter.php
@@ -4,7 +4,7 @@ namespace Formwork\Data;
 
 use Formwork\Data\Traits\DataMultipleSetter;
 
-class DataSetter extends DataGetter
+final class DataSetter extends DataGetter
 {
     use DataMultipleSetter;
 }

--- a/formwork/src/Fields/Field.php
+++ b/formwork/src/Fields/Field.php
@@ -2,11 +2,19 @@
 
 namespace Formwork\Fields;
 
+use Formwork\Data\Contracts\Arrayable;
+use Formwork\Data\Traits\DataArrayable;
+use Formwork\Data\Traits\DataMultipleGetter;
+use Formwork\Data\Traits\DataMultipleSetter;
 use Formwork\Utils\Constraint;
 use UnexpectedValueException;
 
-class Field extends DataSetter
+class Field implements Arrayable
 {
+    use DataArrayable;
+    use DataMultipleGetter;
+    use DataMultipleSetter;
+
     /**
      * Field name
      */
@@ -18,7 +26,7 @@ class Field extends DataSetter
     public function __construct(string $name, array $data = [])
     {
         $this->name = $name;
-        parent::__construct($data);
+        $this->data = $data;
         if ($this->has('import')) {
             $this->importData();
         }

--- a/formwork/src/Router/RouteParams.php
+++ b/formwork/src/Router/RouteParams.php
@@ -2,8 +2,14 @@
 
 namespace Formwork\Router;
 
-use Formwork\Data\DataGetter;
+use Formwork\Data\Traits\DataGetter;
 
-class RouteParams extends DataGetter
+class RouteParams
 {
+    use DataGetter;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
 }

--- a/formwork/src/Schemes/Scheme.php
+++ b/formwork/src/Schemes/Scheme.php
@@ -2,13 +2,18 @@
 
 namespace Formwork\Schemes;
 
-use Formwork\Data\DataGetter;
+use Formwork\Data\Contracts\Arrayable;
+use Formwork\Data\Traits\DataArrayable;
+use Formwork\Data\Traits\DataGetter;
 use Formwork\Formwork;
 use Formwork\Parsers\YAML;
 use Formwork\Utils\FileSystem;
 
-class Scheme extends DataGetter
+class Scheme implements Arrayable
 {
+    use DataArrayable;
+    use DataGetter;
+
     /**
      * Scheme type
      */
@@ -33,11 +38,11 @@ class Scheme extends DataGetter
         $this->path = $path;
         $this->name = FileSystem::name($path);
 
-        parent::__construct(YAML::parseFile($this->path));
+        $this->data = YAML::parseFile($this->path);
 
         if ($this->has('extend') && $this->get('extend') !== $this->name) {
             $parent = Formwork::instance()->schemes()->get($type, $this->get('extend'));
-            $this->data = array_replace_recursive($parent->toArray(), $this->data);
+            $this->data = array_replace_recursive($parent->data, $this->data);
         }
 
         if (!$this->has('title')) {


### PR DESCRIPTION
This PR makes all data classes `final` like `Collection` from #387 to avoid extending too generic classes. This is part of the preparation for a more general refactor.