### PR TITLE
Add the possibility to set markdown editor placeholder and disabled state

### DIFF
--- a/panel/package.json
+++ b/panel/package.json
@@ -36,6 +36,7 @@
         "@codemirror/commands": "^6.10.0",
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language": "^6.11.3",
+        "@codemirror/state": "^6.5.2",
         "@codemirror/view": "^6.38.7",
         "@lezer/highlight": "^1.2.3",
         "chartist": "^1.5.0",

--- a/panel/pnpm-lock.yaml
+++ b/panel/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@codemirror/language':
         specifier: ^6.11.3
         version: 6.11.3
+      '@codemirror/state':
+        specifier: ^6.5.2
+        version: 6.5.2
       '@codemirror/view':
         specifier: ^6.38.7
         version: 6.38.7

--- a/panel/src/scss/components/forms/_forms-editor.scss
+++ b/panel/src/scss/components/forms/_forms-editor.scss
@@ -2,6 +2,8 @@
 @use "../variables" as *;
 @use "../colors" as *;
 
+/* stylelint-disable selector-class-pattern */
+
 .editor-toolbar {
     position: relative;
     display: flex;
@@ -52,6 +54,10 @@
 
 .toolbar-button.is-active {
     color: var(--color-accent-500);
+
+    &:disabled {
+        color: var(--color-base-500);
+    }
 }
 
 .form-textarea.editor-textarea {
@@ -63,8 +69,6 @@
     }
 }
 
-/* stylelint-disable selector-class-pattern */
-
 .ProseMirror,
 .cm-editor {
     min-height: 6rem;
@@ -73,6 +77,10 @@
     border-radius: var(--border-radius);
     font-family: var(--font-family-sans);
     font-size: var(--font-size-md);
+}
+
+.cm-content .cm-line {
+    padding: 0;
 }
 
 .ProseMirror {
@@ -85,6 +93,23 @@
 
     &:focus {
         outline: none;
+    }
+
+    & .pm-placeholder {
+        color: var(--color-base-300);
+        font-size: var(--font-size-sm);
+        pointer-events: none;
+    }
+}
+
+.editor-textarea:disabled {
+    & + [contenteditable="false"] {
+        background-color: var(--color-base-700);
+        color: var(--color-base-300);
+
+        & > * {
+            opacity: 0.6;
+        }
     }
 }
 

--- a/panel/src/ts/components/inputs/editor/markdown/menu.ts
+++ b/panel/src/ts/components/inputs/editor/markdown/menu.ts
@@ -72,8 +72,9 @@ class MenuView {
     update() {
         this.items.forEach(({ command, dom, mark, dropdown, name, node }) => {
             const state = this.editorView.state;
+            const editable = this.editorView.props.editable ? this.editorView.props.editable(state) : true;
 
-            const applicable = command(state, undefined, this.editorView);
+            const applicable = editable && command(state, undefined, this.editorView);
 
             if (dom instanceof HTMLButtonElement) {
                 dom.disabled = !applicable;
@@ -82,7 +83,9 @@ class MenuView {
 
             if (dropdown && name) {
                 if (!applicable) {
-                    this.dropdowns[dropdown].querySelector(".dropdown-button")!.textContent = name;
+                    const btn = this.dropdowns[dropdown].querySelector(".dropdown-button") as HTMLButtonElement;
+                    btn.textContent = name;
+                    btn.disabled = !editable;
                 }
                 dom.classList.toggle("is-active", !applicable);
             }

--- a/panel/src/ts/components/inputs/editor/markdown/menu.ts
+++ b/panel/src/ts/components/inputs/editor/markdown/menu.ts
@@ -82,10 +82,10 @@ class MenuView {
             }
 
             if (dropdown && name) {
+                const btn = this.dropdowns[dropdown].querySelector(".dropdown-button") as HTMLButtonElement;
+                btn.disabled = !editable;
                 if (!applicable) {
-                    const btn = this.dropdowns[dropdown].querySelector(".dropdown-button") as HTMLButtonElement;
                     btn.textContent = name;
-                    btn.disabled = !editable;
                 }
                 dom.classList.toggle("is-active", !applicable);
             }

--- a/panel/src/ts/components/inputs/editor/markdown/placeholder.ts
+++ b/panel/src/ts/components/inputs/editor/markdown/placeholder.ts
@@ -1,0 +1,22 @@
+import { Decoration, DecorationSet } from "prosemirror-view";
+import { EditorState, Plugin } from "prosemirror-state";
+
+export function placeholderPlugin(text: string) {
+    return new Plugin({
+        props: {
+            decorations(state: EditorState) {
+                const isEmpty = state.doc.childCount === 1 && state.doc?.firstChild?.isTextblock && state.doc?.firstChild.content.size === 0;
+
+                if (!isEmpty) {
+                    return null;
+                }
+
+                const placeholder = document.createElement("span");
+                placeholder.className = "pm-placeholder";
+                placeholder.textContent = text;
+
+                return DecorationSet.create(state.doc, [Decoration.widget(1, placeholder, { side: 1 })]);
+            },
+        },
+    });
+}

--- a/panel/src/ts/components/inputs/editor/markdown/placeholder.ts
+++ b/panel/src/ts/components/inputs/editor/markdown/placeholder.ts
@@ -2,6 +2,10 @@ import { Decoration, DecorationSet } from "prosemirror-view";
 import { EditorState, Plugin } from "prosemirror-state";
 
 export function placeholderPlugin(text: string) {
+    if (!text) {
+        return new Plugin({});
+    }
+
     return new Plugin({
         props: {
             decorations(state: EditorState) {


### PR DESCRIPTION
This pull request enhances the editor input components in the panel by improving support for disabled and read-only states, adding placeholder functionality, and refining styling for better accessibility and user experience. The changes span TypeScript, SCSS, and dependency updates, focusing on making both Markdown and CodeMirror editors more robust and user-friendly.

**Editor functionality and accessibility improvements:**

* Both the Markdown and CodeMirror editors now properly support `disabled` and `readOnly` states, ensuring the editors become non-editable and update their UI accordingly. The toolbar toggle button and menu items also reflect the disabled state. (`panel/src/ts/components/inputs/editor-input.ts` [[1]](diffhunk://#diff-3b5edff579247093543f5b95a2ed0b849ce7707380efdbd15bb43729c217cbd4R83) [[2]](diffhunk://#diff-3b5edff579247093543f5b95a2ed0b849ce7707380efdbd15bb43729c217cbd4R129-R133) [[3]](diffhunk://#diff-3b5edff579247093543f5b95a2ed0b849ce7707380efdbd15bb43729c217cbd4L138-R146) [[4]](diffhunk://#diff-3b5edff579247093543f5b95a2ed0b849ce7707380efdbd15bb43729c217cbd4R162-R172); `panel/src/ts/components/inputs/editor/code/view.ts` [[5]](diffhunk://#diff-f3ab453027412500c8a41e07cd5c58af93813f5cba3766f2ffb74422ea7b6fc2R48-R53) [[6]](diffhunk://#diff-f3ab453027412500c8a41e07cd5c58af93813f5cba3766f2ffb74422ea7b6fc2R74-R75) [[7]](diffhunk://#diff-f3ab453027412500c8a41e07cd5c58af93813f5cba3766f2ffb74422ea7b6fc2R91-R100); `panel/src/ts/components/inputs/editor/markdown/menu.ts` [[8]](diffhunk://#diff-3e03a27d32ad0ea8cf3f258b50ad99b00b4f8a2532caecf9b15b1e94524a55ecR75-R77) [[9]](diffhunk://#diff-3e03a27d32ad0ea8cf3f258b50ad99b00b4f8a2532caecf9b15b1e94524a55ecL85-R88); `panel/src/ts/components/inputs/editor/markdown/view.ts` [[10]](diffhunk://#diff-a3ffe786a04723d37e5b1520461b722da572d5ceba38f601c05b67bc1d6083b2R12-R23) [[11]](diffhunk://#diff-a3ffe786a04723d37e5b1520461b722da572d5ceba38f601c05b67bc1d6083b2L37-R46) [[12]](diffhunk://#diff-a3ffe786a04723d37e5b1520461b722da572d5ceba38f601c05b67bc1d6083b2R69-R76)

* Placeholders are now supported in both Markdown and CodeMirror editors, improving usability when the input is empty. For Markdown, a custom ProseMirror plugin displays the placeholder. (`panel/src/ts/components/inputs/editor-input.ts` [[1]](diffhunk://#diff-3b5edff579247093543f5b95a2ed0b849ce7707380efdbd15bb43729c217cbd4R129-R133) [[2]](diffhunk://#diff-3b5edff579247093543f5b95a2ed0b849ce7707380efdbd15bb43729c217cbd4L138-R146); `panel/src/ts/components/inputs/editor/code/view.ts` [[3]](diffhunk://#diff-f3ab453027412500c8a41e07cd5c58af93813f5cba3766f2ffb74422ea7b6fc2L2-R13) [[4]](diffhunk://#diff-f3ab453027412500c8a41e07cd5c58af93813f5cba3766f2ffb74422ea7b6fc2R74-R75); `panel/src/ts/components/inputs/editor/markdown/placeholder.ts` [[5]](diffhunk://#diff-fc9e40b0b5402a1c3a0edad61b1fc9058724ac7810787e553aa93ce2b261156cR1-R22); `panel/src/ts/components/inputs/editor/markdown/view.ts` [[6]](diffhunk://#diff-a3ffe786a04723d37e5b1520461b722da572d5ceba38f601c05b67bc1d6083b2R12-R23) [[7]](diffhunk://#diff-a3ffe786a04723d37e5b1520461b722da572d5ceba38f601c05b67bc1d6083b2R33)

**Styling and user interface:**

* SCSS styles have been updated to visually indicate disabled states for both the editor and toolbar buttons, and to improve placeholder appearance and line padding in the editors. (`panel/src/scss/components/forms/_forms-editor.scss` [[1]](diffhunk://#diff-f0db377c96e39001834cecd18d0c474ef02389bcbfee070ad29ce019783e990bR5-R6) [[2]](diffhunk://#diff-f0db377c96e39001834cecd18d0c474ef02389bcbfee070ad29ce019783e990bR57-R60) [[3]](diffhunk://#diff-f0db377c96e39001834cecd18d0c474ef02389bcbfee070ad29ce019783e990bR82-R85) [[4]](diffhunk://#diff-f0db377c96e39001834cecd18d0c474ef02389bcbfee070ad29ce019783e990bR97-R113)

**Code quality and maintainability:**

* Refactored the initialization and state handling of editor containers and options for clarity and robustness, including safer parent node checks and consistent option passing. (`panel/src/ts/components/inputs/editor-input.ts` [panel/src/ts/components/inputs/editor-input.tsL68-R68](diffhunk://#diff-3b5edff579247093543f5b95a2ed0b849ce7707380efdbd15bb43729c217cbd4L68-R68))

**Dependencies:**

* Added `@codemirror/state` as a dependency to support the new editor features. (`panel/package.json` [[1]](diffhunk://#diff-ef4bb18954e89ffd248349033d127f4477fe4df8294af123a36760d4964316aaR39) `panel/pnpm-lock.yaml` [[2]](diffhunk://#diff-caf04650733f3ed8ecfb0a7ce323d40601513df79d3e601e6eb256229e54d0e6R20-R22)