### PR TITLE
Add the possibility to save and create a new page

### DIFF
--- a/formwork/src/Panel/Controllers/PagesController.php
+++ b/formwork/src/Panel/Controllers/PagesController.php
@@ -165,7 +165,7 @@ final class PagesController extends AbstractController
             return $this->redirect($this->generateRoute('panel.pages.edit.lang', ['page' => trim($page->route(), '/'), 'language' => $page->language()]));
         }
 
-        $createNew = !Constraint::isFalsy($this->request->query()->get('createNew', false));
+        $createNew = $this->request->query()->has('createNew');
 
         // Load page fields
         $fieldCollection = $page->fields()->deepClone();

--- a/formwork/src/Panel/Controllers/PagesController.php
+++ b/formwork/src/Panel/Controllers/PagesController.php
@@ -165,6 +165,8 @@ final class PagesController extends AbstractController
             return $this->redirect($this->generateRoute('panel.pages.edit.lang', ['page' => trim($page->route(), '/'), 'language' => $page->language()]));
         }
 
+        $createNew = !Constraint::isFalsy($this->request->query()->get('createNew', false));
+
         // Load page fields
         $fieldCollection = $page->fields()->deepClone();
 
@@ -208,13 +210,21 @@ final class PagesController extends AbstractController
                     throw new UnexpectedValueException('Unexpected missing page route');
                 }
 
+                $query = [];
+
+                if ($createNew) {
+                    $query[] = 'createNew';
+                }
+
                 // Redirect to avoid ERR_CACHE_MISS
                 if ($routeParams->has('language')) {
-                    return $this->redirect($this->generateRoute('panel.pages.edit.lang', ['page' => $page->route(), 'language' => $routeParams->get('language')]));
+                    return $this->redirect(Uri::make(['query' => implode('&', $query)], $this->generateRoute('panel.pages.edit.lang', ['page' => $page->route(), 'language' => $routeParams->get('language')])));
                 }
-                return $this->redirect($this->generateRoute('panel.pages.edit', ['page' => $page->route()]));
+                return $this->redirect(Uri::make(['query' => implode('&', $query)], $this->generateRoute('panel.pages.edit', ['page' => $page->route()])));
         }
 
+        $this->modal('newPage')->setFieldsModel($page->parent() ?? $this->site);
+        $this->modal('newPage')->open($createNew);
         $this->modal('images')->setFieldsModel($page);
 
         $contentHistory = $page->contentPath()

--- a/panel/src/ts/components/views/pages.ts
+++ b/panel/src/ts/components/views/pages.ts
@@ -120,6 +120,13 @@ export class Pages {
         if (newPageModal) {
             const form = newPageModal.form as Form;
 
+            const url = new URL(window.location.href);
+
+            if (url.searchParams.has("createNew")) {
+                url.searchParams.delete("createNew");
+                window.history.replaceState({}, document.title, url.toString());
+            }
+
             const parentSelect = form.inputs["newPageModal[parent]"] as SelectInput;
 
             const filterAllowedTemplates = () => {

--- a/panel/translations/de.yaml
+++ b/panel/translations/de.yaml
@@ -250,6 +250,7 @@ panel.pages.renameFile: Datei umbenennen
 panel.pages.renameFile.name: Name
 panel.pages.replaceFile: Datei ersetzen
 panel.pages.save: Speichern
+panel.pages.saveAndCreateNew: Speichern und neu erstellen
 panel.pages.saveOnly: Speichern ohne zu veröffentlichen
 panel.pages.toggleChildren: Untergeordnete Seiten umschalten
 panel.pages.viewChildren: Unterseiten anzeigen

--- a/panel/translations/en.yaml
+++ b/panel/translations/en.yaml
@@ -250,6 +250,7 @@ panel.pages.renameFile: Rename file
 panel.pages.renameFile.name: Name
 panel.pages.replaceFile: Replace file
 panel.pages.save: Save
+panel.pages.saveAndCreateNew: Save and create new
 panel.pages.saveOnly: Save without publishing
 panel.pages.toggleChildren: Toggle children pages
 panel.pages.viewChildren: View children pages

--- a/panel/translations/es.yaml
+++ b/panel/translations/es.yaml
@@ -250,6 +250,7 @@ panel.pages.renameFile: Renombrar archivo
 panel.pages.renameFile.name: Nombre
 panel.pages.replaceFile: Reemplazar archivo
 panel.pages.save: Guardar
+panel.pages.saveAndCreateNew: Guardar y crear nueva
 panel.pages.saveOnly: Guardar sin publicar
 panel.pages.toggleChildren: Alternar páginas secundarias
 panel.pages.viewChildren: Ver subpáginas

--- a/panel/translations/fr.yaml
+++ b/panel/translations/fr.yaml
@@ -250,6 +250,7 @@ panel.pages.renameFile: Renommer le fichier
 panel.pages.renameFile.name: Nom
 panel.pages.replaceFile: Remplacer le fichier
 panel.pages.save: Enregistrer
+panel.pages.saveAndCreateNew: Enregistrer et créer une nouvelle
 panel.pages.saveOnly: Enregistrer sans publier
 panel.pages.toggleChildren: Afficher/Masquer les sous-pages
 panel.pages.viewChildren: Voir les sous-pages

--- a/panel/translations/it.yaml
+++ b/panel/translations/it.yaml
@@ -250,6 +250,7 @@ panel.pages.renameFile: Rinomina file
 panel.pages.renameFile.name: Nome
 panel.pages.replaceFile: Sostituisci file
 panel.pages.save: Salva
+panel.pages.saveAndCreateNew: Salva e crea nuova
 panel.pages.saveOnly: Salva senza pubblicare
 panel.pages.toggleChildren: Mostra/nascondi sottopagine
 panel.pages.viewChildren: Visualizza sottopagine

--- a/panel/translations/nl.yaml
+++ b/panel/translations/nl.yaml
@@ -250,6 +250,7 @@ panel.pages.renameFile: Bestand hernoemen
 panel.pages.renameFile.name: Naam
 panel.pages.replaceFile: Bestand vervangen
 panel.pages.save: Opslaan
+panel.pages.saveAndCreateNew: Opslaan en nieuwe maken
 panel.pages.saveOnly: Opslaan zonder publiceren
 panel.pages.toggleChildren: Kindpagina's tonen/verbergen
 panel.pages.viewChildren: Bekijk subpagina's

--- a/panel/translations/pl.yaml
+++ b/panel/translations/pl.yaml
@@ -250,6 +250,7 @@ panel.pages.renameFile: Zmień nazwę pliku
 panel.pages.renameFile.name: Nazwa
 panel.pages.replaceFile: Zamień plik
 panel.pages.save: Zapisz
+panel.pages.saveAndCreateNew: Zapisz i utwórz nową
 panel.pages.saveOnly: Zapisz bez publikowania
 panel.pages.toggleChildren: Przełącz strony podrzędne
 panel.pages.viewChildren: Pokaż podstrony

--- a/panel/translations/pt.yaml
+++ b/panel/translations/pt.yaml
@@ -250,6 +250,7 @@ panel.pages.renameFile: Renomear arquivo
 panel.pages.renameFile.name: Nome
 panel.pages.replaceFile: Substituir ficheiro
 panel.pages.save: Guardar
+panel.pages.saveAndCreateNew: Guardar e criar nova
 panel.pages.saveOnly: Guardar sem publicar
 panel.pages.toggleChildren: Expandir páginas
 panel.pages.viewChildren: Ver subpáginas

--- a/panel/translations/ro.yaml
+++ b/panel/translations/ro.yaml
@@ -250,6 +250,7 @@ panel.pages.renameFile: Redenumește fișier
 panel.pages.renameFile.name: Nume
 panel.pages.replaceFile: Înlocuiește fișier
 panel.pages.save: Salvează
+panel.pages.saveAndCreateNew: Salvează și creează una nouă
 panel.pages.saveOnly: Salvează fără a publica
 panel.pages.toggleChildren: Comută subpagini
 panel.pages.viewChildren: Vezi subpagini

--- a/panel/translations/ru.yaml
+++ b/panel/translations/ru.yaml
@@ -250,6 +250,7 @@ panel.pages.renameFile: Переименовать файл
 panel.pages.renameFile.name: Имя
 panel.pages.replaceFile: Заменить файл
 panel.pages.save: Сохранить
+panel.pages.saveAndCreateNew: Сохранить и создать новую
 panel.pages.saveOnly: Сохранить без публикации
 panel.pages.toggleChildren: Переключить дочерние страницы
 panel.pages.viewChildren: Смотреть вложенные

--- a/panel/translations/uk.yaml
+++ b/panel/translations/uk.yaml
@@ -250,6 +250,7 @@ panel.pages.renameFile: Перейменувати файл
 panel.pages.renameFile.name: Назва
 panel.pages.replaceFile: Замінити файл
 panel.pages.save: Зберегти
+panel.pages.saveAndCreateNew: Зберегти і створити нову
 panel.pages.saveOnly: Зберегти без публікації
 panel.pages.toggleChildren: Перемкнути дочірні сторінки
 panel.pages.viewChildren: Перегляд підсторінок

--- a/panel/views/pages/editor.php
+++ b/panel/views/pages/editor.php
@@ -41,19 +41,22 @@
                     </div>
                 </div>
             <?php endif ?>
-            <?php if ($history?->isJustCreated()): ?>
-                <div class="dropdown mb-0">
-                    <div class="button-group">
+            <div class="dropdown mb-0">
+                <div class="button-group">
+                    <?php if ($history?->isJustCreated()): ?>
                         <button type="submit" class="button button-accent" formaction="?publish=true"><?= $this->icon('check-circle') ?> <?= $this->translate('panel.pages.publish') ?></button>
-                        <button type="button" class="button button-accent dropdown-button caret" data-dropdown="dropdown-save-options"></button>
-                    </div>
-                    <div class="dropdown-menu" id="dropdown-save-options">
-                        <button type="submit" class="dropdown-item" formaction="?publish=false"><?= $this->translate('panel.pages.saveOnly') ?></button>
-                    </div>
+                    <?php else: ?>
+                        <button type="submit" class="button button-accent mb-0"><?= $this->icon('check-circle') ?> <?= $this->translate('panel.pages.save') ?></button>
+                    <?php endif ?>
+                    <button type="button" class="button button-accent dropdown-button caret" data-dropdown="dropdown-save-options"></button>
                 </div>
-            <?php else: ?>
-                <button type="submit" class="button button-accent mb-0"><?= $this->icon('check-circle') ?> <?= $this->translate('panel.pages.save') ?></button>
-            <?php endif ?>
+                <div class="dropdown-menu" id="dropdown-save-options">
+                    <?php if ($history?->isJustCreated()): ?>
+                        <button type="submit" class="dropdown-item" formaction="?publish=false"><?= $this->translate('panel.pages.saveOnly') ?></button>
+                    <?php endif ?>
+                    <button type="submit" class="dropdown-item" formaction="?createNew"><?= $this->translate('panel.pages.saveAndCreateNew') ?></button>
+                </div>
+            </div>
         </div>
     </div>
     <div>


### PR DESCRIPTION
This pull request introduces a new "Save and create new" feature to the page editor, allowing users to quickly save their current page and immediately start creating a new one. It also includes UI and backend changes to support this workflow, along with minor improvements to the modal and translation files.

**New "Save and create new" workflow:**

* Added a "Save and create new" button to the page editor dropdown, enabling users to save the current page and open the new page modal in a single action. [[1]](diffhunk://#diff-d5411ab66671dd391cb06236408764cfa645db5c31a9416794f7d80d4d173c89L44-L56) [[2]](diffhunk://#diff-8879b7b36b8f36138da71764453d893c85d45c294f607d8594649b7e6f72ce13R253)
* Updated backend logic in `PagesController.php` to handle the `createNew` query parameter, open the new page modal automatically when appropriate, and ensure redirects preserve the new workflow. [[1]](diffhunk://#diff-c8b238be663183da229ed13ae8e0602420592d770a9c16e71b8987712713b719R168-R169) [[2]](diffhunk://#diff-c8b238be663183da229ed13ae8e0602420592d770a9c16e71b8987712713b719R213-R227)

**Frontend improvements:**

* Enhanced the pages view script to clean up the `createNew` query parameter from the URL after opening the modal, preventing unwanted repeated modal openings on refresh.

**Localization:**

* Added a new translation string for the "Save and create new" action in the English language file.