### PR TITLE
Add `bin/formwork` command

### DIFF
--- a/bin/formwork
+++ b/bin/formwork
@@ -1,0 +1,8 @@
+#!/usr/bin/env php
+<?php
+
+use Formwork\Commands\FormworkCommandRunner;
+
+require dirname(__DIR__) . '/formwork/bootstrap.php';
+
+(new FormworkCommandRunner())($argv);

--- a/formwork/bootstrap.php
+++ b/formwork/bootstrap.php
@@ -10,7 +10,7 @@ if (!defined('SYSTEM_PATH')) {
 
 // Check PHP version requirements
 if (!version_compare(PHP_VERSION, '8.3.0', '>=')) {
-    if (php_sapi_name() === 'cli') {
+    if (PHP_SAPI === 'cli') {
         printf("Formwork requires PHP 8.3.0 or higher. You are running PHP %s.\n", PHP_VERSION);
         exit(1);
     }
@@ -22,7 +22,7 @@ if (!version_compare(PHP_VERSION, '8.3.0', '>=')) {
 if (file_exists(ROOT_PATH . '/vendor/autoload.php')) {
     require ROOT_PATH . '/vendor/autoload.php';
 } else {
-    if (php_sapi_name() === 'cli') {
+    if (PHP_SAPI === 'cli') {
         echo "Composer autoloader not found. Please run \"composer install\" in the root directory.\n";
         exit(1);
     }

--- a/formwork/src/Cms/App.php
+++ b/formwork/src/Cms/App.php
@@ -56,6 +56,11 @@ final class App
      */
     private Container $container;
 
+    /**
+     * Whether the app has been loaded
+     */
+    private bool $loaded = false;
+
     public function __construct()
     {
         $this->initializeSingleton();
@@ -147,15 +152,27 @@ final class App
     }
 
     /**
+     * Load Formwork app
+     */
+    public function load(): void
+    {
+        if ($this->loaded) {
+            return;
+        }
+
+        $this->loadErrorHandler();
+        $this->loadServices($this->container);
+        $this->loadRoutes();
+        $this->loaded = true;
+    }
+
+    /**
      * Run Formwork
      */
     public function run(): Response
     {
-        $this->loadErrorHandler();
-
         try {
-            $this->loadServices($this->container);
-            $this->loadRoutes();
+            $this->load();
             $response = $this->router()->dispatch();
         } catch (Throwable $throwable) {
             try {

--- a/formwork/src/Commands/BackupCommand.php
+++ b/formwork/src/Commands/BackupCommand.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Formwork\Commands;
+
+use Formwork\Backup\Backupper;
+use Formwork\Cms\App;
+use Formwork\Utils\FileSystem;
+use League\CLImate\CLImate;
+use League\CLImate\Exceptions\InvalidArgumentException;
+
+final class BackupCommand implements CommandInterface
+{
+    /**
+     * CLImate instance
+     */
+    private CLImate $climate;
+
+    /**
+     * App instance
+     */
+    private App $app;
+
+    /**
+     * @var array<string, array{description: string}>
+     */
+    private array $actions = [
+        'make' => [
+            'description' => 'Create a backup of the Formwork installation',
+        ],
+        'list' => [
+            'description' => 'List available backups',
+        ],
+    ];
+
+    public function __construct()
+    {
+        $this->climate = new CLImate();
+
+        $this->climate->arguments->add([
+            'action' => [
+                'description' => 'Backup action to perform (make, list)',
+                'required'    => true,
+            ],
+            'help' => [
+                'prefix'      => 'h',
+                'longPrefix'  => 'help',
+                'description' => 'Show this help screen',
+                'noValue'     => true,
+            ],
+        ]);
+    }
+
+    public function __invoke(?array $argv = null): never
+    {
+        $argv ??= $_SERVER['argv'] ?? [];
+
+        $this->app = App::instance();
+        $this->app->load();
+
+        if (count($argv) < 2 || $this->climate->arguments->defined('help', $argv)) {
+            $this->help($argv);
+            exit(0);
+        }
+
+        try {
+            $this->climate->arguments->parse($argv);
+        } catch (InvalidArgumentException $e) {
+            $this->climate->error($e->getMessage());
+            exit(1);
+        }
+
+        $action = (string) $this->climate->arguments->get('action');
+
+        if (isset($this->actions[$action])) {
+            try {
+                $this->{$action}($argv);
+                exit(0);
+            } catch (InvalidArgumentException $e) {
+                $this->climate->error($e->getMessage());
+                exit(1);
+            }
+        }
+
+        $this->climate->error(sprintf('Invalid action: %s.', $action));
+        exit(1);
+    }
+
+    /**
+     * `backup make` action
+     *
+     * @param list<string> $argv
+     */
+    public function make(array $argv = []): void
+    {
+        $this->climate->out('Creating backup... this may take a while depending on the size of your installation.');
+        $file = $this->getBackupper()->backup();
+        $this->climate->br()->out(sprintf('<green>Backup created:</green> %s', $file));
+    }
+
+    /**
+     * `backup list` action
+     *
+     * @param list<string> $argv
+     */
+    public function list(array $argv = []): void
+    {
+        $backups = $this->getBackupper()->getBackups();
+        if (count($backups) === 0) {
+            $this->climate->green('No backups found.');
+            return;
+        }
+        $this->climate->green('Available backups:');
+        foreach ($backups as $backup) {
+            $name = basename($backup);
+            $size = FileSystem::formatSize(FileSystem::size($backup));
+            $time = date('Y-m-d H:i:s T', FileSystem::lastModifiedTime($backup));
+
+            $this->climate->out(sprintf('  <light_gray>[%s]</light_gray> %s <cyan>%s</cyan>', $time, $name, $size));
+        }
+    }
+
+    /**
+     * Get Backupper instance
+     */
+    private function getBackupper(): Backupper
+    {
+        return new Backupper([...$this->app->config()->get('system.backup'), 'hostname' => gethostname() ?: 'local-cli']);
+    }
+
+    /**
+     * @param list<string> $argv
+     */
+    private function help(array $argv): void
+    {
+        $this->climate->usage($argv);
+        $this->climate->br();
+        $this->climate->out('Available Actions:');
+
+        foreach ($this->actions as $name => ['description' => $description]) {
+            $this->climate->tab()->out($name);
+            $this->climate->tab(2)->out($description);
+        }
+    }
+}

--- a/formwork/src/Commands/CacheCommand.php
+++ b/formwork/src/Commands/CacheCommand.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace Formwork\Commands;
+
+use Formwork\Cache\FilesCache;
+use Formwork\Cms\App;
+use Formwork\Utils\FileSystem;
+use League\CLImate\CLImate;
+use League\CLImate\Exceptions\InvalidArgumentException;
+
+final class CacheCommand implements CommandInterface
+{
+    /**
+     * CLImate instance
+     */
+    private CLImate $climate;
+
+    private App $app;
+
+    /**
+     * @var array<string, array{description: string}>
+     */
+    private array $actions = [
+        'clear' => [
+            'description' => 'Clear cache files from the specified cache type',
+        ],
+        'invalidate' => [
+            'description' => 'Invalidate cache for the specified cache type (does not delete files)',
+        ],
+        'stats' => [
+            'description' => 'Show cache statistics for the specified cache type',
+        ],
+    ];
+
+    public function __construct()
+    {
+        $this->climate = new CLImate();
+
+        $this->climate->arguments->add([
+            'action' => [
+                'description' => 'Cache action to perform (clear, invalidate, stats)',
+                'required'    => true,
+            ],
+            'type' => [
+                'description'  => 'Type of cache to act on (all, config, images, pages)',
+                'required'     => true,
+                'defaultValue' => 'all',
+            ],
+            'help' => [
+                'prefix'      => 'h',
+                'longPrefix'  => 'help',
+                'description' => 'Show this help screen',
+                'noValue'     => true,
+            ],
+        ]);
+    }
+
+    public function __invoke(?array $argv = null): never
+    {
+        $argv ??= $_SERVER['argv'] ?? [];
+
+        $this->app = App::instance();
+        $this->app->load();
+
+        if (count($argv) < 2 || $this->climate->arguments->defined('help', $argv)) {
+            $this->help($argv);
+            exit(0);
+        }
+
+        try {
+            $this->climate->arguments->parse($argv);
+        } catch (InvalidArgumentException $e) {
+            $this->climate->error($e->getMessage());
+            exit(1);
+        }
+
+        $action = (string) $this->climate->arguments->get('action');
+        $type = (string) $this->climate->arguments->get('type');
+
+        if (isset($this->actions[$action])) {
+            try {
+                $this->{$action}($type, $argv);
+                exit(0);
+            } catch (InvalidArgumentException $e) {
+                $this->climate->error($e->getMessage());
+                exit(1);
+            }
+        }
+
+        $this->climate->error(sprintf('Invalid action: %s.', $action));
+        exit(1);
+    }
+
+    /**
+     * `cache clear` action
+     *
+     * @param list<string> $argv
+     */
+    public function clear(string $type, array $argv = []): void
+    {
+        switch ($type) {
+            case 'all':
+                $this->clearConfigCache();
+                $this->clearImagesCache();
+                $this->clearPagesCache();
+                $this->climate->green('All caches cleared.');
+                break;
+            case 'config':
+                $this->clearConfigCache();
+                $this->climate->green('Config cache cleared.');
+                break;
+            case 'pages':
+                $this->clearPagesCache();
+                $this->climate->green('Pages cache cleared.');
+                break;
+            case 'images':
+                $this->clearImagesCache();
+                $this->climate->green('Images cache cleared.');
+                break;
+            default:
+                throw new InvalidArgumentException('Invalid cache type for clearing.');
+        }
+    }
+
+    /**
+     * `cache invalidate` action
+     *
+     * @param list<string> $argv
+     */
+    public function invalidate(string $type, array $argv = []): void
+    {
+        switch ($type) {
+            case 'all':
+                $this->invalidatePagesCache();
+                $this->climate->green('All caches invalidated.');
+                break;
+
+            case 'pages':
+                $this->invalidatePagesCache();
+                $this->climate->green('Pages cache invalidated.');
+                break;
+
+            default:
+                throw new InvalidArgumentException('Invalid cache type for invalidation.');
+        }
+    }
+
+    /**
+     * `cache stats` action
+     *
+     * @param list<string> $argv
+     */
+    public function stats(string $type, array $argv = []): void
+    {
+        switch ($type) {
+            case 'all':
+                $this->configCacheStats();
+                $this->climate->br();
+                $this->imagesCacheStats();
+                $this->climate->br();
+                $this->pagesCacheStats();
+                $this->climate->br();
+                break;
+            case 'config':
+                $this->configCacheStats();
+                break;
+            case 'images':
+                $this->imagesCacheStats();
+                break;
+            case 'pages':
+                $this->pagesCacheStats();
+                break;
+            default:
+                throw new InvalidArgumentException('Invalid cache type for stats.');
+        }
+    }
+
+    /**
+     * @param list<string>|null $argv
+     */
+    private function help(?array $argv = null): void
+    {
+        $this->climate->usage($argv);
+        $this->climate->br();
+        $this->climate->out('Available Actions:');
+
+        foreach ($this->actions as $name => ['description' => $description]) {
+            $this->climate->tab()->out($name);
+            $this->climate->tab(2)->out($description);
+        }
+    }
+
+    /**
+     * Output config cache stats
+     */
+    private function configCacheStats(): void
+    {
+        $path = ROOT_PATH . '/cache/config/';
+        $items = iterator_to_array(FileSystem::listContents($path));
+        $size = FileSystem::directorySize($path);
+
+        $this->climate->out('<green>Config Cache</green>');
+        $this->climate->out(sprintf('  Items number: <cyan>%d</cyan>', count($items)));
+        $this->climate->out(sprintf('  Total size:   <cyan>%s</cyan>', FileSystem::formatSize($size)));
+    }
+
+    /**
+     * Output images cache stats
+     */
+    private function imagesCacheStats(): void
+    {
+        $path = $this->app->config()->get('system.images.processPath');
+        $items = iterator_to_array(FileSystem::listContents($path));
+        $size = FileSystem::directorySize($path);
+
+        $this->climate->out('<green>Images Cache</green>');
+        $this->climate->out(sprintf('  Items number: <cyan>%d</cyan>', count($items)));
+        $this->climate->out(sprintf('  Total size:   <cyan>%s</cyan>', FileSystem::formatSize($size)));
+    }
+
+    /**
+     * Output pages cache stats
+     */
+    private function pagesCacheStats(): void
+    {
+        $path = $this->app->config()->get('system.cache.path');
+        $items = iterator_to_array(FileSystem::listContents($path));
+        $size = FileSystem::directorySize($path);
+
+        $this->climate->out('<green>Pages Cache</green>');
+        $this->climate->out(sprintf('  Items number: <cyan>%d</cyan>', count($items)));
+        $this->climate->out(sprintf('  Total size:   <cyan>%s</cyan>', FileSystem::formatSize($size)));
+    }
+
+    /**
+     * Clear config cache
+     */
+    private function clearConfigCache(): void
+    {
+        $path = ROOT_PATH . '/cache/config/';
+        FileSystem::delete($path, recursive: true);
+        FileSystem::createDirectory($path, recursive: true);
+    }
+
+    /**
+     * Clear images cache
+     */
+    private function clearImagesCache(): void
+    {
+        $path = $this->app->config()->get('system.images.processPath');
+        FileSystem::delete($path, recursive: true);
+        FileSystem::createDirectory($path, recursive: true);
+    }
+
+    /**
+     * Clear pages cache
+     */
+    private function clearPagesCache(): void
+    {
+        /** @var FilesCache */
+        $cache = $this->app->getService('cache');
+
+        $cache->clear();
+
+        $site = $this->app->site();
+        if ($site->contentPath() !== null) {
+            FileSystem::touch($site->contentPath());
+        }
+    }
+
+    /**
+     * Invalidate pages cache
+     */
+    private function invalidatePagesCache(): void
+    {
+        $site = $this->app->site();
+        if ($site->contentPath() !== null) {
+            FileSystem::touch($site->contentPath());
+        }
+    }
+}

--- a/formwork/src/Commands/FormworkCommandRunner.php
+++ b/formwork/src/Commands/FormworkCommandRunner.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Formwork\Commands;
+
+use Formwork\Cms\App;
+use League\CLImate\CLImate;
+use League\CLImate\Exceptions\InvalidArgumentException;
+
+final class FormworkCommandRunner implements CommandInterface
+{
+    /**
+     * CLImate instance
+     */
+    private CLImate $climate;
+
+    /**
+     * @var array<string, array{description: string, command: class-string<CommandInterface>}>
+     */
+    private array $commands = [
+        'backup' => [
+            'description' => 'Create a backup of the Formwork installation',
+            'command'     => BackupCommand::class,
+        ],
+        'cache' => [
+            'description' => 'Manage Formwork cache',
+            'command'     => CacheCommand::class,
+        ],
+        'serve' => [
+            'description' => 'Start Formwork development server',
+            'command'     => ServeCommand::class,
+        ],
+        'updates' => [
+            'description' => 'Manage Formwork updates',
+            'command'     => UpdatesCommand::class,
+        ],
+    ];
+
+    public function __construct()
+    {
+        $this->climate = new CLImate();
+
+        $this->climate->description(sprintf('<bold>Formwork <cyan>%s</cyan></bold> CLI', App::VERSION));
+
+        $this->climate->arguments->add([
+            'command' => [
+                'description' => 'Command to run',
+                'required'    => true,
+            ],
+            'arguments' => [
+                'description' => 'Arguments to pass to the command',
+            ],
+            'help' => [
+                'prefix'      => 'h',
+                'longPrefix'  => 'help',
+                'description' => 'Show this help screen',
+                'noValue'     => true,
+            ],
+            'version' => [
+                'prefix'      => 'v',
+                'longPrefix'  => 'version',
+                'description' => 'Show Formwork version',
+                'noValue'     => true,
+            ],
+        ]);
+    }
+
+    public function __invoke(?array $argv = null): never
+    {
+        $argv ??= $_SERVER['argv'] ?? [];
+
+        if (count($argv) < 2 || $this->hasDirectArgument('help', $argv)) {
+            $this->help($argv);
+            exit(0);
+        }
+
+        if ($this->hasDirectArgument('version', $argv)) {
+            $this->climate->out(sprintf('<bold>Formwork <cyan>%s</cyan></bold>', App::VERSION));
+            exit(0);
+        }
+
+        try {
+            $this->climate->arguments->parse($argv);
+        } catch (InvalidArgumentException $e) {
+            $this->climate->error($e->getMessage());
+            exit(1);
+        }
+
+        $command = (string) $this->climate->arguments->get('command');
+
+        if (isset($this->commands[$command])) {
+            try {
+                $commandClass = $this->commands[$command]['command'];
+
+                /** @var list<string> */
+                $arguments = [sprintf('%s %s', $argv[0], $command), ...array_slice($argv, 2)];
+
+                (new $commandClass())($arguments);
+            } catch (InvalidArgumentException $e) {
+                $this->climate->error($e->getMessage());
+                exit(1);
+            }
+        }
+
+        $this->climate->error(sprintf('Invalid command: %s.', $command));
+        exit(1);
+    }
+
+    /**
+     * @param list<string> $argv
+     */
+    public function help(array $argv): void
+    {
+        $this->climate->usage($argv);
+        $this->climate->br();
+        $this->climate->out('Available Commands:');
+
+        foreach ($this->commands as $name => ['description' => $description]) {
+            $this->climate->tab()->out($name);
+            $this->climate->tab(2)->out($description);
+        }
+    }
+
+    /**
+     * @param list<string> $argv
+     */
+    private function hasDirectArgument(string $name, array $argv): bool
+    {
+        return count($argv) === 2 && $this->climate->arguments->defined($name, $argv);
+    }
+}

--- a/formwork/src/Commands/UpdatesCommand.php
+++ b/formwork/src/Commands/UpdatesCommand.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Formwork\Commands;
+
+use Formwork\Backup\Backupper;
+use Formwork\Cache\AbstractCache;
+use Formwork\Cms\App;
+use Formwork\Updater\Updater;
+use League\CLImate\CLImate;
+use League\CLImate\Exceptions\InvalidArgumentException;
+
+final class UpdatesCommand implements CommandInterface
+{
+    /**
+     * CLImate instance
+     */
+    private CLImate $climate;
+
+    private App $app;
+
+    /**
+     * @var array<string, array{description: string}>
+     */
+    private array $actions = [
+        'check' => [
+            'description' => 'Check for available updates',
+        ],
+        'update' => [
+            'description' => 'Update Formwork to the latest version',
+        ],
+    ];
+
+    public function __construct()
+    {
+        $this->climate = new CLImate();
+
+        $this->climate->arguments->add([
+            'action' => [
+                'description' => 'Updates action to perform (check, update)',
+                'required'    => true,
+            ],
+            'force' => [
+                'prefix'      => 'f',
+                'longPrefix'  => 'force',
+                'description' => 'Force the update retrieval, ignoring any cached data',
+                'noValue'     => true,
+            ],
+            'no-backup' => [
+                'longPrefix'  => 'no-backup',
+                'description' => 'Skip the backup before updating',
+                'noValue'     => true,
+            ],
+            'no-prefer-dist' => [
+                'longPrefix'  => 'no-prefer-dist',
+                'description' => 'Do not prefer dist packages when updating',
+                'noValue'     => true,
+            ],
+            'no-cleanup' => [
+                'longPrefix'  => 'no-cleanup',
+                'description' => 'Do not remove temporary files after updating',
+                'noValue'     => true,
+            ],
+            'help' => [
+                'prefix'      => 'h',
+                'longPrefix'  => 'help',
+                'description' => 'Show this help screen',
+                'noValue'     => true,
+            ],
+        ]);
+    }
+
+    public function __invoke(?array $argv = null): never
+    {
+        $argv ??= $_SERVER['argv'] ?? [];
+
+        $this->app = App::instance();
+        $this->app->load();
+
+        if (count($argv) < 2 || $this->climate->arguments->defined('help', $argv)) {
+            $this->help($argv);
+            exit(0);
+        }
+
+        try {
+            $this->climate->arguments->parse($argv);
+        } catch (InvalidArgumentException $e) {
+            $this->climate->error($e->getMessage());
+            exit(1);
+        }
+
+        $action = (string) $this->climate->arguments->get('action');
+
+        if (isset($this->actions[$action])) {
+            try {
+                $this->{$action}($argv);
+                exit(0);
+            } catch (InvalidArgumentException $e) {
+                $this->climate->error($e->getMessage());
+                exit(1);
+            }
+        }
+
+        $this->climate->error(sprintf('Invalid action: %s.', $action));
+        exit(1);
+    }
+
+    /**
+     * `updates check` action
+     *
+     * @param list<string> $argv
+     */
+    public function check(array $argv = []): void
+    {
+        $force = $this->climate->arguments->defined('force');
+
+        $updater = $this->getUpdater(['force' => $force]);
+
+        try {
+            $upToDate = $updater->checkUpdates();
+        } catch (\RuntimeException $e) {
+            $this->climate->error('Cannot check for updates: ' . $e->getMessage());
+            exit(1);
+        }
+
+        $release = $updater->latestRelease();
+
+        if ($release === null) {
+            $this->climate->error('Cannot retrieve latest release information.');
+            exit(1);
+        }
+
+        if ($upToDate) {
+            $this->climate->out("<bold>Formwork <cyan>{$release['tag']}</cyan></bold> is already up to date.");
+            exit(0);
+        }
+
+        $currentVersion = App::VERSION;
+        $this->climate->out("Formwork <bold><yellow>{$currentVersion}</yellow></bold> is out of date.");
+        $this->climate->out("Latest available version: <bold><green>{$release['tag']}</green></bold>.");
+        $this->climate->br();
+
+        $command = implode(' ', array_slice($argv, 0, -1)) . ' update';
+        $this->climate->out("Run <cyan>{$command}</cyan> to update to the latest version.");
+    }
+
+    /**
+     * `updates update` action
+     *
+     * @param list<string> $argv
+     */
+    public function update(array $argv = []): void
+    {
+        $force = $this->climate->arguments->defined('force');
+        $backup = !$this->climate->arguments->defined('no-backup');
+        $preferDist = !$this->climate->arguments->defined('no-prefer-dist');
+        $cleanup = !$this->climate->arguments->defined('no-cleanup');
+        $updater = $this->getUpdater([
+            'force'               => $force,
+            'preferDistAssets'    => $preferDist,
+            'cleanupAfterInstall' => $cleanup,
+        ]);
+
+        try {
+            $upToDate = $updater->checkUpdates();
+        } catch (\RuntimeException $e) {
+            $this->climate->error("Cannot check for updates: {$e->getMessage()}");
+            exit(1);
+        }
+
+        $release = $updater->latestRelease();
+        if ($release === null) {
+            $this->climate->error('Cannot retrieve latest release information.');
+            exit(1);
+        }
+
+        if ($upToDate) {
+            $this->climate->out("<bold>Formwork <cyan>{$release['tag']}</cyan></bold> is already up to date.");
+            exit(0);
+        }
+
+        if ($backup) {
+            $this->climate->out('Creating backup before update... this may take a while depending on the size of your installation and site.');
+            $backupper = $this->getBackupper();
+            try {
+                $backupper->backup();
+            } catch (\RuntimeException $e) {
+                $this->climate->error("Cannot make backup: {$e->getMessage()}");
+                exit(1);
+            }
+            $this->climate->br();
+        }
+
+        try {
+            $this->climate->out("Updating <bold>Formwork</bold> to <bold><green>{$release['tag']}</green></bold>...");
+            $updater->update();
+        } catch (\RuntimeException $e) {
+            $this->climate->error("Cannot install updates: {$e->getMessage()}");
+            exit(1);
+        }
+        $this->climate->br();
+
+        if ($this->app->config()->get('system.cache.enabled')) {
+            $this->climate->out('Clearing cache...');
+            $this->app->getService(AbstractCache::class)->clear();
+            $this->climate->br();
+        }
+
+        $this->climate->out("<bold>Formwork</bold> has been updated successfully to <bold><green>{$release['tag']}</green></bold>.");
+    }
+
+    /**
+     * Get Updater instance
+     *
+     * @param array<string, mixed> $config
+     */
+    private function getUpdater(array $config): Updater
+    {
+        return new Updater([...$this->app->config()->get('system.updates'), ...$config], App::instance());
+    }
+
+    /**
+     * Get Backupper instance
+     */
+    private function getBackupper(): Backupper
+    {
+        return new Backupper([...$this->app->config()->get('system.backup'), 'hostname' => gethostname() ?: 'local-cli']);
+    }
+
+    /**
+     * @param list<string> $argv
+     */
+    private function help(array $argv): void
+    {
+        $this->climate->usage($argv);
+        $this->climate->br();
+        $this->climate->out('Available Actions:');
+
+        foreach ($this->actions as $name => ['description' => $description]) {
+            $this->climate->tab()->out($name);
+            $this->climate->tab(2)->out($description);
+        }
+    }
+}

--- a/formwork/src/Services/Loaders/ConfigServiceLoader.php
+++ b/formwork/src/Services/Loaders/ConfigServiceLoader.php
@@ -41,7 +41,9 @@ final class ConfigServiceLoader implements ServiceLoaderInterface
                 '%SYSTEM_PATH%' => SYSTEM_PATH,
             ]);
 
-            Php::encodeToFile($config->toArray(), $cacheFile);
+            if (PHP_SAPI !== 'cli') {
+                Php::encodeToFile($config->toArray(), $cacheFile);
+            }
         }
 
         date_default_timezone_set($config->get('system.date.timezone'));

--- a/formwork/src/Updater/Updater.php
+++ b/formwork/src/Updater/Updater.php
@@ -194,9 +194,9 @@ final class Updater
     /**
      * Get latest release data
      *
-     * @return array{name: string, tag: string, date: int, archive: string}
+     * @return ?array{name: string, tag: string, date: int, archive: string}
      */
-    public function latestRelease(): array
+    public function latestRelease(): ?array
     {
         return $this->registry->get('release');
     }


### PR DESCRIPTION
This pull request introduces a new, modular command-line interface (CLI) architecture for Formwork, enabling structured CLI commands for tasks like backup, cache management, and more. It also refactors the app lifecycle to better support CLI operations and improves PHP compatibility checks.

**CLI Infrastructure and Commands:**

* Introduced a new CLI command runner, `FormworkCommandRunner`, which acts as the entry point for CLI commands and delegates to specific command classes (e.g., backup, cache, serve, updates). This provides a clear, extensible structure for adding new CLI commands.
* Added `BackupCommand` and `CacheCommand` classes, each encapsulating their respective logic for actions such as creating/listing backups and clearing/invalidation/stats for various cache types. These commands use the CLImate library for argument parsing and output formatting. [[1]](diffhunk://#diff-0297a20e117cdb1e20fd9a62e6410a9db877c48817333d62c9e14c51fc40f490R1-R140) [[2]](diffhunk://#diff-cdf9f740933bfde00cc468889b51be67f0b018953d7933c81cb5ba4a0d1937a1R1-R275)

**App Lifecycle Improvements:**

* Refactored the `App` class to add a `load()` method, which initializes error handlers, services, and routes only once. The `run()` method now calls `load()` before dispatching routes, ensuring proper setup for both web and CLI contexts. [[1]](diffhunk://#diff-46157155d4e57fd657fd917e7ccbee85651c2ff8d498dbeb4c479c09d08a5966R59-R63) [[2]](diffhunk://#diff-46157155d4e57fd657fd917e7ccbee85651c2ff8d498dbeb4c479c09d08a5966L150-R175)

**General Code Quality and Compatibility:**

* Updated usage of `php_sapi_name()` to the more modern and direct `PHP_SAPI` constant for checking CLI context, improving code clarity and performance. [[1]](diffhunk://#diff-da7f60177d68601fac665dae54a98856223d87b968c5f0c6b99cf175349fbef4L13-R13) [[2]](diffhunk://#diff-da7f60177d68601fac665dae54a98856223d87b968c5f0c6b99cf175349fbef4L25-R25)