### PR TITLE
Improved cache control

### DIFF
--- a/formwork/src/Controllers/PageController.php
+++ b/formwork/src/Controllers/PageController.php
@@ -160,7 +160,7 @@ final class PageController extends AbstractController
         $response = new Response($content, $page->responseStatus(), $page->headers() + $headers);
 
         if ($cacheable) {
-            $this->filesCache->save($cacheKey, $response);
+            $this->filesCache->save($cacheKey, $response, $page->get('cache.time', null));
         }
 
         return $response;

--- a/formwork/src/Controllers/PageController.php
+++ b/formwork/src/Controllers/PageController.php
@@ -126,35 +126,38 @@ final class PageController extends AbstractController
          */
         $page = $this->site->currentPage();
 
-        // Use requested route as cache key to inlude parameters like pagination and tags
+        // Use requested route as cache key to include parameters like pagination and tags
         $cacheKey = $this->router->request();
 
-        $headers = [];
+        $cacheable = $this->config->get('system.cache.enabled')
+            && $this->isRequestCacheable()
+            && $page->cacheable()
+            && !$page->isErrorPage();
 
-        if (($cacheable = $this->config->get('system.cache.enabled') && $this->isRequestCacheable() && $page->cacheable())) {
-            if ($page->contentFile() !== null) {
-                $lastModifiedTime = max($page->lastModifiedTime(), $this->site->lastModifiedTime());
-                $headers = [
-                    'ETag'          => hash('sha256', $page->contentFile()->path() . ':' . $lastModifiedTime),
-                    'Last-Modified' => gmdate('D, d M Y H:i:s T', $lastModifiedTime),
-                ];
+        if ($cacheable && $this->filesCache->has($cacheKey)) {
+            /**
+             * @var int
+             */
+            $cachedTime = $this->filesCache->cachedTime($cacheKey);
+            // Validate cached response
+            if (!$this->site->modifiedSince($cachedTime)) {
+                return $this->filesCache->fetch($cacheKey);
             }
-
-            if ($this->filesCache->has($cacheKey)) {
-                /**
-                 * @var int
-                 */
-                $cachedTime = $this->filesCache->cachedTime($cacheKey);
-                // Validate cached response
-                if (!$this->site->modifiedSince($cachedTime)) {
-                    return $this->filesCache->fetch($cacheKey);
-                }
-
-                $this->filesCache->delete($cacheKey);
-            }
+            $this->filesCache->delete($cacheKey);
         }
 
-        $response = new Response($page->render(), $page->responseStatus(), $page->headers() + $headers);
+        $content = $page->render();
+        $headers = [];
+
+        if ($cacheable) {
+            $lastModifiedTime = max($page->lastModifiedTime(), $this->site->lastModifiedTime());
+            $headers = [
+                'ETag'          => hash('sha256', $content . ':' . $lastModifiedTime),
+                'Last-Modified' => gmdate('D, d M Y H:i:s T', $lastModifiedTime),
+            ];
+        }
+
+        $response = new Response($content, $page->responseStatus(), $page->headers() + $headers);
 
         if ($cacheable) {
             $this->filesCache->save($cacheKey, $response);
@@ -168,6 +171,7 @@ final class PageController extends AbstractController
      */
     private function isRequestCacheable(): bool
     {
-        return in_array($this->request->method(), [RequestMethod::GET, RequestMethod::HEAD]);
+        return in_array($this->request->method(), [RequestMethod::GET, RequestMethod::HEAD])
+            && $this->request->query()->isEmpty();
     }
 }


### PR DESCRIPTION
This pull request updates the page response caching logic in `PageController.php` to improve cache accuracy and control. The main changes ensure that error pages are never cached, cache headers are generated based on the rendered content, and only cache GET/HEAD requests without query parameters. These improvements help prevent serving outdated or incorrect content.

Caching logic improvements:

* Error pages are now explicitly excluded from being cached by adding a check for `!$page->isErrorPage()` to the `$cacheable` condition.
* Cache headers (`ETag` and `Last-Modified`) are now generated using the rendered page content and its last modified time, instead of the content file path, for more accurate cache validation.
* The cache save operation now uses an optional cache time from the page configuration (`$page->get('cache.time', null)`), allowing for configurable cache durations.

Request cacheability refinement:

* Requests with query parameters are now excluded from caching by updating `isRequestCacheable()` to require an empty query string.