### PR TITLE
Add the possibility to delete pages in place from the tree

### DIFF
--- a/formwork/src/Panel/Controllers/PagesController.php
+++ b/formwork/src/Panel/Controllers/PagesController.php
@@ -322,6 +322,9 @@ final class PagesController extends AbstractController
         $page = $this->site->findPage($routeParams->get('page'));
 
         if ($page === null) {
+            if ($this->request->isXmlHttpRequest()) {
+                return JsonResponse::error($this->translate('panel.pages.page.cannotDelete.pageNotFound'), ResponseStatus::InternalServerError);
+            }
             $this->panel->notify($this->translate('panel.pages.page.cannotDelete.pageNotFound'), 'error');
             return $this->redirectToReferer(default: $this->generateRoute('panel.pages'), base: $this->panel->panelRoot());
         }
@@ -331,12 +334,18 @@ final class PagesController extends AbstractController
             if ($page->languages()->available()->has($language)) {
                 $page->setLanguage($language);
             } else {
+                if ($this->request->isXmlHttpRequest()) {
+                    return JsonResponse::error($this->translate('panel.pages.page.cannotDelete.invalidLanguage', $language), ResponseStatus::InternalServerError);
+                }
                 $this->panel->notify($this->translate('panel.pages.page.cannotDelete.invalidLanguage', $language), 'error');
                 return $this->redirectToReferer(default: $this->generateRoute('panel.pages'), base: $this->panel->panelRoot());
             }
         }
 
         if (!$page->isDeletable()) {
+            if ($this->request->isXmlHttpRequest()) {
+                return JsonResponse::error($this->translate('panel.pages.page.cannotDelete.notDeletable'), ResponseStatus::InternalServerError);
+            }
             $this->panel->notify($this->translate('panel.pages.page.cannotDelete.notDeletable'), 'error');
             return $this->redirectToReferer(default: $this->generateRoute('panel.pages'), base: $this->panel->panelRoot());
         }
@@ -350,6 +359,9 @@ final class PagesController extends AbstractController
             }
         }
 
+        if ($this->request->isXmlHttpRequest()) {
+            return JsonResponse::success($this->translate('panel.pages.page.deleted'));
+        }
         $this->panel->notify($this->translate('panel.pages.page.deleted'), 'success');
 
         // Try to redirect to referer unless it's to Pages@edit

--- a/panel/config/routes/routes.php
+++ b/panel/config/routes/routes.php
@@ -95,6 +95,7 @@ return [
             'path'    => '/pages/{page:all}/delete/',
             'action'  => 'Formwork\Panel\Controllers\PagesController@delete',
             'methods' => ['POST'],
+            'types'   => ['HTTP', 'XHR'],
         ],
 
         'panel.pages.delete.lang' => [

--- a/panel/modals/deletePageItem.yaml
+++ b/panel/modals/deletePageItem.yaml
@@ -1,0 +1,18 @@
+title: '{{panel.pages.deletePage}}'
+
+message: '{{panel.pages.deletePage.prompt}}'
+
+buttons:
+    dismiss:
+        action: dismiss
+        icon: times-circle
+        label: '{{panel.modal.action.cancel}}'
+        variant: secondary
+
+    delete:
+        action: command
+        icon: trash
+        label: '{{panel.modal.action.delete}}'
+        align: right
+        variant: danger
+        command: delete-page

--- a/panel/views/pages/tree.php
+++ b/panel/views/pages/tree.php
@@ -1,4 +1,4 @@
-<?php $this->modals()->add('deletePage') ?>
+<?php $this->modals()->add('deletePageItem') ?>
 
 <?php if ($headers) : ?>
     <div class="pages-tree-headers" aria-hidden="true">
@@ -82,7 +82,7 @@
                                 <a class="dropdown-item hide-from-lg" href="<?= $panel->uri('/pages/' . trim($page->route(), '/') . '/tree/') ?>"><?= $this->icon('pages-level-down') ?> <?= $this->translate('panel.pages.viewChildren') ?></a>
                             <?php endif ?>
                             <?php if ($panel->user()->permissions()->has('panel.pages.delete')) : ?>
-                                <button type="button" class="dropdown-item" data-modal="deletePageModal" data-modal-action="<?= $panel->uri('/pages/' . trim($page->route(), '/') . '/delete/') ?>" <?php if (!$page->isDeletable()) : ?> disabled<?php endif ?>><?= $this->icon('trash') ?> <?= $this->translate('panel.pages.deletePage') ?></button>
+                                <button type="button" class="dropdown-item" data-modal="deletePageItemModal" data-action="<?= $panel->uri('/pages/' . trim($page->route(), '/') . '/delete/') ?>" <?php if (!$page->isDeletable()) : ?> disabled<?php endif ?>><?= $this->icon('trash') ?> <?= $this->translate('panel.pages.deletePage') ?></button>
                             <?php endif ?>
                         </div>
                     </div>


### PR DESCRIPTION
This pull request improves the user experience and robustness of deleting pages in the panel by introducing a dedicated modal for page deletion and enhancing both backend and frontend handling of delete actions, especially for AJAX (XHR) requests. The changes ensure that errors and success messages are communicated appropriately whether the action is performed via a standard HTTP request or an XHR request, and that the UI updates dynamically after deletion.

**Backend enhancements for delete actions:**

* The `PagesController@delete` method now returns JSON error responses for XHR requests when the page is not found, the language is invalid, or the page is not deletable, ensuring AJAX requests receive structured error feedback. [[1]](diffhunk://#diff-c8b238be663183da229ed13ae8e0602420592d770a9c16e71b8987712713b719R325-R327) [[2]](diffhunk://#diff-c8b238be663183da229ed13ae8e0602420592d770a9c16e71b8987712713b719R337-R348)
* On successful deletion via XHR, a JSON success response is returned, improving frontend integration.
* The `panel.pages.delete` route now explicitly supports both HTTP and XHR request types, clarifying its usage for AJAX operations.

**Frontend and modal improvements:**

* A new modal definition `deletePageItem.yaml` is added for deleting pages, with clear messaging and command handling.
* The pages tree UI now uses the new `deletePageItemModal` for delete actions, and the modal is properly initialized in the TypeScript logic. [[1]](diffhunk://#diff-45fed0a3d9bb68f4057f9e2e24f4643100d3c6aa4a1ad11e3ab1773ca9762842L1-R1) [[2]](diffhunk://#diff-3c13b27742d4dd6efac232739a07cfcf99c69ea73ab9f9ef378eed19af24bb3eR21) [[3]](diffhunk://#diff-45fed0a3d9bb68f4057f9e2e24f4643100d3c6aa4a1ad11e3ab1773ca9762842L85-R85)
* The frontend logic (`pages.ts`) is updated to handle the new modal's open and command events, sending the delete request via AJAX, updating the UI to remove the deleted page, and showing notifications based on the server response.

These changes collectively make page deletion more user-friendly, reliable, and consistent across different types of requests.