### PR TITLE
Add basic named filters to collections `filterBy()` method

### DIFF
--- a/formwork/src/Data/AbstractCollection.php
+++ b/formwork/src/Data/AbstractCollection.php
@@ -418,17 +418,37 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
     /**
      * Filter the collection using the key from each item
      */
-    public function filterBy(string $key, mixed $value = true, mixed $default = null, ?bool $strict = null): static
+    public function filterBy(string $key, mixed $value = true, mixed $comparison = null): static
     {
-        $values = $this->extract($key, $default);
+        $values = $this->extract($key);
+
+        $args = func_num_args();
 
         if (is_callable($value)) {
+            if ($args > 2) {
+                throw new LogicException(sprintf('Unexpected third argument passed to %s()', __METHOD__));
+            }
             $values = Arr::map($values, $value);
-            $comparison = true;
-            $strict ??= true;
+            $parameters = [Constraint::isEqualTo(...), true, true];
         }
 
-        return $this->filter(fn($v, $k) => Constraint::isEqualTo($values[$k], $comparison ??= $value, $strict ??= false));
+        if ($args > 2) {
+            $parameters = match ($value) {
+                'equalTo', '==' => [Constraint::isEqualTo(...), $comparison, false],
+                'notEqualTo', '!=' => [Constraint::isNotEqualTo(...), $comparison, false],
+                'strictlyEqualTo', '===' => [Constraint::isEqualTo(...), $comparison, true],
+                'strictlyNotEqualTo', '!==' => [Constraint::isNotEqualTo(...), $comparison, true],
+                'greaterThan', '>' => [Constraint::isGreaterThan(...), $comparison],
+                'greaterThanOrEqualTo', '>=' => [Constraint::isGreaterThanOrEqualTo(...), $comparison],
+                'lessThan', '<' => [Constraint::isLessThan(...), $comparison],
+                'lessThanOrEqualTo', '<=' => [Constraint::isLessThanOrEqualTo(...), $comparison],
+                default => throw new LogicException(sprintf('Unknown filter "%s"', $value)),
+            };
+        }
+
+        [$filter, $comparison] = $parameters ??= [Constraint::isEqualTo(...), $value, false];
+
+        return $this->filter(fn($v, $k) => $filter($values[$k], $comparison, ...array_slice($parameters, 2)));
     }
 
     /**

--- a/formwork/src/Data/AbstractCollection.php
+++ b/formwork/src/Data/AbstractCollection.php
@@ -448,6 +448,7 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
         [$filter, $comparison, $strict] = array_replace([Constraint::isEqualTo(...), $value, false], $parameters ?? []);
 
+        // @phpstan-ignore arguments.count
         return $this->filter(fn($v, $k) => $filter($values[$k], $comparison, $strict));
     }
 

--- a/formwork/src/Data/AbstractCollection.php
+++ b/formwork/src/Data/AbstractCollection.php
@@ -446,7 +446,7 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
             };
         }
 
-        [$filter, $comparison, $strict] = $parameters ??= [Constraint::isEqualTo(...), $value, false];
+        [$filter, $comparison, $strict] = array_replace([Constraint::isEqualTo(...), $value, false], $parameters ?? []);
 
         return $this->filter(fn($v, $k) => $filter($values[$k], $comparison, $strict));
     }

--- a/formwork/src/Data/AbstractCollection.php
+++ b/formwork/src/Data/AbstractCollection.php
@@ -446,9 +446,9 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
             };
         }
 
-        [$filter, $comparison] = $parameters ??= [Constraint::isEqualTo(...), $value, false];
+        [$filter, $comparison, $strict] = $parameters ??= [Constraint::isEqualTo(...), $value, false];
 
-        return $this->filter(fn($v, $k) => $filter($values[$k], $comparison, ...array_slice($parameters, 2)));
+        return $this->filter(fn($v, $k) => $filter($values[$k], $comparison, $strict));
     }
 
     /**

--- a/formwork/src/Utils/Constraint.php
+++ b/formwork/src/Utils/Constraint.php
@@ -62,6 +62,46 @@ final class Constraint
     }
 
     /**
+     * Return whether a value is not equal to another
+     */
+    public static function isNotEqualTo(mixed $value, mixed $comparison, bool $strict = true): bool
+    {
+        return $strict ? $value !== $comparison : $value != $comparison;
+    }
+
+    /**
+     * Return whether a value is greater than another
+     */
+    public static function isGreaterThan(int|float $value, int|float $comparison): bool
+    {
+        return $value > $comparison;
+    }
+
+    /**
+     * Return whether a value is greater than or equal to another
+     */
+    public static function isGreaterThanOrEqualTo(int|float $value, int|float $comparison): bool
+    {
+        return $value >= $comparison;
+    }
+
+    /**
+     * Return whether a value is less than another
+     */
+    public static function isLessThan(int|float $value, int|float $comparison): bool
+    {
+        return $value < $comparison;
+    }
+
+    /**
+     * Return whether a value is less than or equal to another
+     */
+    public static function isLessThanOrEqualTo(int|float $value, int|float $comparison): bool
+    {
+        return $value <= $comparison;
+    }
+
+    /**
      * Return whether a value matches the specified regex pattern
      */
     public static function matchesRegex(string $value, string $regex, bool $entireMatch = true): bool


### PR DESCRIPTION
This pull request introduces enhancements to the filtering functionality in the `AbstractCollection` class and adds new comparison methods to the `Constraint` utility class. The changes improve the flexibility and readability of filtering operations by supporting various comparison types and adding corresponding utility methods.

### Enhancements to filtering functionality:

* Modified the `filterBy` method in `AbstractCollection` to support multiple comparison types (e.g., `equalTo`, `greaterThan`, `lessThan`) using a `match` statement. This change replaces the previous implementation and introduces a more structured approach for handling comparisons.
* Added validation to ensure no unexpected arguments are passed when using callable filters in the `filterBy` method.

### New comparison methods in `Constraint`:

* Added utility methods such as `isNotEqualTo`, `isGreaterThan`, `isGreaterThanOrEqualTo`, `isLessThan`, and `isLessThanOrEqualTo` to the `Constraint` class to support the new filtering capabilities. These methods provide reusable logic for performing various comparisons.