### PR TITLE
Require entire matches by default with `Constraint::matchesRegex()`

### DIFF
--- a/formwork/fields/color.php
+++ b/formwork/fields/color.php
@@ -9,7 +9,7 @@ return function (App $app) {
     return [
         'methods' => [
             'validate' => function (Field $field, $value): string {
-                if (!Constraint::matchesRegex($value, '/^#[0-9A-Fa-f]{6}$/')) {
+                if (!Constraint::matchesRegex($value, '#[0-9A-Fa-f]{6}')) {
                     throw new ValidationException(sprintf('Invalid value for field "%s" of type "%s"', $field->name(), $field->type()));
                 }
 

--- a/formwork/schemes/config/system.yaml
+++ b/formwork/schemes/config/system.yaml
@@ -81,7 +81,7 @@ fields:
         label: '{{panel.options.system.files.allowedExtensions}}'
         icon: file-exclamation
         placeholder: '{{panel.options.system.files.allowedExtensions.noExtensions}}'
-        pattern: '^\.[a-zA-Z0-9]+$'
+        pattern: '\.[a-zA-Z0-9]+'
         options@: mimeTypes.getExtensionTypes()
 
     cache.enabled:

--- a/formwork/src/Utils/Constraint.php
+++ b/formwork/src/Utils/Constraint.php
@@ -64,8 +64,11 @@ final class Constraint
     /**
      * Return whether a value matches the specified regex pattern
      */
-    public static function matchesRegex(string $value, string $regex): bool
+    public static function matchesRegex(string $value, string $regex, bool $entireMatch = true): bool
     {
+        if ($entireMatch) {
+            $regex = '^(?:' . trim($regex, '^$/') . ')$';
+        }
         return (bool) @preg_match(Str::wrap($regex, '/'), $value);
     }
 

--- a/panel/modals/newPage.yaml
+++ b/panel/modals/newPage.yaml
@@ -13,7 +13,7 @@ fields:
         label: '{{page.slug}}'
         suggestion: '{{page.slug.suggestion}}'
         required: true
-        pattern: '^[a-z0-9\-]+$'
+        pattern: '[a-z0-9\-]+'
         source: title
         root: parent
 

--- a/site/schemes/config/site.yaml
+++ b/site/schemes/config/site.yaml
@@ -54,7 +54,7 @@ fields:
         label: '{{panel.site.languages.availableLanguages}}'
         icon: translate
         placeholder: '{{panel.site.languages.availableLanguages.noLanguages}}'
-        pattern: '^[a-z]{2,3}$'
+        pattern: '[a-z]{2,3}'
         translate: [label, placeholder]
         options@: languages.names
 


### PR DESCRIPTION
This pull request introduces updates to regex patterns across multiple files to improve flexibility and consistency, as well as enhancements to the `matchesRegex` method to support partial or full regex matches.

Now patterns need to match the entire string by default, as if they were wrapped between `^(?:` and `)$`.
This is to avoid unexpected matches and be consistent with the browser validation with pattern specified with the [`<input pattern="...">` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/pattern).

Below is a summary of the most important changes:

### Method Enhancement:
* Modified the `matchesRegex` method in `formwork/src/Utils/Constraint.php` to include an optional `$entireMatch` parameter, defaulting to `true`. This allows for both full and partial regex matches by dynamically appending anchors when needed.