### PR TITLE
Add image preview functionality to tree.php

### DIFF
--- a/panel/views/pages/tree.php
+++ b/panel/views/pages/tree.php
@@ -53,6 +53,18 @@
                         <div class="page-route truncate mr-2" aria-hidden="true">
                             <span><?= $page->canonicalRoute() ?? $page->route() ?></span>
                         </div>
+                        <?php
+                            $imagePreviewFieldName = $page->scheme()->options()->get('imagePreviewField', '');
+                            $imagePreviewFieldValue = $imagePreviewFieldName == '' ? '' : $page->fields()->get($imagePreviewFieldName);
+                            $imagePreviewFile = $imagePreviewFieldValue == '' ? '' : $page->files()->get($imagePreviewFieldValue);
+                        ?>
+                        <?php if($imagePreviewFile != '') : ?>
+                            <div class="col-sm-1-2 col-xs-1-3 mt-3 pl-0">
+                                <a href="<?= $panel->uri('/pages/' . trim($page->route(), '/') . '/edit/') ?>">
+                                    <img src="<?= $imagePreviewFile->square(300, 'contain')->uri() ?>" alt="" />
+                                </a>
+                            </div>
+                        <?php endif; ?>
                     </div>
                 </div>
                 <div class="pages-tree-item-cell page-date truncate show-from-lg"><?= $date ?></div>

--- a/panel/views/pages/tree.php
+++ b/panel/views/pages/tree.php
@@ -53,16 +53,12 @@
                         <div class="page-route truncate mr-2" aria-hidden="true">
                             <span><?= $page->canonicalRoute() ?? $page->route() ?></span>
                         </div>
-                        <?php
-                            $imagePreviewFieldName = $page->scheme()->options()->get('imagePreviewField', '');
-                            $imagePreviewFieldValue = $imagePreviewFieldName == '' ? '' : $page->fields()->get($imagePreviewFieldName);
-                            $imagePreviewFile = $imagePreviewFieldValue == '' ? '' : $page->files()->get($imagePreviewFieldValue);
-                        ?>
-                        <?php if($imagePreviewFile != '') : ?>
-                            <div class="col-sm-1-2 col-xs-1-3 mt-3 pl-0">
-                                <a href="<?= $panel->uri('/pages/' . trim($page->route(), '/') . '/edit/') ?>">
-                                    <img src="<?= $imagePreviewFile->square(300, 'contain')->uri() ?>" alt="" />
-                                </a>
+                        <?php $imagePreviewField = $page->scheme()->options()->get('imagePreviewField') ?>
+                        <?php if ($imagePreviewField !== null && $page->fields()->get($imagePreviewField)?->type() === 'image' && $page->get($imagePreviewField) != '') : ?>
+                            <div class="row mt-3">
+                                <div class="col-sm-1-2 col-xs-1-3">
+                                    <img src="<?= $page->get($imagePreviewField)->square(300, 'contain')->uri() ?>" alt="" />
+                                </div>
                             </div>
                         <?php endif; ?>
                     </div>


### PR DESCRIPTION
Allow child page options to set a preview image to display in page tree. Like this:

options:
    default: false
    children: false
    num: date
    imagePreviewField: coverImage