### PR TITLE
Add the possibility to specify layout section order

### DIFF
--- a/formwork/src/Fields/Layout/Layout.php
+++ b/formwork/src/Fields/Layout/Layout.php
@@ -19,10 +19,9 @@ class Layout
     /**
      * @param array<string, mixed> $data
      */
-    public function __construct(array $data, Translation $translation)
+    public function __construct(protected array $data, protected Translation $translation)
     {
         $this->type = $data['type'];
-        $this->sections = new SectionCollection($data['sections'] ?? [], $translation);
     }
 
     /** Get layout type
@@ -38,6 +37,10 @@ class Layout
      */
     public function sections(): SectionCollection
     {
-        return $this->sections;
+        return $this->sections ??= (new SectionCollection(
+            $this->data['sections'] ?? [],
+            $this->translation,
+        ))
+            ->sort(sortBy: fn(Section $a, Section $b): int => $a->order() <=> $b->order());
     }
 }

--- a/formwork/src/Fields/Layout/Section.php
+++ b/formwork/src/Fields/Layout/Section.php
@@ -44,6 +44,6 @@ class Section implements Arrayable
      */
     public function order(): int
     {
-        return (int) $this->get('order', PHP_INT_MAX);
+        return (int) ($this->get('order') ?? PHP_INT_MAX);
     }
 }

--- a/formwork/src/Fields/Layout/Section.php
+++ b/formwork/src/Fields/Layout/Section.php
@@ -2,13 +2,16 @@
 
 namespace Formwork\Fields\Layout;
 
+use Formwork\Data\Contracts\Arrayable;
+use Formwork\Data\Traits\DataArrayable;
 use Formwork\Data\Traits\DataGetter;
 use Formwork\Translations\Translation;
 use Formwork\Utils\Str;
 
-class Section
+class Section implements Arrayable
 {
     use DataGetter;
+    use DataArrayable;
 
     /**
      * @param array<string, mixed> $data
@@ -34,5 +37,13 @@ class Section
     public function label(): string
     {
         return Str::interpolate($this->get('label', ''), fn($key) => $this->translation->translate($key));
+    }
+
+    /**
+     * Get section order
+     */
+    public function order(): int
+    {
+        return (int) $this->get('order', PHP_INT_MAX);
     }
 }


### PR DESCRIPTION
This pull request introduces improvements to the `Layout` and `Section` classes within the layout fields system. The main focus is on optimizing how sections are handled, specifically by enabling dynamic sorting and enhancing data interoperability.

**Enhancements to section handling and layout construction:**

* The `Layout` class now lazily initializes its `sections` property and ensures sections are always sorted by their `order` value, improving both performance and consistency when accessing sections. [[1]](diffhunk://#diff-cc96e9fca1c6c2cf8848425a0713548279c331ad10ac1babf8ffd00b827cfe3eL22-L25) [[2]](diffhunk://#diff-cc96e9fca1c6c2cf8848425a0713548279c331ad10ac1babf8ffd00b827cfe3eL41-R44)
* The `Section` class now implements the `Arrayable` interface and uses the `DataArrayable` trait, making it easier to convert section data to arrays for serialization or further processing.
* A new `order()` method was added to the `Section` class, which retrieves the section's order for sorting, defaulting to `PHP_INT_MAX` if not set. This supports the new sorting logic in `Layout`.