### PR TITLE
Add panel field 'width' attribute

### DIFF
--- a/panel/views/fields/layout/sections.php
+++ b/panel/views/fields/layout/sections.php
@@ -8,11 +8,15 @@
                 <span class="caption"><?= $this->escape($section->label()) ?></span>
             </div>
             <div class="section-content">
+                <div class="row">
                 <?php foreach ($fields->getMultiple($section->get('fields', [])) as $field) : ?>
                     <?php if ($field->isVisible()) : ?>
-                        <?php $this->insert('fields.' . $field->type(), ['field' => $field]) ?>
+                        <div <?= $this->attr(['class' => ['col-md-'.$field->get('width', '12-12')]]) ?>>
+                            <?php $this->insert('fields.' . $field->type(), ['field' => $field]) ?>
+                        </div>
                     <?php endif ?>
                 <?php endforeach ?>
+                </div>
             </div>
         </section>
     <?php endforeach ?>

--- a/panel/views/fields/layout/sections.php
+++ b/panel/views/fields/layout/sections.php
@@ -9,13 +9,13 @@
             </div>
             <div class="section-content">
                 <div class="row">
-                <?php foreach ($fields->getMultiple($section->get('fields', [])) as $field) : ?>
-                    <?php if ($field->isVisible()) : ?>
-                        <div <?= $this->attr(['class' => ['col-md-'.$field->get('width', '12-12')]]) ?>>
-                            <?php $this->insert('fields.' . $field->type(), ['field' => $field]) ?>
-                        </div>
-                    <?php endif ?>
-                <?php endforeach ?>
+                    <?php foreach ($fields->getMultiple($section->get('fields', [])) as $field) : ?>
+                        <?php if ($field->isVisible()) : ?>
+                            <div <?= $this->attr(['class' => ['col-md-' . $field->get('width', '12-12')]]) ?>>
+                                <?php $this->insert('fields.' . $field->type(), ['field' => $field]) ?>
+                            </div>
+                        <?php endif ?>
+                    <?php endforeach ?>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
according to https://github.com/getformwork/formwork/discussions/671#discussion-8090105 pull request

```
<div class="section-content">
   <div class="row">
      <?php foreach ($fields->getMultiple($section->get('fields', [])) as $field) : ?>
         <?php if ($field->isVisible()) : ?>
             <div <?= $this->attr(['class' => ['col-md-'.$field->get('width', '12-12')]]) ?>>
                   <?php $this->insert('fields.' . $field->type(), ['field' => $field]) ?>
              </div>
         <?php endif ?>
      <?php endforeach ?>
   </div>
</div>
```

```
published:
        type: checkbox
        label: '{{page.status.published}}'
        description: '{{page.status.published.description}}'
        default: true
        width: 6-12

routable:
        type: checkbox
        label: '{{page.routable}}'
        description: '{{page.routable.description}}'
        default: true
        width: 6-12
```