### PR TITLE
Normalize data structure by removing dots when merging defaults and frontmatter

### DIFF
--- a/formwork/src/Pages/ContentFile.php
+++ b/formwork/src/Pages/ContentFile.php
@@ -4,6 +4,7 @@ namespace Formwork\Pages;
 
 use Formwork\Files\File;
 use Formwork\Parsers\Yaml;
+use Formwork\Utils\Arr;
 use Formwork\Utils\FileSystem;
 use UnexpectedValueException;
 
@@ -67,7 +68,7 @@ class ContentFile extends File
 
         [, $frontmatter, $content] = $matches;
 
-        $this->frontmatter = Yaml::parse($frontmatter);
+        $this->frontmatter = Arr::undot(Yaml::parse($frontmatter));
 
         $this->content = str_replace("\r\n", "\n", $content);
     }

--- a/formwork/src/Pages/Page.php
+++ b/formwork/src/Pages/Page.php
@@ -175,11 +175,11 @@ class Page extends Model implements Stringable
         $this->loadFiles();
 
         if ($this->contentFile instanceof ContentFile && !$this->contentFile->isEmpty()) {
-            $this->data = [
-                ...$this->data,
-                ...$this->contentFile->frontmatter(),
-                'content' => $this->contentFile->content(),
-            ];
+            $this->data = array_replace_recursive(
+                $this->data,
+                $this->contentFile->frontmatter(),
+                ['content' => $this->contentFile->content()],
+            );
         }
 
         $this->fields->setValues([...$this->data, 'slug' => $this->slug, 'parent' => $this->parent()?->route(), 'template' => $this->template]);
@@ -249,7 +249,7 @@ class Page extends Model implements Stringable
             $defaults['allowChildren'] = false;
         }
 
-        return $defaults;
+        return Arr::undot($defaults);
     }
 
     /**
@@ -1009,7 +1009,7 @@ class Page extends Model implements Stringable
 
         $this->files ??= (new FileCollection($files))->sort();
 
-        $this->data = [...$this->defaults(), ...$this->data];
+        $this->data = array_replace_recursive($this->defaults(), $this->data);
     }
 
     /**


### PR DESCRIPTION
This pull request introduces improvements to how nested data structures are handled in page content and configuration files by ensuring that "dotted" keys are properly expanded into nested arrays. The changes primarily focus on using the `Arr::undot()` utility to convert flattened arrays into nested ones, which helps maintain correct data structure throughout the application. Additionally, the logic for merging data arrays has been updated to use `array_replace_recursive` for more robust handling of nested values.

**Improvements to nested data handling:**

* [`formwork/src/Pages/ContentFile.php`](diffhunk://#diff-69957f12f8684b073b9f0d2d22b3f8416336aeebe13214d4a3db5cd52bea4f1dR7): Now uses `Arr::undot()` to convert dotted keys in frontmatter to nested arrays when loading content files, ensuring correct data structure. [[1]](diffhunk://#diff-69957f12f8684b073b9f0d2d22b3f8416336aeebe13214d4a3db5cd52bea4f1dR7) [[2]](diffhunk://#diff-69957f12f8684b073b9f0d2d22b3f8416336aeebe13214d4a3db5cd52bea4f1dL70-R71)
* [`formwork/src/Pages/Page.php`](diffhunk://#diff-41cde3f613679dfb74ed037d6b61206fb870d9a5118bf4810073330493ec2b70L252-R252): Returns undotted (nested) defaults in the `defaults()` method by applying `Arr::undot()`.

**Enhancements to array merging logic:**

* [`formwork/src/Pages/Page.php`](diffhunk://#diff-41cde3f613679dfb74ed037d6b61206fb870d9a5118bf4810073330493ec2b70L178-R182): Uses `array_replace_recursive` instead of array spread for merging defaults and content file frontmatter into the page data, which improves handling of nested arrays and prevents overwriting nested values. [[1]](diffhunk://#diff-41cde3f613679dfb74ed037d6b61206fb870d9a5118bf4810073330493ec2b70L178-R182) [[2]](diffhunk://#diff-41cde3f613679dfb74ed037d6b61206fb870d9a5118bf4810073330493ec2b70L1012-R1012)