### PR TITLE
Improve updates check to include current release

### DIFF
--- a/formwork/config/system.yaml
+++ b/formwork/config/system.yaml
@@ -124,7 +124,7 @@ translations:
 
 updates:
     time: 900
-    force: true
+    force: false
     tempFile: '${%ROOT_PATH%}/.formwork-update.zip'
     preferDistAssets: true
     backupBefore: true


### PR DESCRIPTION
This pull request refactors and improves the update checking logic in the `Updater` class, making update checks more accurate and efficient. The changes introduce new registry fields for better tracking of releases, refine the use of ETags for update validation, and clarify the distinction between release and archive headers. The configuration is also updated to make forced updates optional by default.

**Updater logic and registry improvements:**

* Added new registry fields: `currentRelease` (tracks the currently installed version) and `releaseArchiveEtag` (stores the ETag of the release archive), and updated the default registry data structure accordingly.
* Refined the update check in `checkUpdates()` to only perform remote checks when necessary, based on version and ETag, and to use the new registry fields for more precise update validation.
* Updated the update process to set the new registry fields after a successful update, ensuring accurate tracking of the installed release and its archive ETag.

**Header handling refactor:**

* Renamed and separated header handling: replaced the generic `headers` property with `releaseArchiveHeaders`, and introduced dedicated methods `getReleaseArchiveHeaders()` and `getReleaseArchiveEtag()` for clarity and correctness. [[1]](diffhunk://#diff-5292dfadba397776d7cf3959eb28fa0666d81eb146d082848821da26601631e6L58-R63) [[2]](diffhunk://#diff-5292dfadba397776d7cf3959eb28fa0666d81eb146d082848821da26601631e6L244-R252)

**Configuration update:**

* Changed the `force` option in `system.yaml` to `false` by default, making forced update checks opt-in.