### PR TITLE
Rename current `AbstractCollection::pluck()` to `extract()` since it keeps array keys, and make `pluck()` return only values

### DIFF
--- a/formwork/src/Data/AbstractCollection.php
+++ b/formwork/src/Data/AbstractCollection.php
@@ -381,16 +381,28 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
     }
 
     /**
-     * Get the value corresponding to the specified key from each item in the collection
+     * Extract an associative array of values corresponding to the specified key from the collection items
      *
-     * Typed collection should implement their own version of this method, optimised for their data type
+     * Typed collections should implement their own version of this method, optimised for their data type
+     *
+     * @return array<mixed>
+     */
+    public function extract(string $key, mixed $default = null): array
+    {
+        // @phpstan-ignore argument.templateType
+        return Arr::extract($this->data, $key, $default);
+    }
+
+    /**
+     * Extract a list of values corresponding to the specified key from the collection items
+     *
+     * This method is similar to `extract()` but does not preserve keys
      *
      * @return array<mixed>
      */
     public function pluck(string $key, mixed $default = null): array
     {
-        // @phpstan-ignore argument.templateType
-        return Arr::pluck($this->data, $key, $default);
+        return array_values($this->extract($key, $default));
     }
 
     /**
@@ -408,7 +420,7 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
      */
     public function filterBy(string $key, mixed $value = true, mixed $default = null, ?bool $strict = null): static
     {
-        $values = $this->pluck($key, $default);
+        $values = $this->extract($key, $default);
 
         if (is_callable($value)) {
             $values = Arr::map($values, $value);
@@ -429,7 +441,7 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
         bool $caseSensitive = false,
         bool $preserveKeys = true,
     ): static {
-        return $this->sort($direction, $type, $this->pluck($key), $caseSensitive, $preserveKeys);
+        return $this->sort($direction, $type, $this->extract($key), $caseSensitive, $preserveKeys);
     }
 
     /**
@@ -439,7 +451,7 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
      */
     public function groupBy(string $key, mixed $default = null): array
     {
-        $values = $this->pluck($key, $default);
+        $values = $this->extract($key, $default);
         return $this->group(fn($v, $k) => $values[$k]);
     }
 

--- a/formwork/src/Fields/FieldCollection.php
+++ b/formwork/src/Fields/FieldCollection.php
@@ -58,7 +58,7 @@ class FieldCollection extends AbstractCollection
         return $this->model;
     }
 
-    public function pluck(string $key, mixed $default = null): array
+    public function extract(string $key, mixed $default = null): array
     {
         return $this->everyItem()->get($key, $default)->toArray();
     }

--- a/formwork/src/Pages/Page.php
+++ b/formwork/src/Pages/Page.php
@@ -235,7 +235,7 @@ class Page extends Model implements Stringable
         ];
 
         // Merge with scheme default field values
-        $defaults = [...$defaults, ...Arr::reject($this->fields()->pluck('default'), fn($value) => $value === null)];
+        $defaults = [...$defaults, ...Arr::reject($this->fields()->extract('default'), fn($value) => $value === null)];
 
         // If the page doesn't have a route, by default it won't be routable nor cacheable
         if ($this->route() === null) {

--- a/formwork/src/Pages/PageCollection.php
+++ b/formwork/src/Pages/PageCollection.php
@@ -52,7 +52,7 @@ class PageCollection extends AbstractCollection implements Paginable
         return $pageCollection;
     }
 
-    public function pluck(string $key, mixed $default = null): array
+    public function extract(string $key, mixed $default = null): array
     {
         return $this->everyItem()->get($key, $default)->toArray();
     }

--- a/formwork/src/Panel/Controllers/FilesController.php
+++ b/formwork/src/Panel/Controllers/FilesController.php
@@ -342,7 +342,7 @@ final class FilesController extends AbstractController
 
         $scheme = $file->scheme();
 
-        $defaults = $scheme->fields()->pluck('default');
+        $defaults = $scheme->fields()->extract('default');
 
         foreach ($fieldCollection as $field) {
             if ($field->isEmpty() || (Arr::has($defaults, $field->name()) && Arr::get($defaults, $field->name()) === $field->value())) {

--- a/formwork/src/Utils/Arr.php
+++ b/formwork/src/Utils/Arr.php
@@ -535,7 +535,9 @@ final class Arr
     }
 
     /**
-     * Get the value corresponding to the specified key from each element of an array
+     * Extract an array of values corresponding to the specified key from the given array
+     *
+     * The original array keys are preserved
      *
      * @param array<TKey, array<K, V>> $array
      *
@@ -545,7 +547,7 @@ final class Arr
      * @template K of array-key
      * @template V
      */
-    public static function pluck(array $array, string $key, mixed $default = null): array
+    public static function extract(array $array, string $key, mixed $default = null): array
     {
         return self::map($array, fn($value) => self::get(self::from($value), $key, $default));
     }


### PR DESCRIPTION
This pull request refactors the `AbstractCollection::pluck()` method replacing it with a new `extract()` method to improve clarity and maintainability.

In fact in many other projects, like notably Laravel, `pluck()` extracts only the values from the collection items, without preserving the keys, unlike the former Formwork equivalent of the method.

By doing this we ensure the collection API is more predictable.

`pluck()` is still kept in `AbstractCollection` to provide a variant of `extract()` that does not preserve keys.

The changes impact several classes and methods, ensuring consistency across the codebase.

**Note:** `Arr::pluck()` has been renamed to `Arr::extract()`.