### PR TITLE
Page taxonomies

### DIFF
--- a/formwork/config/routes/routes.php
+++ b/formwork/config/routes/routes.php
@@ -8,6 +8,7 @@ use Formwork\Http\Request;
 use Formwork\Http\ResponseStatus;
 use Formwork\Router\Router;
 use Formwork\Security\CsrfToken;
+use Formwork\Utils\Arr;
 use Formwork\Utils\FileSystem;
 use Formwork\Utils\Str;
 
@@ -37,14 +38,14 @@ return [
         'taxonomy.pagination' => [
             'path'  => '/{page:all}/{taxonomy}/{taxonomyTerm:slug}/page/{paginationPage:number}/',
             'where' => [
-                'taxonomy' => fn($value, Site $site) => in_array($value, $site->taxonomies(), true),
+                'taxonomy' => fn($value, Site $site) => in_array($value, Arr::from($site->get('taxonomies')), true),
             ],
             'action' => 'Formwork\Controllers\PageController@load',
         ],
         'taxonomy' => [
             'path'  => '/{page:all}/{taxonomy}/{taxonomyTerm:slug}/',
             'where' => [
-                'taxonomy' => fn($value, Site $site) => in_array($value, $site->taxonomies(), true),
+                'taxonomy' => fn($value, Site $site) => in_array($value, Arr::from($site->get('taxonomies')), true),
             ],
             'action' => 'Formwork\Controllers\PageController@load',
         ],

--- a/formwork/config/routes/routes.php
+++ b/formwork/config/routes/routes.php
@@ -34,12 +34,18 @@ return [
             'path'   => '/files/{name}/',
             'action' => 'Formwork\Controllers\FilesController@file',
         ],
-        'tag.pagination' => [
-            'path'   => '/{page:all}/tag/{tagName:slug}/page/{paginationPage:number}/',
+        'taxonomy.pagination' => [
+            'path'  => '/{page:all}/{taxonomy}/{taxonomyTerm:slug}/page/{paginationPage:number}/',
+            'where' => [
+                'taxonomy' => fn($value, Site $site) => in_array($value, $site->taxonomies(), true),
+            ],
             'action' => 'Formwork\Controllers\PageController@load',
         ],
-        'tag' => [
-            'path'   => '/{page:all}/tag/{tagName:slug}/',
+        'taxonomy' => [
+            'path'  => '/{page:all}/{taxonomy}/{taxonomyTerm:slug}/',
+            'where' => [
+                'taxonomy' => fn($value, Site $site) => in_array($value, $site->taxonomies(), true),
+            ],
             'action' => 'Formwork\Controllers\PageController@load',
         ],
         'page.pagination' => [

--- a/formwork/config/site.yaml
+++ b/formwork/config/site.yaml
@@ -34,3 +34,5 @@ statistics:
     cleanup:
         ttl: 86400
         probability: 5
+
+taxonomies: [tag]

--- a/formwork/config/site.yaml
+++ b/formwork/config/site.yaml
@@ -35,4 +35,4 @@ statistics:
         ttl: 86400
         probability: 5
 
-taxonomies: [tag]
+taxonomies: []

--- a/formwork/src/Controllers/PageController.php
+++ b/formwork/src/Controllers/PageController.php
@@ -66,7 +66,7 @@ final class PageController extends AbstractController
                 return $this->getPageResponse($this->site->errorPage());
             }
 
-            if ($routeParams->has('tagName') && !$page->scheme()->options()->get('allowTags', false)) {
+            if ($routeParams->has('taxonomy') && !$page->scheme()->options()->get('allowTaxonomy', false)) {
                 return $this->getPageResponse($this->site->errorPage());
             }
 

--- a/formwork/src/Pages/Page.php
+++ b/formwork/src/Pages/Page.php
@@ -231,6 +231,7 @@ class Page extends Model implements Stringable
             'headers'        => [],
             'responseStatus' => 200,
             'metadata'       => [],
+            'taxonomy'       => [],
             'content'        => '',
         ];
 
@@ -384,6 +385,30 @@ class Page extends Model implements Stringable
     public function files(): FileCollection
     {
         return $this->files;
+    }
+
+    /**
+     * Get page taxonomy
+     *
+     * @return array<string, list<string>>
+     */
+    public function taxonomy(): array
+    {
+        return $this->data['taxonomy'];
+    }
+
+    /**
+     * Set page taxonomy
+     *
+     * @param array<string, list<string>> $taxonomy
+     */
+    public function setTaxonomy(array $taxonomy): void
+    {
+        if (!Arr::every($taxonomy, fn($terms, $taxonomyName) => is_string($taxonomyName)
+            && is_array($terms) && Arr::every($terms, fn($term) => is_string($term)))) {
+            throw new InvalidValueException('Invalid taxonomy format');
+        }
+        $this->data['taxonomy'] = $taxonomy;
     }
 
     /**

--- a/formwork/src/Pages/Page.php
+++ b/formwork/src/Pages/Page.php
@@ -758,11 +758,11 @@ class Page extends Model implements Stringable
                 || in_array($field->name(), self::IGNORED_FIELD_NAMES, true)
                 || in_array($field->type(), self::IGNORED_FIELD_TYPES, true)
             ) {
-                unset($frontmatter[$field->name()]);
+                Arr::remove($frontmatter, $field->name());
                 continue;
             }
 
-            $frontmatter[$field->name()] = $field->value();
+            Arr::set($frontmatter, $field->name(), $field->value());
         }
 
         $content = str_replace("\r\n", "\n", $this->data['content']);

--- a/formwork/src/Router/Route.php
+++ b/formwork/src/Router/Route.php
@@ -2,6 +2,7 @@
 
 namespace Formwork\Router;
 
+use Closure;
 use InvalidArgumentException;
 
 class Route
@@ -40,6 +41,13 @@ class Route
      * @var list<string>
      */
     protected array $types = self::DEFAULT_TYPES;
+
+    /**
+     * Route parameter constraints
+     *
+     * @var array<string, array<mixed>|Closure>
+     */
+    protected array $constraints = [];
 
     /**
      * Route prefix
@@ -147,5 +155,26 @@ class Route
     public function getPrefix(): string
     {
         return $this->prefix;
+    }
+
+    /**
+     * Set route parameter constraint
+     *
+     * @param array<mixed>|Closure $constraint
+     */
+    public function where(string $parameter, Closure|array $constraint): self
+    {
+        $this->constraints[$parameter] = $constraint;
+        return $this;
+    }
+
+    /**
+     * Get route parameter constraints
+     *
+     * @return array<string, array<mixed>|Closure>
+     */
+    public function getConstraints(): array
+    {
+        return $this->constraints;
     }
 }

--- a/formwork/src/Schemes/SchemeFactory.php
+++ b/formwork/src/Schemes/SchemeFactory.php
@@ -3,6 +3,7 @@
 namespace Formwork\Schemes;
 
 use Formwork\Services\Container;
+use Formwork\Utils\Str;
 
 final class SchemeFactory
 {
@@ -17,6 +18,10 @@ final class SchemeFactory
      */
     public function make(string $id, array $data = []): Scheme
     {
+        if (Str::startsWith($id, 'pages.') && isset($data['options']['allowTags'])) {
+            trigger_error('The Scheme option "allowTags" is deprecated since Formwork 2.2.0, use "allowTaxonomy"', E_USER_DEPRECATED);
+            $data['options']['allowTaxonomy'] = $data['options']['allowTags'];
+        }
         return $this->container->build(Scheme::class, compact('id', 'data'));
     }
 }

--- a/formwork/translations/de.yaml
+++ b/formwork/translations/de.yaml
@@ -80,6 +80,9 @@ site.maintenance.enabled.enabled: Aktiviert
 site.maintenance.page: Wartungsseite
 site.pages: Seiten
 site.pages.defaultTemplate: Standardvorlage
+site.pages.taxonomies: Taxonomien
+site.pages.taxonomies.description: Taxonomien zur Organisation von Seiten, zu verwenden in Template-Controllern zum Filtern von Seiten
+site.pages.taxonomies.noTaxonomies: Keine Taxonomien
 site.statistics: Statistiken
 site.statistics.enabled: Seitenbesuche verfolgen
 site.statistics.enabled.disabled: Deaktiviert

--- a/formwork/translations/en.yaml
+++ b/formwork/translations/en.yaml
@@ -80,6 +80,9 @@ site.maintenance.enabled.enabled: Enabled
 site.maintenance.page: Maintenance page
 site.pages: Pages
 site.pages.defaultTemplate: Default template
+site.pages.taxonomies: Taxonomies
+site.pages.taxonomies.description: Taxonomies for organizing pages, to be used in template controllers to filter pages
+site.pages.taxonomies.noTaxonomies: No taxonomies
 site.statistics: Statistics
 site.statistics.enabled: Track page visits
 site.statistics.enabled.disabled: Disabled

--- a/formwork/translations/es.yaml
+++ b/formwork/translations/es.yaml
@@ -80,6 +80,9 @@ site.maintenance.enabled.enabled: Activado
 site.maintenance.page: Página de mantenimiento
 site.pages: Páginas
 site.pages.defaultTemplate: Plantilla predeterminada
+site.pages.taxonomies: Taxonomías
+site.pages.taxonomies.description: Taxonomías para organizar páginas, a usar en los controladores de plantillas para filtrar páginas
+site.pages.taxonomies.noTaxonomies: Sin taxonomías
 site.statistics: Estadísticas
 site.statistics.enabled: Rastrear visitas a la página
 site.statistics.enabled.disabled: Desactivado

--- a/formwork/translations/fr.yaml
+++ b/formwork/translations/fr.yaml
@@ -80,6 +80,9 @@ site.maintenance.enabled.enabled: Activé
 site.maintenance.page: Page de maintenance
 site.pages: Pages
 site.pages.defaultTemplate: Modèle (template) par défaut
+site.pages.taxonomies: Taxonomies
+site.pages.taxonomies.description: Taxonomies pour organiser les pages, à utiliser dans les contrôleurs de modèles pour filtrer les pages
+site.pages.taxonomies.noTaxonomies: Aucune taxonomie
 site.statistics: Statistiques
 site.statistics.enabled: Suivre les visites de la page
 site.statistics.enabled.disabled: Désactivé

--- a/formwork/translations/it.yaml
+++ b/formwork/translations/it.yaml
@@ -80,6 +80,9 @@ site.maintenance.enabled.enabled: Attivata
 site.maintenance.page: Pagina manutenzione
 site.pages: Pagine
 site.pages.defaultTemplate: Template predefinito
+site.pages.taxonomies: Tassonomie
+site.pages.taxonomies.description: Tassonomie per organizzare le pagine, da usare nei controller dei template per filtrare le pagine
+site.pages.taxonomies.noTaxonomies: Nessuna tassonomia
 site.statistics: Statistiche
 site.statistics.enabled: Traccia visite alle pagine
 site.statistics.enabled.disabled: Disabilitato

--- a/formwork/translations/nl.yaml
+++ b/formwork/translations/nl.yaml
@@ -80,6 +80,9 @@ site.maintenance.enabled.enabled: Ingeschakeld
 site.maintenance.page: Onderhoudspagina
 site.pages: Pagina’s
 site.pages.defaultTemplate: Standaardsjabloon
+site.pages.taxonomies: Taxonomieën
+site.pages.taxonomies.description: Taxonomieën voor het organiseren van pagina’s, te gebruiken in templatecontrollers om pagina’s te filteren
+site.pages.taxonomies.noTaxonomies: Geen taxonomieën
 site.statistics: Statistieken
 site.statistics.enabled: Paginaweergaven bijhouden
 site.statistics.enabled.disabled: Uitgeschakeld

--- a/formwork/translations/pl.yaml
+++ b/formwork/translations/pl.yaml
@@ -80,6 +80,9 @@ site.maintenance.enabled.enabled: Włączony
 site.maintenance.page: Strona konserwacyjna
 site.pages: Strony
 site.pages.defaultTemplate: Domyślny szablon
+site.pages.taxonomies: Taksonomie
+site.pages.taxonomies.description: Taksonomie do organizowania stron, używane w kontrolerach szablonów do filtrowania stron
+site.pages.taxonomies.noTaxonomies: Brak taksonomii
 site.statistics: Statystyki
 site.statistics.enabled: Śledzenie wizyt na stronie
 site.statistics.enabled.disabled: Wyłączone

--- a/formwork/translations/pt.yaml
+++ b/formwork/translations/pt.yaml
@@ -80,6 +80,9 @@ site.maintenance.enabled.enabled: Ativado
 site.maintenance.page: Página de manutenção
 site.pages: Páginas
 site.pages.defaultTemplate: Template padrão
+site.pages.taxonomies: Taxonomias
+site.pages.taxonomies.description: Taxonomias para organizar páginas, usadas nos controladores de templates para filtrar páginas
+site.pages.taxonomies.noTaxonomies: Sem taxonomias
 site.statistics: Estatísticas
 site.statistics.enabled: Rastrear visitas à página
 site.statistics.enabled.disabled: Desativado

--- a/formwork/translations/ro.yaml
+++ b/formwork/translations/ro.yaml
@@ -80,6 +80,9 @@ site.maintenance.enabled.enabled: Activat
 site.maintenance.page: Pagină de mentenanță
 site.pages: Pagini
 site.pages.defaultTemplate: Șablon implicit
+site.pages.taxonomies: Taxonomii
+site.pages.taxonomies.description: Taxonomii pentru organizarea paginilor, folosite în controllerele șabloanelor pentru a filtra pagini
+site.pages.taxonomies.noTaxonomies: Nicio taxonomie
 site.statistics: Statistici
 site.statistics.enabled: Urmărește vizitele paginilor
 site.statistics.enabled.disabled: Dezactivat

--- a/formwork/translations/ru.yaml
+++ b/formwork/translations/ru.yaml
@@ -80,6 +80,9 @@ site.maintenance.enabled.enabled: Включено
 site.maintenance.page: Страница обслуживания
 site.pages: Страницы
 site.pages.defaultTemplate: Шаблон по умолчанию
+site.pages.taxonomies: Таксономии
+site.pages.taxonomies.description: Таксономии для организации страниц, используются в контроллерах шаблонов для фильтрации страниц
+site.pages.taxonomies.noTaxonomies: Нет таксономий
 site.statistics: Статистика
 site.statistics.enabled: Отслеживать посещения страницы
 site.statistics.enabled.disabled: Отключено

--- a/formwork/translations/uk.yaml
+++ b/formwork/translations/uk.yaml
@@ -80,6 +80,9 @@ site.maintenance.enabled.enabled: Увімкнено
 site.maintenance.page: Сторінка обслуговування
 site.pages: Сторінки
 site.pages.defaultTemplate: Шаблон за замовчуванням
+site.pages.taxonomies: Таксономії
+site.pages.taxonomies.description: Таксономії для впорядкування сторінок, використовуються в контролерах шаблонів для фільтрації сторінок
+site.pages.taxonomies.noTaxonomies: Немає таксономій
 site.statistics: Статистика
 site.statistics.enabled: Відстежувати відвідування сторінки
 site.statistics.enabled.disabled: Вимкнено

--- a/site/config/site.yaml
+++ b/site/config/site.yaml
@@ -2,3 +2,5 @@ title: Formwork
 languages:
     available:
         - en
+taxonomies:
+    - tag

--- a/site/pages/2-blog/20180615-hello-world/post.md
+++ b/site/pages/2-blog/20180615-hello-world/post.md
@@ -6,9 +6,10 @@ summary: |-
 
     This simple phrase has become a time-honored tradition in programming. It’s the output of the very first program most developers write when learning a new language, a framework, or — like now — setting up a new site.
 coverImage: nasa-vhsz50aafas-unsplash.jpg
-tags:
-    - ideas
-    - 'getting started'
+taxonomy:
+    tag:
+        - ideas
+        - 'getting started'
 ---
 ## Why "Hello World"?
 

--- a/site/pages/2-blog/20220624-another-blog-post/post.md
+++ b/site/pages/2-blog/20220624-another-blog-post/post.md
@@ -3,11 +3,12 @@ title: 'Coffee, Mornings, and Ideas'
 publishDate: '2022-06-24 22:13:00'
 summary: 'There’s something magical about the first sip of coffee in the morning. The day is still quiet, thoughts begin to form, and the smell alone seems to awaken possibility.'
 coverImage: vruyr-martirosyan-0n632k-mow4-unsplash.jpg
-tags:
-    - 'morning routine'
-    - ideas
-    - lifestyle
-    - productivity
+taxonomy:
+    tag:
+        - 'morning routine'
+        - ideas
+        - lifestyle
+        - productivity
 ---
 ## Little rituals
 

--- a/site/pages/2-blog/20250505-a-walk-in-the-park/post.md
+++ b/site/pages/2-blog/20250505-a-walk-in-the-park/post.md
@@ -3,11 +3,12 @@ title: 'A Walk in the Park'
 summary: 'Sometimes the simplest things bring the most peace. A quiet stroll beneath the trees, birdsong in the air, and the crunch of gravel underfoot.'
 publishDate: '2025-05-05 22:16:00'
 coverImage: spencer-demera-opsimocytr0-unsplash.jpg
-tags:
-    - lifestyle
-    - relaxation
-    - ideas
-    - mindfulness
+taxonomy:
+    tag:
+        - lifestyle
+        - relaxation
+        - ideas
+        - mindfulness
 ---
 ## Nature’s small details
 

--- a/site/schemes/config/site.yaml
+++ b/site/schemes/config/site.yaml
@@ -11,7 +11,7 @@ layout:
         pages:
             label: '{{site.pages}}'
             collapsible: true
-            fields: [defaultTemplate]
+            fields: [defaultTemplate, taxonomies]
 
         languages:
             collapsible: true
@@ -48,6 +48,12 @@ fields:
     defaultTemplate:
         type: template
         label: '{{site.pages.defaultTemplate}}'
+
+    taxonomies:
+        type: tags
+        label: '{{site.pages.taxonomies}}'
+        placeholder: '{{site.pages.taxonomies.noTaxonomies}}'
+        description: '{{site.pages.taxonomies.description}}'
 
     languages.available:
         type: tags

--- a/site/schemes/pages/post.yaml
+++ b/site/schemes/pages/post.yaml
@@ -10,7 +10,7 @@ options:
 layout:
     sections:
         content:
-            fields: [title, coverImage, tags, summary, content]
+            fields: [title, coverImage, taxonomy.tag, summary, content]
 
 fields:
     summary:
@@ -22,7 +22,7 @@ fields:
         type: image
         label: '{{page.image}}'
 
-    tags:
+    taxonomy.tag:
         type: tags
         label: '{{page.tags}}'
         placeholder: '{{page.noTags}}'

--- a/site/templates/controllers/blog.php
+++ b/site/templates/controllers/blog.php
@@ -2,18 +2,16 @@
 
 use Formwork\Http\ResponseStatus;
 use Formwork\Http\Utils\Header;
-use Formwork\Utils\Str;
 
 // Posts are the published children of the blog page
 $posts = $page->children()->published();
 
-// If the route has the param `{tagName}`
-if ($router->params()->has('tagName')) {
-    $posts = $posts->filterBy(
-        'tags',             // Filter posts by tags...
-        fn ($tags) => $tags
-            ->map(fn ($tag) => Str::slug($tag)) // where the collection of their slugs...
-            ->contains($router->params()->get('tagName'))   // contains the value of the `tagName` param.
+// If the route has the param `{taxonomy}`
+if ($router->params()->has('taxonomy')) {
+    // Filter posts by the taxonomy term provided in the `{taxonomyTerm}` param
+    $posts = $posts->havingTaxonomy(
+        [$router->params()->get('taxonomy') => [$router->params()->get('taxonomyTerm')]],
+        slug: true // Use slugs for matching terms
     );
 }
 

--- a/site/templates/partials/tags.php
+++ b/site/templates/partials/tags.php
@@ -1,6 +1,6 @@
-<?php if ($post->has('tags')) : ?>
+<?php if ($post->has('taxonomy.tag')) : ?>
     <div class="tags">
-        <?php foreach ($post->tags() as $tag) : ?>
+        <?php foreach ($post->get('taxonomy.tag') as $tag) : ?>
             <a class="tag" rel="tag" href="<?= $blog->uri('/tag/' . $this->slug($tag) . '/') ?>"><?= $this->escape($tag) ?></a>
         <?php endforeach ?>
     </div>


### PR DESCRIPTION
This pull request refactors the handling of tags in the Formwork CMS to support a more flexible taxonomy system. Tags are now treated as a type of taxonomy, enabling future support for additional taxonomies beyond just tags. The changes include updates to routes, data structures, filtering logic, and deprecation notices, ensuring backward compatibility and extensibility.

### Taxonomy system introduction and migration

* Replaced the old tag-specific routes and logic with generic taxonomy-based routes in `routes.php`, allowing for filtering and pagination by any taxonomy defined in the site config.
* Updated post metadata in markdown files and page schemes to use the new `taxonomy` structure instead of `tags`, and adjusted templates to display taxonomy terms. [[1]](diffhunk://#diff-352902f7d8a1fea6322e808e42b3c9ec2e6876955612301970d5ae2c9692a364L9-R10) [[2]](diffhunk://#diff-40de687e19872c88f4818ab19ac48d9b8934546ade07f1af47ba7137cd68edfcL6-R7) [[3]](diffhunk://#diff-8a16c0fd690f172c8527575d71ba600d8b0edbb8876e03d51f8eb64eadfda23fL6-R7) [[4]](diffhunk://#diff-7e3213ea30d7e037614d30b584d4812b2c0ce06211bcea89f740b82dc9377736L13-R13) [[5]](diffhunk://#diff-7e3213ea30d7e037614d30b584d4812b2c0ce06211bcea89f740b82dc9377736L25-R25) [[6]](diffhunk://#diff-a45b9407dd6fdf47583a469b098fce64e06614d87e91f1160c1271789d07fa17L1-R3)

### Core data model and API changes

* Added `taxonomy` support to the `Page` class, including getter and setter methods with validation, and included taxonomy in page defaults. [[1]](diffhunk://#diff-41cde3f613679dfb74ed037d6b61206fb870d9a5118bf4810073330493ec2b70R234) [[2]](diffhunk://#diff-41cde3f613679dfb74ed037d6b61206fb870d9a5118bf4810073330493ec2b70R390-R413)
* Implemented a new `havingTaxonomy` method in `PageCollection` to filter pages by taxonomy terms, supporting both plain and slug matching.

### Routing engine enhancements

* Added parameter constraints to the routing system, allowing routes to validate taxonomy names against those defined in the site configuration, and ensured constraints are checked during dispatch. [[1]](diffhunk://#diff-035b7bad8bdc52c000edb249b9d438b944f57a3292607d927df1fbfec67930feR45-R51) [[2]](diffhunk://#diff-035b7bad8bdc52c000edb249b9d438b944f57a3292607d927df1fbfec67930feR159-R179) [[3]](diffhunk://#diff-354d305924a9a5acd1efa7e9bbae4fd5cca34a55c81b5d634e7c324c90836b29R217-R228) [[4]](diffhunk://#diff-354d305924a9a5acd1efa7e9bbae4fd5cca34a55c81b5d634e7c324c90836b29R303-R309)

### Deprecation and compatibility

* Deprecated the `allowTags` scheme option in favor of `allowTaxonomy`, with a deprecation warning, and updated code to check for the new option. [[1]](diffhunk://#diff-db2507f8a44939f884ec365f5dc7bcec8c875b1edcea5deeba11609b45139ec1R21-R24) [[2]](diffhunk://#diff-a855f64a4bbc85f3f7d1f2294ecb506b89d8c8e010932dcda53cb5c6b3b860e4L69-R69)

### Configuration updates

* Added a `taxonomies` entry to the site configuration, initializing it with `tag` for backward compatibility and future extensibility.