### PR TITLE
Add Dutch and Romanian translations

### DIFF
--- a/formwork/translations/nl.yaml
+++ b/formwork/translations/nl.yaml
@@ -1,0 +1,130 @@
+date.distance.ago: '%s geleden'
+date.distance.in: 'over %s'
+date.duration.days: ['dag', 'dagen']
+date.duration.hours: ['uur', 'uren']
+date.duration.minutes: ['minuut', 'minuten']
+date.duration.months: ['maand', 'maanden']
+date.duration.seconds: ['seconde', 'seconden']
+date.duration.weeks: ['week', 'weken']
+date.duration.years: ['jaar', 'jaren']
+date.months.long: ['januari', 'februari', 'maart', 'april', 'mei', 'juni', 'juli', 'augustus', 'september', 'oktober', 'november', 'december']
+date.months.short: ['jan', 'feb', 'mrt', 'apr', 'mei', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec']
+date.never: nooit
+date.noDate: Geen datum
+date.now: nu
+date.today: Vandaag
+date.weekdays.long: ['zondag', 'maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag', 'zaterdag']
+date.weekdays.short: ['zo', 'ma', 'di', 'wo', 'do', 'vr', 'za']
+fields.array.add: Toevoegen
+fields.array.remove: Verwijderen
+fields.date.nextHour: Volgend uur
+fields.date.nextMinute: Volgende minuut
+fields.date.nextMonth: Volgende maand
+fields.date.previousHour: Vorig uur
+fields.date.previousMinute: Vorige minuut
+fields.date.previousMonth: Vorige maand
+fields.file.none: (Geen)
+fields.file.uploadLabel: <strong>Klik</strong> om een bestand te kiezen of <strong>sleep</strong> het hierheen
+fields.image.none: (Geen)
+fields.select.empty: Geen overeenkomende opties
+fields.tags.remove: Verwijderen
+file.metadata: Metadata
+file.metadata.alternativeText: Alternatieve tekst
+page.attributes: Attributen
+page.cacheable: Cachebaar
+page.content: Inhoud
+page.files: Bestanden
+page.image: Afbeelding
+page.listed: In lijst
+page.listed.description: Lijstpagina’s zijn zichtbaar in het menu
+page.noFiles: Geen bestanden
+page.noImage: Geen afbeelding
+page.none: (Geen)
+page.noTags: Geen tags
+page.notListed: Niet in lijst
+page.notRoutable: Niet routbaar
+page.options: Opties
+page.page: Pagina
+page.parent: Bovenliggende pagina
+page.postsPerPage: Berichten per pagina
+page.publishDate: Publicatiedatum
+page.routable: Routbaar
+page.routable.description: Routbare pagina’s zijn bereikbaar via hun adres
+page.slug: Slug
+page.slug.suggestion: alleen letters, cijfers en streepjes
+page.status.notPublished: Niet gepubliceerd
+page.status.published: Gepubliceerd
+page.status.published.description: Gepubliceerde pagina’s zijn zichtbaar op de site en bereikbaar via hun adres
+page.summary: Samenvatting
+page.tags: Tags
+page.template: Sjabloon
+page.text: Tekst
+page.title: Titel
+page.unpublishDate: Datum van intrekking
+site.advanced: Geavanceerde opties
+site.advanced.aliases: Aliassen
+site.advanced.aliases.alias: Alias
+site.advanced.aliases.route: Route
+site.advanced.metadata: HTML-metadata
+site.advanced.metadata.content: Inhoud
+site.advanced.metadata.name: Naam
+site.info: Info
+site.info.author: Auteur
+site.info.description: Beschrijving
+site.info.language: Taal
+site.info.title: Titel
+site.maintenance: Onderhoud
+site.maintenance.enabled: Onderhoudsmodus
+site.maintenance.enabled.disabled: Uitgeschakeld
+site.maintenance.enabled.enabled: Ingeschakeld
+site.maintenance.page: Onderhoudspagina
+site.pages: Pagina’s
+site.pages.defaultTemplate: Standaardsjabloon
+site.statistics: Statistieken
+site.statistics.enabled: Paginaweergaven bijhouden
+site.statistics.enabled.disabled: Uitgeschakeld
+site.statistics.enabled.enabled: Ingeschakeld
+site.statistics.trackLocalhost: Bezoeken vanaf localhost bijhouden
+site.statistics.trackLocalhost.disabled: Uitgeschakeld
+site.statistics.trackLocalhost.enabled: Ingeschakeld
+site.statistics.visitsDelay: Bezoekvertraging
+site.statistics.visitsDelay.description: Vertraging tussen bezoeken van dezelfde gebruiker aan dezelfde pagina om als verschillend te tellen
+upload.error: Kan bestand niet uploaden. %s.
+upload.error.alreadyExists: Een bestand met dezelfde naam bestaat al
+upload.error.cannotMoveToDestination: Kon het geüploade bestand niet naar de bestemming verplaatsen
+upload.error.cannotWrite: Kon bestand niet op schijf schrijven
+upload.error.destinationTooLong: Bestemmingspad te lang
+upload.error.fileName: Ongeldige bestandsnaam
+upload.error.fileNameTooLong: Bestandsnaam te lang
+upload.error.hiddenFiles: Verborgen bestanden die met een punt beginnen kunnen niet worden geüpload
+upload.error.mimeType: Bestandstype niet toegestaan
+upload.error.noFile: Er is geen bestand geüpload
+upload.error.noTemp: Tijdelijke map ontbreekt
+upload.error.partial: Het bestand is slechts gedeeltelijk geüpload
+upload.error.phpExtension: Uploaden gestopt door extensie
+upload.error.size: Het geüploade bestand overschrijdt de maximale bestandsgrootte
+user.colorScheme: Kleurenschema
+user.colorScheme.auto: Automatisch
+user.colorScheme.dark: Donker
+user.colorScheme.light: Licht
+user.email: E-mail
+user.fullname: Volledige naam
+user.image: Afbeelding
+user.language: Taal
+user.password: Wachtwoord
+user.password.placeholder: Typ een nieuw wachtwoord om te wijzigen...
+user.role: Rol
+user.role.admin: Beheerder
+user.role.editor: Redacteur
+user.role.user: Gebruiker
+user.user: Gebruiker
+user.username: Gebruikersnaam
+zip.error.alreadyExists: Het archief bestaat al
+zip.error.cannotOpen: Kan het archief niet openen
+zip.error.cannotRead: Kan het archief niet lezen
+zip.error.inconsistentArchive: Inconsistent archief
+zip.error.invalidArgument: Ongeldig argument
+zip.error.memoryFailure: Geheugenfout
+zip.error.notFound: Archief niet gevonden
+zip.error.notZipArchive: Geen ZIP-archief
+zip.error.unspecified: Niet-gespecificeerde fout

--- a/formwork/translations/ro.yaml
+++ b/formwork/translations/ro.yaml
@@ -1,0 +1,130 @@
+date.distance.ago: 'acum %s'
+date.distance.in: 'în %s'
+date.duration.days: ['zi', 'zile']
+date.duration.hours: ['oră', 'ore']
+date.duration.minutes: ['minut', 'minute']
+date.duration.months: ['lună', 'luni']
+date.duration.seconds: ['secundă', 'secunde']
+date.duration.weeks: ['săptămână', 'săptămâni']
+date.duration.years: ['an', 'ani']
+date.months.long: ['ianuarie', 'februarie', 'martie', 'aprilie', 'mai', 'iunie', 'iulie', 'august', 'septembrie', 'octombrie', 'noiembrie', 'decembrie']
+date.months.short: ['ian', 'feb', 'mar', 'apr', 'mai', 'iun', 'iul', 'aug', 'sep', 'oct', 'nov', 'dec']
+date.never: niciodată
+date.noDate: Fără dată
+date.now: acum
+date.today: Astăzi
+date.weekdays.long: ['duminică', 'luni', 'marți', 'miercuri', 'joi', 'vineri', 'sâmbătă']
+date.weekdays.short: ['dum', 'lun', 'mar', 'mie', 'joi', 'vin', 'sâm']
+fields.array.add: Adaugă
+fields.array.remove: Elimină
+fields.date.nextHour: Ora următoare
+fields.date.nextMinute: Minutul următor
+fields.date.nextMonth: Luna următoare
+fields.date.previousHour: Ora precedentă
+fields.date.previousMinute: Minutul precedent
+fields.date.previousMonth: Luna precedentă
+fields.file.none: (Niciunul)
+fields.file.uploadLabel: <strong>Click</strong> pentru a alege un fișier de încărcat sau <strong>trage</strong> aici
+fields.image.none: (Niciuna)
+fields.select.empty: Nicio opțiune corespunzătoare
+fields.tags.remove: Elimină
+file.metadata: Metadate
+file.metadata.alternativeText: Text alternativ
+page.attributes: Atribute
+page.cacheable: Cacheabil
+page.content: Conținut
+page.files: Fișiere
+page.image: Imagine
+page.listed: Listată
+page.listed.description: Paginile listate sunt vizibile în meniu
+page.noFiles: Fără fișiere
+page.noImage: Fără imagine
+page.none: (Niciuna)
+page.noTags: Fără etichete
+page.notListed: Nelistată
+page.notRoutable: Nerutabilă
+page.options: Opțiuni
+page.page: Pagină
+page.parent: Pagină părinte
+page.postsPerPage: Articole pe pagină
+page.publishDate: Dată publicare
+page.routable: Rutabilă
+page.routable.description: Paginile rutabile sunt accesibile de la adresa lor
+page.slug: Slug
+page.slug.suggestion: doar litere, cifre și cratime
+page.status.notPublished: Nepublicată
+page.status.published: Publicată
+page.status.published.description: Paginile publicate sunt vizibile pe site și accesibile de la adresa lor
+page.summary: Rezumat
+page.tags: Etichete
+page.template: Șablon
+page.text: Text
+page.title: Titlu
+page.unpublishDate: Dată depublicare
+site.advanced: Opțiuni avansate
+site.advanced.aliases: Aliasuri
+site.advanced.aliases.alias: Alias
+site.advanced.aliases.route: Rută
+site.advanced.metadata: Metadate HTML
+site.advanced.metadata.content: Conținut
+site.advanced.metadata.name: Nume
+site.info: Informații
+site.info.author: Autor
+site.info.description: Descriere
+site.info.language: Limbă
+site.info.title: Titlu
+site.maintenance: Mentenanță
+site.maintenance.enabled: Mod de mentenanță
+site.maintenance.enabled.disabled: Dezactivat
+site.maintenance.enabled.enabled: Activat
+site.maintenance.page: Pagină de mentenanță
+site.pages: Pagini
+site.pages.defaultTemplate: Șablon implicit
+site.statistics: Statistici
+site.statistics.enabled: Urmărește vizitele paginilor
+site.statistics.enabled.disabled: Dezactivat
+site.statistics.enabled.enabled: Activat
+site.statistics.trackLocalhost: Urmărește vizitele de la localhost
+site.statistics.trackLocalhost.disabled: Dezactivat
+site.statistics.trackLocalhost.enabled: Activat
+site.statistics.visitsDelay: Întârziere vizite
+site.statistics.visitsDelay.description: Întârziere între vizitele aceluiași utilizator pe aceeași pagină pentru a fi considerate diferite
+upload.error: Nu se poate încărca fișierul. %s.
+upload.error.alreadyExists: Există deja un fișier cu același nume
+upload.error.cannotMoveToDestination: Nu s-a putut muta fișierul încărcat la destinație
+upload.error.cannotWrite: Nu s-a putut scrie fișierul pe disc
+upload.error.destinationTooLong: Calea destinației este prea lungă
+upload.error.fileName: Nume de fișier nevalid
+upload.error.fileNameTooLong: Numele fișierului este prea lung
+upload.error.hiddenFiles: Nu se pot încărca fișiere ascunse care încep cu punct
+upload.error.mimeType: Tip de fișier nepermis
+upload.error.noFile: Niciun fișier nu a fost încărcat
+upload.error.noTemp: Lipsește un dosar temporar
+upload.error.partial: Fișierul a fost încărcat doar parțial
+upload.error.phpExtension: Încărcarea fișierului a fost oprită de o extensie
+upload.error.size: Fișierul încărcat depășește dimensiunea maximă permisă
+user.colorScheme: Schemat de culori
+user.colorScheme.auto: Automat
+user.colorScheme.dark: Întunecat
+user.colorScheme.light: Deschis
+user.email: Email
+user.fullname: Nume complet
+user.image: Imagine
+user.language: Limbă
+user.password: Parolă
+user.password.placeholder: Tastează o parolă nouă pentru a o schimba...
+user.role: Rol
+user.role.admin: Administrator
+user.role.editor: Editor
+user.role.user: Utilizator
+user.user: Utilizator
+user.username: Nume de utilizator
+zip.error.alreadyExists: Arhiva există deja
+zip.error.cannotOpen: Nu se poate deschide arhiva
+zip.error.cannotRead: Nu se poate citi arhiva
+zip.error.inconsistentArchive: Arhivă inconsistentă
+zip.error.invalidArgument: Argument nevalid
+zip.error.memoryFailure: Eroare de memorie
+zip.error.notFound: Arhivă negăsită
+zip.error.notZipArchive: Nu este o arhivă ZIP
+zip.error.unspecified: Eroare nespecificată

--- a/panel/translations/nl.yaml
+++ b/panel/translations/nl.yaml
@@ -1,0 +1,340 @@
+panel.backup.backup: Backup
+panel.backup.deleted: Backup verwijderd
+panel.backup.error.cannotDelete: Kan backup niet verwijderen. %s.
+panel.backup.error.cannotDelete.invalidFilename: Ongeldig back-upbestand
+panel.backup.error.cannotDownload: Kan backup niet downloaden. %s.
+panel.backup.error.cannotDownload.invalidFilename: Ongeldig back-upbestand
+panel.backup.error.cannotMake: Kan backup niet aanmaken. %s.
+panel.backup.ready: Backup gereed. Start downloaden...
+panel.cache.clear: Cache legen
+panel.cache.clear.images: Cache voor afbeeldingen legen
+panel.cache.clear.pages: Cache voor pagina's legen
+panel.cache.cleared: Cache geleegd
+panel.cache.cleared.images: Afbeeldingscache geleegd
+panel.cache.cleared.pages: Pagina-cache geleegd
+panel.cache.error: Kan cache niet legen
+panel.dashboard.dashboard: Dashboard
+panel.dashboard.lastModifiedPages: Recent bewerkte pagina's
+panel.dashboard.quickActions: Snelle acties
+panel.dashboard.statistics: Statistieken
+panel.dashboard.statistics.uniqueVisitors: Unieke bezoekers
+panel.dashboard.statistics.visits: Bezoeken
+panel.dashboard.welcome: Welkom
+panel.dragToReorder: Sleep om te herschikken
+panel.editor.bold: Vet
+panel.editor.bulletList: Opsommingstekens
+panel.editor.code: Code
+panel.editor.decreaseIndent: Inspringing verkleinen
+panel.editor.heading1: Kop 1
+panel.editor.heading2: Kop 2
+panel.editor.heading3: Kop 3
+panel.editor.heading4: Kop 4
+panel.editor.heading5: Kop 5
+panel.editor.heading6: Kop 6
+panel.editor.image: Afbeelding
+panel.editor.increaseIndent: Inspringing vergroten
+panel.editor.italic: Cursief
+panel.editor.link: Link
+panel.editor.numberedList: Genummerde lijst
+panel.editor.paragraph: Alinea
+panel.editor.quote: Citaat
+panel.editor.redo: Herstellen
+panel.editor.summary: Samenvatting
+panel.editor.toggleMarkdown: Markdown wisselen
+panel.editor.undo: Ongedaan maken
+panel.errors.action.reportToGithub: Meld een probleem op GitHub
+panel.errors.action.returnToDashboard: Terug naar dashboard
+panel.errors.error.forbidden.description: Je hebt geen toestemming om deze pagina te bekijken.
+panel.errors.error.forbidden.heading: Oeps, toestemming vereist!
+panel.errors.error.forbidden.status: Verboden
+panel.errors.error.internalServerError.description: Formwork is een fout tegengekomen bij het verwerken van je verzoek. Controleer de Formwork-configuratie of de serverlog voor fouten.
+panel.errors.error.internalServerError.heading: Oeps, er is iets misgegaan!
+panel.errors.error.internalServerError.status: Interne serverfout
+panel.errors.error.notFound.description: De pagina bestaat niet of het verzoek is niet geldig.
+panel.errors.error.notFound.heading: Oeps, pagina niet gevonden!
+panel.errors.error.notFound.status: Niet gevonden
+panel.files.actions: Acties
+panel.files.backToPage: Terug naar pagina
+panel.files.cannotDelete.fileNotFound: Kan bestand niet verwijderen, bestand niet gevonden
+panel.files.cannotDelete.pageNotFound: Kan bestand niet verwijderen, bestand niet gevonden
+panel.files.cannotRename.fileAlreadyExists: Kan bestand niet hernoemen, er bestaat al een bestand met die naam
+panel.files.cannotRename.fileNotFound: Kan bestand niet hernoemen, bestand niet gevonden
+panel.files.cannotRename.pageNotFound: Kan bestand niet hernoemen, pagina niet gevonden
+panel.files.cannotReplace.fileNotFound: Kan bestand niet vervangen, bestand niet gevonden
+panel.files.cannotReplace.multipleFiles: Kan bestand niet vervangen, meerdere bestanden opgegeven
+panel.files.cannotReplace.pageNotFound: Kan bestand niet vervangen, pagina niet gevonden
+panel.files.cannotUpload.pageNotFound: Kan bestand niet uploaden, pagina niet gevonden
+panel.files.deleted: Bestand verwijderd
+panel.files.exif: EXIF
+panel.files.fileNotFound: Kan bestandgegevens niet ophalen, bestand niet gevonden
+panel.files.files: Bestanden
+panel.files.info: Info
+panel.files.info.image.colorDepth: Kleurendiepte
+panel.files.info.image.colorNumber: Aantal kleuren
+panel.files.info.image.colorProfile: Kleurprofiel
+panel.files.info.image.colorSpace: Kleurruimte
+panel.files.info.image.dimensions: Afmetingen
+panel.files.info.image.dimensions.widthByHeightPixels: '%d × %d pixels'
+panel.files.info.image.exif.aperture: Diafragma
+panel.files.info.image.exif.camera: Camera
+panel.files.info.image.exif.creationDateAndTime: Aanmaakdatum en -tijd
+panel.files.info.image.exif.exposureCompensation: Belichtingscompensatie
+panel.files.info.image.exif.exposureProgram: Belichtingsprogramma
+panel.files.info.image.exif.exposureTime: Belichtingstijd
+panel.files.info.image.exif.flash: Flits
+panel.files.info.image.exif.focalLength: Brandpuntsafstand
+panel.files.info.image.exif.lensModel: Objectiefmodel
+panel.files.info.image.exif.meteringMode: Meetmethode
+panel.files.info.image.exif.sensitivity: Gevoeligheid
+panel.files.info.image.exif.whiteBalance: Witbalans
+panel.files.info.image.frames: '%d frames'
+panel.files.info.image.framesCount: Aantal frames
+panel.files.info.image.repeats: '%d herhalingen'
+panel.files.info.image.repeatsCount: Aantal herhalingen
+panel.files.info.image.resolution: Resolutie
+panel.files.info.lastModifiedTime: Laatste wijziging
+panel.files.info.mimeType: MIME-type
+panel.files.info.name: Naam
+panel.files.info.size: Grootte
+panel.files.info.uri: URI
+panel.files.metadata.updated: Bestandmetadata bijgewerkt
+panel.files.next: Volgend bestand
+panel.files.pageNotFound: Kan bestandgegevens niet ophalen, pagina niet gevonden
+panel.files.parent: Ouder
+panel.files.position: Positie
+panel.files.preview: Voorbeeld
+panel.files.previous: Vorig bestand
+panel.files.renamed: Bestand hernoemd
+panel.files.search: Bestanden zoeken...
+panel.files.upload: Bestand uploaden
+panel.files.uploaded: Bestanden geüpload
+panel.files.viewAsList: Weergeven als lijst
+panel.files.viewAsThumbnails: Weergeven als miniaturen
+panel.login.attempt.failed: Aanmeldpoging mislukt! Probeer het opnieuw.
+panel.login.attempt.tooMany: Te veel aanmeldpogingen. Probeer het opnieuw over %d minuten.
+panel.login.loggedOut: Je bent uitgelogd
+panel.login.login: Inloggen
+panel.login.logout: Uitloggen
+panel.login.password: Wachtwoord
+panel.login.suspiciousRequestDetected: Er is een verdachte aanvraag gedetecteerd en om veiligheidsredenen ben je uitgelogd. Log opnieuw in.
+panel.login.usernameOrEmail: Gebruikersnaam of e-mail
+panel.manage: Beheer
+panel.modal.action.cancel: Annuleer
+panel.modal.action.continue: Doorgaan
+panel.modal.action.delete: Verwijderen
+panel.modal.action.edit: Bewerken
+panel.modal.action.rename: Hernoemen
+panel.modal.action.save: Opslaan
+panel.modal.action.upload: Uploaden
+panel.modal.action.uploadFile: Bestand uploaden
+panel.modal.images.noImages: Er zijn hier geen afbeeldingen
+panel.modal.images.noImages.upload: Upload aub enkele afbeeldingen
+panel.modal.images.title: Selecteer een afbeelding
+panel.modal.link.text: Tekst
+panel.modal.link.title: Link invoegen
+panel.modal.link.uri: Uri
+panel.navigation.toggle: Navigatie wisselen
+panel.options.options: Opties
+panel.options.site: Site
+panel.options.system: Systeem
+panel.options.system.adminPanel: Administratiepaneel
+panel.options.system.adminPanel.defaultColorScheme: Standaard kleurenschema
+panel.options.system.adminPanel.defaultColorScheme.dark: Donker
+panel.options.system.adminPanel.defaultColorScheme.light: Licht
+panel.options.system.adminPanel.defaultLanguage: Standaardtaal
+panel.options.system.adminPanel.logoutRedirectsTo: Uitloggen doorsturen naar
+panel.options.system.adminPanel.logoutRedirectsTo.home: Startpagina
+panel.options.system.adminPanel.logoutRedirectsTo.login: Inlogpagina
+panel.options.system.adminPanel.sessionTimeout: Sessie time-out
+panel.options.system.backup: Backup
+panel.options.system.backup.backupFilesToKeep: Backups om op de server te bewaren
+panel.options.system.cache: Cache
+panel.options.system.cache.disabled: Uitgeschakeld
+panel.options.system.cache.enabled: Ingeschakeld
+panel.options.system.cache.time: Cache-tijd
+panel.options.system.content: Inhoud
+panel.options.system.content.allowHtml: HTML toestaan in Markdown-velden
+panel.options.system.content.allowHtml.description: Potentieel gevaarlijke tags zoals `<script>` en `<style>` worden altijd naar tekst geconverteerd
+panel.options.system.content.allowHtml.disabled: Uitgeschakeld
+panel.options.system.content.allowHtml.enabled: Ingeschakeld
+panel.options.system.dateAndTime: Datum en tijd
+panel.options.system.dateAndTime.dateFormat: Datumformaat
+panel.options.system.dateAndTime.firstWeekday: Eerste weekdag
+panel.options.system.dateAndTime.firstWeekday.monday: Maandag
+panel.options.system.dateAndTime.firstWeekday.sunday: Zondag
+panel.options.system.dateAndTime.hourFormat: Uurformaat
+panel.options.system.dateAndTime.timezone: Tijdzone
+panel.options.system.debug: Debug
+panel.options.system.debug.editorUri: Editor-URI
+panel.options.system.debug.editorUri.description: Gebruik `{{filename}}` en `{{line}}` om de URI te bouwen die de code-editor opent
+panel.options.system.debug.mode: Debug-modus
+panel.options.system.debug.mode.description: Debug-modus toont foutinformatie en moet uitgeschakeld zijn in productie omdat het gevoelige data kan onthullen
+panel.options.system.debug.mode.disabled: Uitgeschakeld
+panel.options.system.debug.mode.enabled: Ingeschakeld
+panel.options.system.files: Bestanden
+panel.options.system.files.allowedExtensions: Toegestane extensies
+panel.options.system.files.allowedExtensions.noExtensions: Geen extensies (geen bestanden toegestaan)
+panel.options.system.images: Afbeeldingen
+panel.options.system.images.clearCacheByDefault: Afbeeldingscache standaard legen
+panel.options.system.images.clearCacheByDefault.disabled: Uitgeschakeld
+panel.options.system.images.clearCacheByDefault.enabled: Ingeschakeld
+panel.options.system.images.jpegQuality: JPEG-kwaliteit
+panel.options.system.images.jpegSaveProgressive: Sla JPEG-afbeeldingen progressief op
+panel.options.system.images.jpegSaveProgressive.disabled: Uitgeschakeld
+panel.options.system.images.jpegSaveProgressive.enabled: Ingeschakeld
+panel.options.system.images.pngCompressionLevel: PNG-compressieniveau
+panel.options.system.images.webpQuality: WebP-kwaliteit
+panel.options.system.uploads.processImages: Verwerk (optimaliseer) geüploade afbeeldingen
+panel.options.system.uploads.processImages.disabled: Uitgeschakeld
+panel.options.system.uploads.processImages.enabled: Ingeschakeld
+panel.options.updated: Opties bijgewerkt
+panel.pages.changes.continue: Doorgaan zonder op te slaan
+panel.pages.changes.detected: Wijzigingen gedetecteerd
+panel.pages.changes.detected.prompt: Je hebt wijzigingen die niet zijn opgeslagen. Weet je zeker dat je deze pagina wilt verlaten?
+panel.pages.changeSlug: Slug bewerken
+panel.pages.changeSlug.generate: Genereer vanuit titel
+panel.pages.deleteFile: Bestand verwijderen
+panel.pages.deleteFile.prompt: Weet je zeker dat je dit bestand wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.
+panel.pages.deletePage: Pagina verwijderen
+panel.pages.deletePage.prompt: Weet je zeker dat je deze pagina wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.
+panel.pages.edit: Pagina bewerken
+panel.pages.editPage: Pagina %s bewerken
+panel.pages.history.event.created: Pagina aangemaakt door %s %s.
+panel.pages.history.event.edited: Pagina bewerkt door %s %s.
+panel.pages.languages: Talen
+panel.pages.languages.addLanguage: Voeg %s toe
+panel.pages.languages.editLanguage: Bewerk %s
+panel.pages.newPage: Nieuwe pagina
+panel.pages.newPage.site: Site
+panel.pages.next: Volgende pagina
+panel.pages.page: Pagina
+panel.pages.page.actions: Acties
+panel.pages.page.cannotChangeNum: Paginanummer kan niet worden gewijzigd
+panel.pages.page.cannotCreate: Kan pagina niet aanmaken
+panel.pages.page.cannotCreate.alreadyExists: Kan pagina niet aanmaken, een pagina met dezelfde URI bestaat al
+panel.pages.page.cannotCreate.invalidParent: Kan pagina niet aanmaken, ongeldige bovenliggende pagina
+panel.pages.page.cannotCreate.invalidSlug: Kan pagina niet aanmaken, slug van de pagina mag alleen letters en cijfers bevatten, gescheiden door streepjes
+panel.pages.page.cannotCreate.invalidTemplate: Kan pagina niet aanmaken, ongeldig sjabloon
+panel.pages.page.cannotCreate.varMissing: Kan pagina niet aanmaken, ontbrekende variabele
+panel.pages.page.cannotDelete.invalidLanguage: 'Kan pagina niet verwijderen, ongeldige taal: %s'
+panel.pages.page.cannotDelete.notDeletable: Kan pagina niet verwijderen, de pagina is niet verwijderbaar
+panel.pages.page.cannotDelete.pageNotFound: Kan pagina niet verwijderen, pagina niet gevonden
+panel.pages.page.cannotEdit.alreadyExists: Kan pagina niet bewerken, een pagina met dezelfde URI bestaat al
+panel.pages.page.cannotEdit.indexOrErrorPageSlug: Kan slug van index- of foutpagina niet bewerken
+panel.pages.page.cannotEdit.invalidLanguage: 'Kan pagina niet bewerken, ongeldige taal: %s'
+panel.pages.page.cannotEdit.invalidParent: Kan pagina niet bewerken, ongeldige bovenliggende pagina
+panel.pages.page.cannotEdit.invalidSlug: Kan slug van de pagina niet bewerken, deze mag alleen letters en cijfers bevatten gescheiden door streepjes
+panel.pages.page.cannotEdit.invalidTemplate: Kan pagina niet bewerken, ongeldig sjabloon
+panel.pages.page.cannotEdit.pageNotFound: Kan pagina niet bewerken, pagina niet gevonden
+panel.pages.page.cannotEdit.varMissing: Kan pagina niet bewerken, ontbrekende variabele
+panel.pages.page.cannotMove: Kan pagina niet verplaatsen
+panel.pages.page.cannotPreview.pageNotFound: Kan pagina niet bekijken, pagina niet gevonden
+panel.pages.page.cannotPreview.parentChanged: Kan pagina niet bekijken, bovenliggende pagina is veranderd
+panel.pages.page.created: Pagina aangemaakt!
+panel.pages.page.deleted: Pagina verwijderd
+panel.pages.page.edited: Pagina bewerkt
+panel.pages.page.lastModified: Laatste wijziging
+panel.pages.page.moved: Pagina verplaatst!
+panel.pages.page.notFound: Pagina niet gevonden
+panel.pages.page.status: Status
+panel.pages.pages: Pagina's
+panel.pages.pages.collapseAll: Vouw alles in
+panel.pages.pages.expandAll: Vouw alles uit
+panel.pages.pages.reorder: Herschikken
+panel.pages.pages.search: Pagina's zoeken...
+panel.pages.preview: Voorbeeld
+panel.pages.previewFile: Voorbeeld
+panel.pages.previous: Vorige pagina
+panel.pages.publish: Publiceer
+panel.pages.renameFile: Bestand hernoemen
+panel.pages.renameFile.name: Naam
+panel.pages.replaceFile: Bestand vervangen
+panel.pages.save: Opslaan
+panel.pages.saveOnly: Opslaan zonder publiceren
+panel.pages.toggleChildren: Kindpagina's tonen/verbergen
+panel.pages.viewChildren: Bekijk subpagina's
+panel.pages.viewPage: Bekijk pagina
+panel.panel: Administratiepaneel
+panel.register.createUser: Formwork is geïnstalleerd maar er zijn geen gebruikers gevonden. Maak nu een gebruiker aan.
+panel.register.register: Nieuwe gebruiker registreren
+panel.request.error.postMaxSize: De HTTP POST-aanvraag overschrijdt de maximaal toegestane grootte
+panel.sections.toggle: Sectie wisselen
+panel.site.languages: Talen
+panel.site.languages.availableLanguages: Beschikbare talen
+panel.site.languages.availableLanguages.noLanguages: Geen talen
+panel.site.languages.preferredLanguage: Gebruik door de browser geprefereerde taal
+panel.site.languages.preferredLanguage.disabled: Uitgeschakeld
+panel.site.languages.preferredLanguage.enabled: Ingeschakeld
+panel.statistics.devices: Apparaten
+panel.statistics.devices.type: Type
+panel.statistics.devices.type.desktop: Desktop
+panel.statistics.devices.type.mobile: Mobiel
+panel.statistics.devices.type.tablet: Tablet
+panel.statistics.monthlyUniqueVisitors: Maandelijkse unieke bezoekers
+panel.statistics.monthlyVisits: Maandelijkse bezoeken
+panel.statistics.sources: Bronnen
+panel.statistics.sources.direct: Direct
+panel.statistics.sources.site: Site
+panel.statistics.statistics: Statistieken
+panel.statistics.totalVisits: Totaal bezoeken
+panel.statistics.totalVisits.percentTotal: '% totaal'
+panel.statistics.totalVisits.uri: URI
+panel.statistics.visits: Bezoeken
+panel.statistics.weeklyUniqueVisitors: Wekelijkse unieke bezoekers
+panel.statistics.weeklyVisits: Wekelijkse bezoeken
+panel.tools.backup.actions: Acties
+panel.tools.backup.date: Datum
+panel.tools.backup.delete: Backup verwijderen
+panel.tools.backup.file: Bestand
+panel.tools.backup.size: Grootte
+panel.tools.backups: Backups
+panel.tools.info: Info
+panel.tools.latestBackup: 'Laatste backup:'
+panel.tools.latestBackups: Laatste backups
+panel.tools.tools: Hulpmiddelen
+panel.tools.updates: Updates
+panel.updates.availableForInstall: is beschikbaar voor installatie
+panel.updates.check: Controleer op updates
+panel.updates.install: Installeren
+panel.updates.installed: Update geïnstalleerd!
+panel.updates.installPrompt: Wil je de update installeren?
+panel.updates.latestVersionAvailable: is de nieuwste beschikbare versie
+panel.updates.status.cannotCheck: Kan niet controleren op updates. Probeer later opnieuw.
+panel.updates.status.cannotInstall: Kan update niet installeren
+panel.updates.status.cannotMakeBackup: Kan geen backup maken vóór het updaten
+panel.updates.status.checking: Controleren op updates...
+panel.updates.status.found: Updates gevonden
+panel.updates.status.installing: Updates installeren...
+panel.updates.status.upToDate: Up-to-date!
+panel.uploader.uploaded: Bestand geüpload
+panel.user.actions: Acties
+panel.user.image.actions: Acties
+panel.user.image.cannotDelete.defaultImage: Kan standaardgebruikersafbeelding niet verwijderen
+panel.user.image.delete: Gebruikersafbeelding verwijderen
+panel.user.image.delete.prompt: Weet je zeker dat je de gebruikersafbeelding wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.
+panel.user.image.deleted: Gebruikersafbeelding verwijderd
+panel.user.image.uploaded: Gebruikersafbeelding geüpload
+panel.user.lastAccess: Laatste toegang
+panel.users.deleteUser: Gebruiker verwijderen
+panel.users.deleteUser.prompt: Weet je zeker dat je deze gebruiker wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.
+panel.users.newUser: Nieuwe gebruiker
+panel.users.newUser.password.suggestion: ten minste 8 tekens
+panel.users.newUser.username.suggestion: tussen 3-20 letters, cijfers en - . _
+panel.users.nextUser: Volgende gebruiker
+panel.users.options: Opties
+panel.users.previousUser: Vorige gebruiker
+panel.users.user.cannotChangeEmail.alreadyUsed: Kan e-mail van gebruiker niet wijzigen, het adres is al gekoppeld aan een account
+panel.users.user.cannotChangePassword: Kan wachtwoord van een andere gebruiker niet wijzigen. Deze actie is niet toegestaan.
+panel.users.user.cannotChangeRole: Kan rol van %s niet wijzigen. Deze actie is niet toegestaan.
+panel.users.user.cannotCreate.alreadyExists: Kan gebruiker niet aanmaken, een gebruiker met dezelfde naam bestaat al
+panel.users.user.cannotCreate.emailAlreadyUsed: Kan gebruiker niet aanmaken, het e-mailadres is al gekoppeld aan een account
+panel.users.user.cannotCreate.varMissing: Kan gebruiker niet aanmaken, ontbrekende variabele
+panel.users.user.cannotDelete: Kan gebruiker niet verwijderen. Je moet beheerder zijn en de gebruiker mag niet ingelogd zijn.
+panel.users.user.cannotEdit: Kan gebruiker %s niet bewerken. Deze actie is niet toegestaan.
+panel.users.user.created: Gebruiker aangemaakt
+panel.users.user.deleted: Gebruiker verwijderd
+panel.users.user.edited: Gebruikersgegevens bijgewerkt
+panel.users.user.notFound: Gebruiker niet gevonden
+panel.users.userProfile: '%s gebruikersprofiel'
+panel.users.users: Gebruikers
+panel.viewSite: Bekijk site

--- a/panel/translations/ro.yaml
+++ b/panel/translations/ro.yaml
@@ -1,0 +1,340 @@
+panel.backup.backup: Backup
+panel.backup.deleted: Backup șters
+panel.backup.error.cannotDelete: Nu se poate șterge backup-ul. %s.
+panel.backup.error.cannotDelete.invalidFilename: Fișier de backup invalid
+panel.backup.error.cannotDownload: Nu se poate descărca backup-ul. %s.
+panel.backup.error.cannotDownload.invalidFilename: Fișier de backup invalid
+panel.backup.error.cannotMake: Nu se poate crea backup-ul. %s.
+panel.backup.ready: Backup gata. Încep descărcarea...
+panel.cache.clear: Golește cache-ul
+panel.cache.clear.images: Golește cache-ul de imagini
+panel.cache.clear.pages: Golește cache-ul de pagini
+panel.cache.cleared: Cache golit
+panel.cache.cleared.images: Cache-ul de imagini a fost golit
+panel.cache.cleared.pages: Cache-ul de pagini a fost golit
+panel.cache.error: Nu se poate goli cache-ul
+panel.dashboard.dashboard: Panou de bord
+panel.dashboard.lastModifiedPages: Pagini editate recent
+panel.dashboard.quickActions: Acțiuni rapide
+panel.dashboard.statistics: Statistici
+panel.dashboard.statistics.uniqueVisitors: Vizitatori unici
+panel.dashboard.statistics.visits: Vizite
+panel.dashboard.welcome: Bine ai venit
+panel.dragToReorder: Trage pentru a reordona
+panel.editor.bold: Aldin
+panel.editor.bulletList: Listă cu marcatori
+panel.editor.code: Cod
+panel.editor.decreaseIndent: Micșorează indentarea
+panel.editor.heading1: Titlu 1
+panel.editor.heading2: Titlu 2
+panel.editor.heading3: Titlu 3
+panel.editor.heading4: Titlu 4
+panel.editor.heading5: Titlu 5
+panel.editor.heading6: Titlu 6
+panel.editor.image: Imagine
+panel.editor.increaseIndent: Mărește indentarea
+panel.editor.italic: Italic
+panel.editor.link: Link
+panel.editor.numberedList: Listă numerotată
+panel.editor.paragraph: Paragraf
+panel.editor.quote: Citat
+panel.editor.redo: Refă
+panel.editor.summary: Rezumat
+panel.editor.toggleMarkdown: Comută Markdown
+panel.editor.undo: Anulează
+panel.errors.action.reportToGithub: Raportează o problemă pe GitHub
+panel.errors.action.returnToDashboard: Întoarce-te la panoul de control
+panel.errors.error.forbidden.description: Nu ai permisiunea de a accesa această pagină.
+panel.errors.error.forbidden.heading: Ups, permisiune necesară!
+panel.errors.error.forbidden.status: Interzis
+panel.errors.error.internalServerError.description: Formwork a întâmpinat o eroare la procesarea solicitării. Verifică configurația Formwork sau jurnalul serverului pentru erori.
+panel.errors.error.internalServerError.heading: Ups, ceva nu a mers bine!
+panel.errors.error.internalServerError.status: Eroare internă a serverului
+panel.errors.error.notFound.description: Pagina nu există sau solicitarea nu este validă.
+panel.errors.error.notFound.heading: Ups, pagina nu a fost găsită!
+panel.errors.error.notFound.status: Negăsit
+panel.files.actions: Acțiuni
+panel.files.backToPage: Înapoi la pagină
+panel.files.cannotDelete.fileNotFound: Nu se poate șterge fișierul, fișierul nu a fost găsit
+panel.files.cannotDelete.pageNotFound: Nu se poate șterge fișierul, fișierul nu a fost găsit
+panel.files.cannotRename.fileAlreadyExists: Nu se poate redenumi fișierul, există deja un fișier cu același nume
+panel.files.cannotRename.fileNotFound: Nu se poate redenumi fișierul, fișierul nu a fost găsit
+panel.files.cannotRename.pageNotFound: Nu se poate redenumi fișierul, pagina nu a fost găsită
+panel.files.cannotReplace.fileNotFound: Nu se poate înlocui fișierul, fișierul nu a fost găsit
+panel.files.cannotReplace.multipleFiles: Nu se poate înlocui fișierul, au fost trimise mai multe fișiere
+panel.files.cannotReplace.pageNotFound: Nu se poate înlocui fișierul, pagina nu a fost găsită
+panel.files.cannotUpload.pageNotFound: Nu se poate încărca fișierul, pagina nu a fost găsită
+panel.files.deleted: Fișier șters
+panel.files.exif: EXIF
+panel.files.fileNotFound: Nu se pot obține informații despre fișier, fișierul nu a fost găsit
+panel.files.files: Fișiere
+panel.files.info: Informații
+panel.files.info.image.colorDepth: Adâncime de culoare
+panel.files.info.image.colorNumber: Număr de culori
+panel.files.info.image.colorProfile: Profil de culoare
+panel.files.info.image.colorSpace: Spațiu de culoare
+panel.files.info.image.dimensions: Dimensiuni
+panel.files.info.image.dimensions.widthByHeightPixels: '%d × %d pixeli'
+panel.files.info.image.exif.aperture: Diafragmă
+panel.files.info.image.exif.camera: Cameră
+panel.files.info.image.exif.creationDateAndTime: Data și ora creare
+panel.files.info.image.exif.exposureCompensation: Compensare expunere
+panel.files.info.image.exif.exposureProgram: Program de expunere
+panel.files.info.image.exif.exposureTime: Timp de expunere
+panel.files.info.image.exif.flash: Blitz
+panel.files.info.image.exif.focalLength: Distanță focală
+panel.files.info.image.exif.lensModel: Model obiectiv
+panel.files.info.image.exif.meteringMode: Mod de măsurare
+panel.files.info.image.exif.sensitivity: Sensibilitate
+panel.files.info.image.exif.whiteBalance: Balans de alb
+panel.files.info.image.frames: '%d cadre'
+panel.files.info.image.framesCount: Număr cadre
+panel.files.info.image.repeats: '%d repetări'
+panel.files.info.image.repeatsCount: Număr repetări
+panel.files.info.image.resolution: Rezoluție
+panel.files.info.lastModifiedTime: Ultima modificare
+panel.files.info.mimeType: Tip MIME
+panel.files.info.name: Nume
+panel.files.info.size: Dimensiune
+panel.files.info.uri: URI
+panel.files.metadata.updated: Metadatele fișierului au fost actualizate
+panel.files.next: Fișierul următor
+panel.files.pageNotFound: Nu se pot obține informații despre fișier, pagina nu a fost găsită
+panel.files.parent: Părinte
+panel.files.position: Poziție
+panel.files.preview: Previzualizare
+panel.files.previous: Fișierul anterior
+panel.files.renamed: Fișierul a fost redenumit
+panel.files.search: Caută fișiere...
+panel.files.upload: Încarcă fișiere
+panel.files.uploaded: Fișiere încărcate
+panel.files.viewAsList: Vizualizează ca listă
+panel.files.viewAsThumbnails: Vizualizează ca miniaturi
+panel.login.attempt.failed: Încercare de autentificare eșuată! Încearcă din nou.
+panel.login.attempt.tooMany: Prea multe încercări de autentificare. Te rog încearcă din nou în %d minute.
+panel.login.loggedOut: Ai fost delogat
+panel.login.login: Autentificare
+panel.login.logout: Deconectare
+panel.login.password: Parolă
+panel.login.suspiciousRequestDetected: A fost detectată o solicitare suspectă și, din motive de securitate, ai fost delogat. Te rugăm să te autentifici din nou.
+panel.login.usernameOrEmail: Nume de utilizator sau e-mail
+panel.manage: Gestionează
+panel.modal.action.cancel: Anulează
+panel.modal.action.continue: Continuă
+panel.modal.action.delete: Șterge
+panel.modal.action.edit: Editează
+panel.modal.action.rename: Redenumește
+panel.modal.action.save: Salvează
+panel.modal.action.upload: Încarcă
+panel.modal.action.uploadFile: Încarcă un fișier
+panel.modal.images.noImages: Nu există imagini aici
+panel.modal.images.noImages.upload: Te rugăm încarcă niște imagini
+panel.modal.images.title: Selectează o imagine
+panel.modal.link.text: Text
+panel.modal.link.title: Inserează link
+panel.modal.link.uri: Uri
+panel.navigation.toggle: Comută navigarea
+panel.options.options: Opțiuni
+panel.options.site: Site
+panel.options.system: Sistem
+panel.options.system.adminPanel: Panoul de administrare
+panel.options.system.adminPanel.defaultColorScheme: Schema de culori implicită
+panel.options.system.adminPanel.defaultColorScheme.dark: Întunecat
+panel.options.system.adminPanel.defaultColorScheme.light: Deschis
+panel.options.system.adminPanel.defaultLanguage: Limba implicită
+panel.options.system.adminPanel.logoutRedirectsTo: Redirecționare după logout
+panel.options.system.adminPanel.logoutRedirectsTo.home: Acasă
+panel.options.system.adminPanel.logoutRedirectsTo.login: Pagina de autentificare
+panel.options.system.adminPanel.sessionTimeout: Timp expirare sesiune
+panel.options.system.backup: Backup
+panel.options.system.backup.backupFilesToKeep: Backup-uri de păstrat pe server
+panel.options.system.cache: Cache
+panel.options.system.cache.disabled: Dezactivat
+panel.options.system.cache.enabled: Activat
+panel.options.system.cache.time: Timp cache
+panel.options.system.content: Conținut
+panel.options.system.content.allowHtml: Permite HTML în câmpurile Markdown
+panel.options.system.content.allowHtml.description: Etichete potențial periculoase precum `<script>` și `<style>` sunt întotdeauna convertite în text
+panel.options.system.content.allowHtml.disabled: Dezactivat
+panel.options.system.content.allowHtml.enabled: Activat
+panel.options.system.dateAndTime: Dată și oră
+panel.options.system.dateAndTime.dateFormat: Format dată
+panel.options.system.dateAndTime.firstWeekday: Prima zi a săptămânii
+panel.options.system.dateAndTime.firstWeekday.monday: Luni
+panel.options.system.dateAndTime.firstWeekday.sunday: Duminică
+panel.options.system.dateAndTime.hourFormat: Format oră
+panel.options.system.dateAndTime.timezone: Fus orar
+panel.options.system.debug: Debug
+panel.options.system.debug.editorUri: URI editor
+panel.options.system.debug.editorUri.description: Folosește `{{filename}}` și `{{line}}` pentru a construi URI-ul care deschide editorul de cod
+panel.options.system.debug.mode: Mod debug
+panel.options.system.debug.mode.description: Modul debug afișează informații despre erori și trebuie dezactivat în producție deoarece poate dezvălui date sensibile
+panel.options.system.debug.mode.disabled: Dezactivat
+panel.options.system.debug.mode.enabled: Activat
+panel.options.system.files: Fișiere
+panel.options.system.files.allowedExtensions: Extensii permise
+panel.options.system.files.allowedExtensions.noExtensions: Nici o extensie (nu sunt permise fișiere)
+panel.options.system.images: Imagini
+panel.options.system.images.clearCacheByDefault: Golește cache-ul de imagini implicit
+panel.options.system.images.clearCacheByDefault.disabled: Dezactivat
+panel.options.system.images.clearCacheByDefault.enabled: Activat
+panel.options.system.images.jpegQuality: Calitate JPEG
+panel.options.system.images.jpegSaveProgressive: Salvează imaginile JPEG ca progressive
+panel.options.system.images.jpegSaveProgressive.disabled: Dezactivat
+panel.options.system.images.jpegSaveProgressive.enabled: Activat
+panel.options.system.images.pngCompressionLevel: Nivel de compresie PNG
+panel.options.system.images.webpQuality: Calitate WebP
+panel.options.system.uploads.processImages: Procesează (optimizează) imaginile încărcate
+panel.options.system.uploads.processImages.disabled: Dezactivat
+panel.options.system.uploads.processImages.enabled: Activat
+panel.options.updated: Opțiuni actualizate
+panel.pages.changes.continue: Continuă fără a salva
+panel.pages.changes.detected: Modificări detectate
+panel.pages.changes.detected.prompt: Ai modificări care nu au fost salvate. Ești sigur că vrei să părăsești această pagină?
+panel.pages.changeSlug: Editează slug
+panel.pages.changeSlug.generate: Generează din titlu
+panel.pages.deleteFile: Șterge fișier
+panel.pages.deleteFile.prompt: Ești sigur că vrei să ștergi acest fișier? Această acțiune nu poate fi anulată.
+panel.pages.deletePage: Șterge pagină
+panel.pages.deletePage.prompt: Ești sigur că vrei să ștergi această pagină? Această acțiune nu poate fi anulată.
+panel.pages.edit: Editează pagină
+panel.pages.editPage: Editează pagina %s
+panel.pages.history.event.created: Pagină creată de %s %s.
+panel.pages.history.event.edited: Pagină editată de %s %s.
+panel.pages.languages: Limbi
+panel.pages.languages.addLanguage: Adaugă %s
+panel.pages.languages.editLanguage: Editează %s
+panel.pages.newPage: Pagină nouă
+panel.pages.newPage.site: Site
+panel.pages.next: Pagina următoare
+panel.pages.page: Pagină
+panel.pages.page.actions: Acțiuni
+panel.pages.page.cannotChangeNum: Nu se poate schimba numărul paginii
+panel.pages.page.cannotCreate: Nu se poate crea pagina
+panel.pages.page.cannotCreate.alreadyExists: Nu se poate crea pagina, o pagină cu aceeași URI există deja
+panel.pages.page.cannotCreate.invalidParent: Nu se poate crea pagina, pagină părinte invalidă
+panel.pages.page.cannotCreate.invalidSlug: Nu se poate crea pagina, slug-ul paginii trebuie să conțină doar litere și cifre separate prin cratime
+panel.pages.page.cannotCreate.invalidTemplate: Nu se poate crea pagina, șablon invalid
+panel.pages.page.cannotCreate.varMissing: Nu se poate crea pagina, lipsește o variabilă
+panel.pages.page.cannotDelete.invalidLanguage: 'Nu se poate șterge pagina, limbă invalidă: %s'
+panel.pages.page.cannotDelete.notDeletable: Nu se poate șterge pagina, pagina nu poate fi ștearsă
+panel.pages.page.cannotDelete.pageNotFound: Nu se poate șterge pagina, pagina nu a fost găsită
+panel.pages.page.cannotEdit.alreadyExists: Nu se poate edita pagina, o pagină cu aceeași URI există deja
+panel.pages.page.cannotEdit.indexOrErrorPageSlug: Nu se poate edita slug-ul paginii index sau paginilor de eroare
+panel.pages.page.cannotEdit.invalidLanguage: 'Nu se poate edita pagina, limbă invalidă: %s'
+panel.pages.page.cannotEdit.invalidParent: Nu se poate edita pagina, pagină părinte invalidă
+panel.pages.page.cannotEdit.invalidSlug: Nu se poate edita slug-ul paginii, acesta trebuie să conțină doar litere și cifre separate prin cratime
+panel.pages.page.cannotEdit.invalidTemplate: Nu se poate edita pagina, șablon invalid
+panel.pages.page.cannotEdit.pageNotFound: Nu se poate edita pagina, pagina nu a fost găsită
+panel.pages.page.cannotEdit.varMissing: Nu se poate edita pagina, lipsește o variabilă
+panel.pages.page.cannotMove: Nu se poate muta pagina
+panel.pages.page.cannotPreview.pageNotFound: Nu se poate previzualiza pagina, pagina nu a fost găsită
+panel.pages.page.cannotPreview.parentChanged: Nu se poate previzualiza pagina, pagina părinte a fost schimbată
+panel.pages.page.created: Pagină creată!
+panel.pages.page.deleted: Pagină ștearsă
+panel.pages.page.edited: Pagină editată
+panel.pages.page.lastModified: Ultima modificare
+panel.pages.page.moved: Pagină mutată!
+panel.pages.page.notFound: Pagina nu a fost găsită
+panel.pages.page.status: Stare
+panel.pages.pages: Pagini
+panel.pages.pages.collapseAll: Restrânge tot
+panel.pages.pages.expandAll: Extinde tot
+panel.pages.pages.reorder: Reordonează
+panel.pages.pages.search: Caută pagini...
+panel.pages.preview: Previzualizare
+panel.pages.previewFile: Previzualizare
+panel.pages.previous: Pagina anterioară
+panel.pages.publish: Publică
+panel.pages.renameFile: Redenumește fișier
+panel.pages.renameFile.name: Nume
+panel.pages.replaceFile: Înlocuiește fișier
+panel.pages.save: Salvează
+panel.pages.saveOnly: Salvează fără a publica
+panel.pages.toggleChildren: Comută subpagini
+panel.pages.viewChildren: Vezi subpagini
+panel.pages.viewPage: Vezi pagina
+panel.panel: Panoul de administrare
+panel.register.createUser: Formwork este instalat dar nu s-au găsit utilizatori. Te rog înregistrează un utilizator acum.
+panel.register.register: Înregistrează utilizator nou
+panel.request.error.postMaxSize: Cererea HTTP POST depășește dimensiunea maximă permisă
+panel.sections.toggle: Comută secțiunea
+panel.site.languages: Limbi
+panel.site.languages.availableLanguages: Limbi disponibile
+panel.site.languages.availableLanguages.noLanguages: Nici o limbă
+panel.site.languages.preferredLanguage: Folosește limba preferată a browserului
+panel.site.languages.preferredLanguage.disabled: Dezactivat
+panel.site.languages.preferredLanguage.enabled: Activat
+panel.statistics.devices: Dispozitive
+panel.statistics.devices.type: Tip
+panel.statistics.devices.type.desktop: Desktop
+panel.statistics.devices.type.mobile: Mobil
+panel.statistics.devices.type.tablet: Tabletă
+panel.statistics.monthlyUniqueVisitors: Vizitatori unici lunar
+panel.statistics.monthlyVisits: Vizite lunare
+panel.statistics.sources: Surse
+panel.statistics.sources.direct: Direct
+panel.statistics.sources.site: Site
+panel.statistics.statistics: Statistici
+panel.statistics.totalVisits: Total vizite
+panel.statistics.totalVisits.percentTotal: '% total'
+panel.statistics.totalVisits.uri: URI
+panel.statistics.visits: Vizite
+panel.statistics.weeklyUniqueVisitors: Vizitatori unici săptămânal
+panel.statistics.weeklyVisits: Vizite săptămânale
+panel.tools.backup.actions: Acțiuni
+panel.tools.backup.date: Dată
+panel.tools.backup.delete: Șterge backup
+panel.tools.backup.file: Fișier
+panel.tools.backup.size: Dimensiune
+panel.tools.backups: Backup-uri
+panel.tools.info: Informații
+panel.tools.latestBackup: 'Ultimul backup:'
+panel.tools.latestBackups: Ultimele backup-uri
+panel.tools.tools: Unelte
+panel.tools.updates: Actualizări
+panel.updates.availableForInstall: este disponibil pentru instalare
+panel.updates.check: Verifică actualizări
+panel.updates.install: Instalează
+panel.updates.installed: Actualizare instalată!
+panel.updates.installPrompt: Dorești să instalezi actualizarea?
+panel.updates.latestVersionAvailable: este ultima versiune disponibilă
+panel.updates.status.cannotCheck: Nu se pot verifica actualizările. Încearcă mai târziu.
+panel.updates.status.cannotInstall: Nu se poate instala actualizarea
+panel.updates.status.cannotMakeBackup: Nu se poate crea backup înainte de actualizare
+panel.updates.status.checking: Se verifică actualizările...
+panel.updates.status.found: Actualizări găsite
+panel.updates.status.installing: Se instalează actualizările...
+panel.updates.status.upToDate: La zi!
+panel.uploader.uploaded: Fișier încărcat
+panel.user.actions: Acțiuni
+panel.user.image.actions: Acțiuni
+panel.user.image.cannotDelete.defaultImage: Nu se poate șterge imaginea implicită a utilizatorului
+panel.user.image.delete: Șterge imaginea utilizatorului
+panel.user.image.delete.prompt: Ești sigur că vrei să ștergi imaginea utilizatorului? Această acțiune nu poate fi anulată.
+panel.user.image.deleted: Imaginea utilizatorului a fost ștearsă
+panel.user.image.uploaded: Imaginea utilizatorului a fost încărcată
+panel.user.lastAccess: Ultimul acces
+panel.users.deleteUser: Șterge utilizator
+panel.users.deleteUser.prompt: Ești sigur că vrei să ștergi acest utilizator? Această acțiune nu poate fi anulată.
+panel.users.newUser: Utilizator nou
+panel.users.newUser.password.suggestion: cel puțin 8 caractere
+panel.users.newUser.username.suggestion: între 3-20 de litere, cifre și - . _
+panel.users.nextUser: Utilizatorul următor
+panel.users.options: Opțiuni
+panel.users.previousUser: Utilizatorul anterior
+panel.users.user.cannotChangeEmail.alreadyUsed: Nu se poate schimba e-mailul utilizatorului, adresa este deja asociată unui cont
+panel.users.user.cannotChangePassword: Nu se poate schimba parola altui utilizator. Această acțiune nu este permisă.
+panel.users.user.cannotChangeRole: Nu se poate schimba rolul lui %s. Această acțiune nu este permisă.
+panel.users.user.cannotCreate.alreadyExists: Nu se poate crea utilizatorul, un utilizator cu același nume există deja
+panel.users.user.cannotCreate.emailAlreadyUsed: Nu se poate crea utilizatorul, adresa de e-mail este deja asociată unui cont
+panel.users.user.cannotCreate.varMissing: Nu se poate crea utilizatorul, lipsește o variabilă
+panel.users.user.cannotDelete: Nu se poate șterge utilizatorul. Trebuie să fii administrator și utilizatorul nu trebuie să fie autentificat.
+panel.users.user.cannotEdit: Nu se poate edita utilizatorul %s. Această acțiune nu este permisă.
+panel.users.user.created: Utilizator creat
+panel.users.user.deleted: Utilizator șters
+panel.users.user.edited: Datele utilizatorului au fost actualizate
+panel.users.user.notFound: Utilizatorul nu a fost găsit
+panel.users.userProfile: '%s profil utilizator'
+panel.users.users: Utilizatori
+panel.viewSite: Vezi site-ul


### PR DESCRIPTION
This pull request adds new Dutch and Romanian translation files for the application. These translations cover user interface strings related to dates, fields, pages, site settings, uploads, user management, and zip file errors, making the application more accessible for Dutch and Romanian-speaking users.

**Added language support:**

* Added Dutch translations for all major UI elements and error messages in `formwork/translations/nl.yaml`.
* Added Romanian translations for all major UI elements and error messages in `formwork/translations/ro.yaml`.