### PR TITLE
Add methods `Image::width()` and `Image::height()` to get computed dimensions

### DIFF
--- a/formwork/src/Images/Image.php
+++ b/formwork/src/Images/Image.php
@@ -470,6 +470,24 @@ class Image extends File
         return $this->handler()->getInfo();
     }
 
+    /**
+     * Get image width. The width is computed after applying transforms (if any).
+     * To get the original image width, use `info()->width()`.
+     */
+    public function width(): int
+    {
+        return $this->process()->info()->width();
+    }
+
+    /**
+     * Get image height. The height is computed after applying transforms (if any).
+     * To get the original image height, use `info()->height()`.
+     */
+    public function height(): int
+    {
+        return $this->process()->info()->height();
+    }
+
     public function toArray(): array
     {
         return [


### PR DESCRIPTION
This pull request adds two new methods to the `Image` class to provide easier access to the image's width and height after any transformations have been applied, improving the API's usability and clarity.

Enhancements to the `Image` class API:

* Added a `width()` method to return the image's width after applying transforms, with documentation clarifying its distinction from the original width (`info()->width()`).
* Added a `height()` method to return the image's height after applying transforms, with documentation clarifying its distinction from the original height (`info()->height()`).