### PR TITLE
Remove propagation of site description metadata to all pages

### DIFF
--- a/formwork/src/Cms/Site.php
+++ b/formwork/src/Cms/Site.php
@@ -253,17 +253,11 @@ class Site extends Model implements Stringable
         }
 
         $defaults = [
-            'charset'     => $this->config->get('system.charset'),
-            'author'      => $this->get('author'),
-            'description' => $this->get('description'),
-            'generator'   => 'Formwork',
+            'charset'   => $this->config->get('system.charset'),
+            'generator' => $this->config->get('system.metadata.setGenerator') ? 'Formwork' : null,
         ];
 
         $data = array_filter([...$defaults, ...$this->data['metadata']]);
-
-        if (!$this->config->get('system.metadata.setGenerator')) {
-            unset($data['generator']);
-        }
 
         return $this->metadata = new MetadataCollection($data);
     }

--- a/formwork/src/Pages/Page.php
+++ b/formwork/src/Pages/Page.php
@@ -137,7 +137,6 @@ class Page extends Model implements Stringable
     /**
      * Page metadata
      */
-    #[ReadonlyModelProperty]
     protected MetadataCollection $metadata;
 
     /**


### PR DESCRIPTION
This pull request removes the propagation of site description field as a `<meta name="description">` to all pages, with the unintended result of potentially compromising search engine results with an identical description for each indexed page.

The pull request also removes the propagation of site author field if present, which would result in the propagation of an author metadata identical for all pages.

The benefit of this change is higher than the risk of changing the previous behavior.

Metadata handling improvements:

* The `generator` metadata field in `Site.php` is now conditionally set based on the `system.metadata.setGenerator` configuration value directly when building the defaults, eliminating redundant logic and making the code more concise.

Codebase cleanup:

* The `ReadonlyModelProperty` attribute was removed from the `metadata` property in the `Page` class, possibly to allow for future modifications or to align with updated property handling conventions.