### PR TITLE
Add the possibility to define field layout tabs

### DIFF
--- a/formwork/src/Fields/Field.php
+++ b/formwork/src/Fields/Field.php
@@ -10,9 +10,8 @@ use Formwork\Data\Traits\DataMultipleSetter;
 use Formwork\Exceptions\RecursionException;
 use Formwork\Fields\Dynamic\DynamicFieldValue;
 use Formwork\Fields\Exceptions\ValidationException;
+use Formwork\Fields\Translations\Translations;
 use Formwork\Traits\Methods;
-use Formwork\Translations\Translation;
-use Formwork\Utils\Arr;
 use Formwork\Utils\Constraint;
 use Formwork\Utils\Str;
 use Stringable;
@@ -29,6 +28,7 @@ class Field implements Arrayable, Stringable
         remove as protected baseRemove;
     }
     use Methods;
+    use Translations;
 
     /**
      * Keys that should not be translated
@@ -46,8 +46,6 @@ class Field implements Arrayable, Stringable
      * Whether the field is being validated
      */
     protected bool $validating = false;
-
-    protected Translation $translation;
 
     /**
      * @param string               $name                  Field name
@@ -317,14 +315,6 @@ class Field implements Arrayable, Stringable
     }
 
     /**
-     * Set field translation
-     */
-    public function setTranslation(Translation $translation): void
-    {
-        $this->translation = $translation;
-    }
-
-    /**
      * Return whether a field key is translatable
      */
     protected function isTranslatable(string $key): bool
@@ -340,34 +330,6 @@ class Field implements Arrayable, Stringable
         }
 
         return $translatable;
-    }
-
-    /**
-     * Translate field value
-     */
-    protected function translate(mixed $value): mixed
-    {
-        if (!isset($this->translation)) {
-            return $value;
-        }
-
-        $language = $this->translation->code();
-
-        if (is_array($value)) {
-            if (isset($value[$language])) {
-                $value = $value[$language];
-            }
-        } elseif (!is_string($value)) {
-            return $value;
-        }
-
-        $interpolate = fn($value) => is_string($value) ? Str::interpolate($value, fn($key) => $this->translation->translate($key)) : $value;
-
-        if (is_array($value)) {
-            return Arr::map($value, $interpolate);
-        }
-
-        return $interpolate($value);
     }
 
     /**

--- a/formwork/src/Fields/Layout/Layout.php
+++ b/formwork/src/Fields/Layout/Layout.php
@@ -16,6 +16,9 @@ class Layout
      */
     protected SectionCollection $sections;
 
+    /**
+     * Layout tabs collection
+     */
     protected TabCollection $tabs;
 
     /**
@@ -38,11 +41,9 @@ class Layout
      */
     public function sections(): SectionCollection
     {
-        return $this->sections ??= (new SectionCollection(
-            $this->data['sections'] ?? [],
-            $this->translation,
-        ))
-            ->sort(sortBy: fn(Section $a, Section $b): int => $a->order() <=> $b->order());
+        return $this->sections ??= (new SectionCollection($this->data['sections'] ?? []))
+            ->each(fn(Section $section) => $section->setTranslation($this->translation))
+            ->sortBy('order');
     }
 
     /**
@@ -50,7 +51,8 @@ class Layout
      */
     public function tabs(): TabCollection
     {
-        return $this->tabs ??= (new TabCollection($this->data['tabs'] ?? [], $this->translation))
-            ->sort(sortBy: fn(Tab $a, Tab $b): int => $a->order() <=> $b->order());
+        return $this->tabs ??= (new TabCollection($this->data['tabs'] ?? []))
+            ->each(fn(Tab $tab) => $tab->setTranslation($this->translation))
+            ->sortBy('order');
     }
 }

--- a/formwork/src/Fields/Layout/Layout.php
+++ b/formwork/src/Fields/Layout/Layout.php
@@ -9,23 +9,24 @@ class Layout
     /**
      * Layout type
      */
-    protected string $type;
+    protected string $type = 'sections';
 
     /**
      * Layout sections collection
      */
     protected SectionCollection $sections;
 
+    protected TabCollection $tabs;
+
     /**
      * @param array<string, mixed> $data
      */
-    public function __construct(protected array $data, protected Translation $translation)
-    {
-        $this->type = $data['type'];
-    }
+    public function __construct(protected array $data, protected Translation $translation) {}
 
-    /** Get layout type
+    /**
+     * Get layout type
      *
+     * @deprecated Type property is no longer used and will be removed in Formwork 3.0
      */
     public function type(): string
     {
@@ -42,5 +43,14 @@ class Layout
             $this->translation,
         ))
             ->sort(sortBy: fn(Section $a, Section $b): int => $a->order() <=> $b->order());
+    }
+
+    /**
+     * Get layout tabs
+     */
+    public function tabs(): TabCollection
+    {
+        return $this->tabs ??= (new TabCollection($this->data['tabs'] ?? [], $this->translation))
+            ->sort(sortBy: fn(Tab $a, Tab $b): int => $a->order() <=> $b->order());
     }
 }

--- a/formwork/src/Fields/Layout/Section.php
+++ b/formwork/src/Fields/Layout/Section.php
@@ -41,9 +41,9 @@ class Section implements Arrayable
     /**
      * Get field label
      */
-    public function label(): string
+    public function label(): ?string
     {
-        return $this->translate($this->get('label'));
+        return $this->translate($this->get('label', $this->name()));
     }
 
     /**

--- a/formwork/src/Fields/Layout/Section.php
+++ b/formwork/src/Fields/Layout/Section.php
@@ -5,31 +5,29 @@ namespace Formwork\Fields\Layout;
 use Formwork\Data\Contracts\Arrayable;
 use Formwork\Data\Traits\DataArrayable;
 use Formwork\Data\Traits\DataGetter;
-use Formwork\Translations\Translation;
-use Formwork\Utils\Str;
+use Formwork\Fields\Translations\Translations;
 
 class Section implements Arrayable
 {
     use DataGetter;
     use DataArrayable;
+    use Translations;
 
     /**
      * @param array<string, mixed> $data
      */
     public function __construct(
-        protected string $name,
         array $data,
-        protected Translation $translation,
     ) {
-        $this->data = $data;
+        $this->data = ['order' => PHP_INT_MAX, ...$data];
     }
 
     /**
      * Get section name
      */
-    public function name(): string
+    public function name(): ?string
     {
-        return $this->name;
+        return $this->get('name');
     }
 
     /**
@@ -41,11 +39,11 @@ class Section implements Arrayable
     }
 
     /**
-     * Get section label
+     * Get field label
      */
     public function label(): string
     {
-        return Str::interpolate($this->get('label', ''), fn($key) => $this->translation->translate($key));
+        return $this->translate($this->get('label'));
     }
 
     /**
@@ -53,6 +51,6 @@ class Section implements Arrayable
      */
     public function order(): int
     {
-        return (int) ($this->get('order') ?? PHP_INT_MAX);
+        return $this->get('order');
     }
 }

--- a/formwork/src/Fields/Layout/SectionCollection.php
+++ b/formwork/src/Fields/Layout/SectionCollection.php
@@ -3,7 +3,6 @@
 namespace Formwork\Fields\Layout;
 
 use Formwork\Data\AbstractCollection;
-use Formwork\Translations\Translation;
 use Formwork\Utils\Arr;
 
 class SectionCollection extends AbstractCollection
@@ -15,8 +14,8 @@ class SectionCollection extends AbstractCollection
     /**
      * @param array<string, array<string, mixed>> $sections
      */
-    public function __construct(array $sections, Translation $translation)
+    public function __construct(array $sections)
     {
-        parent::__construct(Arr::map($sections, fn(array $section, string $name) => new Section($name, $section, $translation)));
+        parent::__construct(Arr::map($sections, fn(array $section, string $name) => new Section(['name' => $name, ...$section])));
     }
 }

--- a/formwork/src/Fields/Layout/SectionCollection.php
+++ b/formwork/src/Fields/Layout/SectionCollection.php
@@ -17,6 +17,6 @@ class SectionCollection extends AbstractCollection
      */
     public function __construct(array $sections, Translation $translation)
     {
-        parent::__construct(Arr::map($sections, fn($section) => new Section($section, $translation)));
+        parent::__construct(Arr::map($sections, fn(array $section, string $name) => new Section($name, $section, $translation)));
     }
 }

--- a/formwork/src/Fields/Layout/Tab.php
+++ b/formwork/src/Fields/Layout/Tab.php
@@ -8,7 +8,7 @@ use Formwork\Data\Traits\DataGetter;
 use Formwork\Translations\Translation;
 use Formwork\Utils\Str;
 
-class Section implements Arrayable
+class Tab implements Arrayable
 {
     use DataGetter;
     use DataArrayable;
@@ -25,7 +25,7 @@ class Section implements Arrayable
     }
 
     /**
-     * Get section name
+     * Get tab name
      */
     public function name(): string
     {
@@ -41,7 +41,7 @@ class Section implements Arrayable
     }
 
     /**
-     * Get section label
+     * Get tab label
      */
     public function label(): string
     {

--- a/formwork/src/Fields/Layout/Tab.php
+++ b/formwork/src/Fields/Layout/Tab.php
@@ -5,31 +5,29 @@ namespace Formwork\Fields\Layout;
 use Formwork\Data\Contracts\Arrayable;
 use Formwork\Data\Traits\DataArrayable;
 use Formwork\Data\Traits\DataGetter;
-use Formwork\Translations\Translation;
-use Formwork\Utils\Str;
+use Formwork\Fields\Translations\Translations;
 
 class Tab implements Arrayable
 {
     use DataGetter;
     use DataArrayable;
+    use Translations;
 
     /**
      * @param array<string, mixed> $data
      */
     public function __construct(
-        protected string $name,
-        array $data,
-        protected Translation $translation,
+        array $data
     ) {
-        $this->data = $data;
+        $this->data = ['order' => PHP_INT_MAX, ...$data];
     }
 
     /**
      * Get tab name
      */
-    public function name(): string
+    public function name(): ?string
     {
-        return $this->name;
+        return $this->get('name');
     }
 
     /**
@@ -45,14 +43,14 @@ class Tab implements Arrayable
      */
     public function label(): string
     {
-        return Str::interpolate($this->get('label', ''), fn($key) => $this->translation->translate($key));
+        return $this->translate($this->get('label'));
     }
 
     /**
-     * Get section order
+     * Get tab order
      */
     public function order(): int
     {
-        return (int) ($this->get('order') ?? PHP_INT_MAX);
+        return $this->get('order');
     }
 }

--- a/formwork/src/Fields/Layout/Tab.php
+++ b/formwork/src/Fields/Layout/Tab.php
@@ -41,9 +41,9 @@ class Tab implements Arrayable
     /**
      * Get tab label
      */
-    public function label(): string
+    public function label(): ?string
     {
-        return $this->translate($this->get('label'));
+        return $this->translate($this->get('label', $this->name()));
     }
 
     /**

--- a/formwork/src/Fields/Layout/TabCollection.php
+++ b/formwork/src/Fields/Layout/TabCollection.php
@@ -3,7 +3,6 @@
 namespace Formwork\Fields\Layout;
 
 use Formwork\Data\AbstractCollection;
-use Formwork\Translations\Translation;
 use Formwork\Utils\Arr;
 
 class TabCollection extends AbstractCollection
@@ -15,8 +14,8 @@ class TabCollection extends AbstractCollection
     /**
      * @param array<string, array<string, mixed>> $tabs
      */
-    public function __construct(array $tabs, Translation $translation)
+    public function __construct(array $tabs)
     {
-        parent::__construct(Arr::map($tabs, fn(array $tab, string $name) => new Tab($name, $tab, $translation)));
+        parent::__construct(Arr::map($tabs, fn(array $tab, string $name) => new Tab(['name' => $name, ...$tab])));
     }
 }

--- a/formwork/src/Fields/Layout/TabCollection.php
+++ b/formwork/src/Fields/Layout/TabCollection.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Formwork\Fields\Layout;
+
+use Formwork\Data\AbstractCollection;
+use Formwork\Translations\Translation;
+use Formwork\Utils\Arr;
+
+class TabCollection extends AbstractCollection
+{
+    protected bool $associative = true;
+
+    protected ?string $dataType = Tab::class;
+
+    /**
+     * @param array<string, array<string, mixed>> $tabs
+     */
+    public function __construct(array $tabs, Translation $translation)
+    {
+        parent::__construct(Arr::map($tabs, fn(array $tab, string $name) => new Tab($name, $tab, $translation)));
+    }
+}

--- a/formwork/src/Fields/Translations/Translations.php
+++ b/formwork/src/Fields/Translations/Translations.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Formwork\Fields\Translations;
+
+use Formwork\Translations\Translation;
+use Formwork\Utils\Arr;
+use Formwork\Utils\Str;
+
+trait Translations
+{
+    protected Translation $translation;
+
+    /**
+     * Set translation
+     */
+    public function setTranslation(Translation $translation): void
+    {
+        $this->translation = $translation;
+    }
+
+    /**
+     * Translate value
+     */
+    protected function translate(mixed $value): mixed
+    {
+        if (!isset($this->translation)) {
+            return $value;
+        }
+
+        $language = $this->translation->code();
+
+        if (is_array($value)) {
+            if (isset($value[$language])) {
+                $value = $value[$language];
+            }
+        } elseif (!is_string($value)) {
+            return $value;
+        }
+
+        $interpolate = fn($value) => is_string($value) ? Str::interpolate($value, fn($key) => $this->translation->translate($key)) : $value;
+
+        if (is_array($value)) {
+            return Arr::map($value, $interpolate);
+        }
+
+        return $interpolate($value);
+    }
+}

--- a/formwork/translations/de.yaml
+++ b/formwork/translations/de.yaml
@@ -52,6 +52,7 @@ page.routable: Routbar
 page.routable.description: Routbare Seiten sind über ihre Adresse zugänglich
 page.slug: Slug
 page.slug.suggestion: Nur Buchstaben, Zahlen und Bindestriche
+page.status: Status
 page.status.notPublished: Nicht veröffentlicht
 page.status.published: Veröffentlicht
 page.status.published.description: Veröffentliche Seiten sind auf der Website sichtbar und über ihre Adresse zugänglich

--- a/formwork/translations/en.yaml
+++ b/formwork/translations/en.yaml
@@ -61,6 +61,7 @@ page.template: Template
 page.text: Text
 page.title: Title
 page.unpublishDate: Unpublish date
+page.status: Status
 site.advanced: Advanced options
 site.advanced.aliases: Aliases
 site.advanced.aliases.alias: Alias

--- a/formwork/translations/es.yaml
+++ b/formwork/translations/es.yaml
@@ -52,6 +52,7 @@ page.routable: Enrutable
 page.routable.description: Las páginas enrutables son accesibles desde su dirección
 page.slug: Slug
 page.slug.suggestion: solo letras, números y guiones
+page.status: Estado
 page.status.notPublished: No publicado
 page.status.published: Publicado
 page.status.published.description: Las páginas publicadas son visibles en el sitio y accesibles desde su dirección

--- a/formwork/translations/fr.yaml
+++ b/formwork/translations/fr.yaml
@@ -52,6 +52,7 @@ page.routable: Accessible
 page.routable.description: Les pages routables sont accessibles depuis leur adresse
 page.slug: Slug
 page.slug.suggestion: lettres, chiffres et tirets seulement
+page.status: Statut
 page.status.notPublished: Brouillon
 page.status.published: Publié
 page.status.published.description: Les pages publiées sont visibles sur le site et accessibles depuis leur adresse

--- a/formwork/translations/it.yaml
+++ b/formwork/translations/it.yaml
@@ -52,6 +52,7 @@ page.routable: Raggiungibile
 page.routable.description: Le pagine raggiungibili sono accessibili dal loro indirizzo
 page.slug: Slug
 page.slug.suggestion: solo lettere, numeri e trattini
+page.status: Stato
 page.status.notPublished: Non pubblicato
 page.status.published: Pubblicato
 page.status.published.description: Le pagine pubblicate sono visibili sul sito e accessibili dal loro indirizzo

--- a/formwork/translations/nl.yaml
+++ b/formwork/translations/nl.yaml
@@ -52,6 +52,7 @@ page.routable: Routbaar
 page.routable.description: Routbare pagina’s zijn bereikbaar via hun adres
 page.slug: Slug
 page.slug.suggestion: alleen letters, cijfers en streepjes
+page.status: Status
 page.status.notPublished: Niet gepubliceerd
 page.status.published: Gepubliceerd
 page.status.published.description: Gepubliceerde pagina’s zijn zichtbaar op de site en bereikbaar via hun adres

--- a/formwork/translations/pl.yaml
+++ b/formwork/translations/pl.yaml
@@ -52,6 +52,7 @@ page.routable: Dostępna
 page.routable.description: Strony dostępne pod adresem URL
 page.slug: Slug
 page.slug.suggestion: tylko litery, cyfry i myślniki
+page.status: Status
 page.status.notPublished: Nieopublikowana
 page.status.published: Opublikowana
 page.status.published.description: Opublikowane strony są widoczne na stronie i dostępne pod adresem

--- a/formwork/translations/pt.yaml
+++ b/formwork/translations/pt.yaml
@@ -52,6 +52,7 @@ page.routable: Roteável
 page.routable.description: As páginas roteáveis são acessíveis a partir do seu endereço
 page.slug: Slug
 page.slug.suggestion: letras, números e hifens apenas
+page.status: Estado
 page.status.notPublished: Não publicado
 page.status.published: Publicado
 page.status.published.description: As páginas publicadas são visíveis no site e acessíveis a partir do seu endereço

--- a/formwork/translations/ro.yaml
+++ b/formwork/translations/ro.yaml
@@ -52,6 +52,7 @@ page.routable: Rutabilă
 page.routable.description: Paginile rutabile sunt accesibile de la adresa lor
 page.slug: Slug
 page.slug.suggestion: doar litere, cifre și cratime
+page.status: Stare
 page.status.notPublished: Nepublicată
 page.status.published: Publicată
 page.status.published.description: Paginile publicate sunt vizibile pe site și accesibile de la adresa lor

--- a/formwork/translations/ru.yaml
+++ b/formwork/translations/ru.yaml
@@ -52,6 +52,7 @@ page.routable: Маршрутизируемый
 page.routable.description: Маршрутизируемые страницы доступны по их адресу
 page.slug: Slug
 page.slug.suggestion: буквы, цифры и дефис только
+page.status: Статус
 page.status.notPublished: Не Опубликовано
 page.status.published: Опубликованный
 page.status.published.description: Опубликованные страницы видны на сайте и доступны по их адресу

--- a/formwork/translations/uk.yaml
+++ b/formwork/translations/uk.yaml
@@ -52,6 +52,7 @@ page.routable: Маршрутизовано
 page.routable.description: Маршрутизовані сторінки доступні за їх адресою
 page.slug: Слаг
 page.slug.suggestion: лише літери, цифри та дефіси
+page.status: Статус
 page.status.notPublished: Не опубліковано
 page.status.published: Опубліковано
 page.status.published.description: Опубліковані сторінки видимі на сайті та доступні за їх адресою

--- a/panel/src/scss/components/_tabs.scss
+++ b/panel/src/scss/components/_tabs.scss
@@ -15,17 +15,42 @@
 .tabs-tab {
     display: inline-block;
     padding: 0.5rem 1.25rem;
+    border: 0;
+    border-radius: var(--border-radius) var(--border-radius) 0 0;
+    margin: var(--focusring-width) var(--focusring-width) 0;
     color: var(--color-base-100);
     cursor: pointer;
+    font: inherit;
+    line-height: inherit;
 
     &:hover {
         color: var(--color-base-100);
+    }
+
+    &:active {
+        outline: none;
+    }
+
+    &:focus {
+        outline: none;
+    }
+
+    &:focus-visible {
+        @include focusring;
     }
 }
 
 .tabs-tab.active {
     border-bottom: 3px solid var(--color-accent-500);
     font-weight: 600;
+}
+
+.tabs-panel {
+    display: none;
+}
+
+.tabs-panel.visible {
+    display: block;
 }
 
 .caption + .tabs {

--- a/panel/src/scss/components/_tabs.scss
+++ b/panel/src/scss/components/_tabs.scss
@@ -27,10 +27,6 @@
         color: var(--color-base-100);
     }
 
-    &:active {
-        outline: none;
-    }
-
     &:focus {
         outline: none;
     }

--- a/panel/src/ts/app.ts
+++ b/panel/src/ts/app.ts
@@ -6,6 +6,7 @@ import { Modals } from "./components/modals";
 import { Navigation } from "./components/navigation";
 import { Notifications } from "./components/notifications";
 import { Sections } from "./components/sections";
+import { Tabs } from "./components/tabs";
 import { Tooltips } from "./components/tooltips";
 
 import { Backups } from "./components/views/backups";
@@ -58,6 +59,7 @@ class App {
             globalAlias: "forms",
         });
 
+        this.loadComponent(Tabs);
         this.loadComponent(Dropdowns);
         this.loadComponent(Tooltips);
         this.loadComponent(Navigation);

--- a/panel/src/ts/components/tabs.ts
+++ b/panel/src/ts/components/tabs.ts
@@ -1,0 +1,27 @@
+import { $, $$ } from "../utils/selectors";
+
+export class Tabs {
+    constructor() {
+        $$(".tabs").forEach((tabs) => {
+            const tabButtons = $$(".tabs-tab", tabs);
+            const tabPanels: HTMLElement[] = [];
+
+            tabButtons.forEach((tabButton) => {
+                const targetPanel = $(`.tabs-panel[data-tab="${tabButton.dataset.tab}"]`);
+
+                if (targetPanel) {
+                    tabPanels.push(targetPanel);
+                }
+
+                tabButton.addEventListener("click", () => {
+                    tabButtons.forEach((button) => button.classList.remove("active"));
+                    tabPanels.forEach((panel) => panel.classList.remove("visible"));
+
+                    tabButton.classList.add("active");
+
+                    targetPanel?.classList.add("visible");
+                });
+            });
+        });
+    }
+}

--- a/panel/src/ts/components/tabs.ts
+++ b/panel/src/ts/components/tabs.ts
@@ -4,22 +4,14 @@ export class Tabs {
     constructor() {
         $$(".tabs").forEach((tabs) => {
             const tabButtons = $$(".tabs-tab", tabs);
-            const tabPanels: HTMLElement[] = [];
-
             tabButtons.forEach((tabButton) => {
-                const targetPanel = $(`.tabs-panel[data-tab="${tabButton.dataset.tab}"]`);
-
-                if (targetPanel) {
-                    tabPanels.push(targetPanel);
-                }
-
                 tabButton.addEventListener("click", () => {
-                    tabButtons.forEach((button) => button.classList.remove("active"));
-                    tabPanels.forEach((panel) => panel.classList.remove("visible"));
-
-                    tabButton.classList.add("active");
-
-                    targetPanel?.classList.add("visible");
+                    tabButtons.forEach((button) => {
+                        button.classList.toggle("active", button === tabButton);
+                        button.ariaSelected = (button === tabButton).toString();
+                        const tabPanel = $(`.tabs-panel[data-tab="${button.dataset.tab}"]`);
+                        tabPanel?.classList.toggle("visible", button === tabButton);
+                    });
                 });
             });
         });

--- a/panel/translations/de.yaml
+++ b/panel/translations/de.yaml
@@ -240,7 +240,6 @@ panel.pages.page.edited: Seite bearbeitet
 panel.pages.page.lastModified: Zuletzt geändert
 panel.pages.page.moved: Seite verschoben!
 panel.pages.page.notFound: Seite nicht gefunden
-panel.pages.page.status: Status
 panel.pages.pages: Seiten
 panel.pages.pages.collapseAll: Alle einklappen
 panel.pages.pages.expandAll: Alle ausklappen

--- a/panel/translations/en.yaml
+++ b/panel/translations/en.yaml
@@ -240,7 +240,6 @@ panel.pages.page.edited: Page edited
 panel.pages.page.lastModified: Last modified
 panel.pages.page.moved: Page moved!
 panel.pages.page.notFound: Page not found
-panel.pages.page.status: Status
 panel.pages.pages: Pages
 panel.pages.pages.collapseAll: Collapse all
 panel.pages.pages.expandAll: Expand all

--- a/panel/translations/es.yaml
+++ b/panel/translations/es.yaml
@@ -240,7 +240,6 @@ panel.pages.page.edited: Página editada
 panel.pages.page.lastModified: Última modificación
 panel.pages.page.moved: ¡Página movida!
 panel.pages.page.notFound: Página no encontrada
-panel.pages.page.status: Estado
 panel.pages.pages: Páginas
 panel.pages.pages.collapseAll: Contraer todo
 panel.pages.pages.expandAll: Expandir todo

--- a/panel/translations/fr.yaml
+++ b/panel/translations/fr.yaml
@@ -240,7 +240,6 @@ panel.pages.page.edited: Page éditée
 panel.pages.page.lastModified: Dernière modification
 panel.pages.page.moved: Page déplacée !
 panel.pages.page.notFound: Page non trouvée
-panel.pages.page.status: Statut
 panel.pages.pages: Pages
 panel.pages.pages.collapseAll: Tout réduire
 panel.pages.pages.expandAll: Tout développer

--- a/panel/translations/it.yaml
+++ b/panel/translations/it.yaml
@@ -240,7 +240,6 @@ panel.pages.page.edited: Pagina modificata!
 panel.pages.page.lastModified: Ultime modifiche
 panel.pages.page.moved: Pagina spostata!
 panel.pages.page.notFound: Pagina non trovata
-panel.pages.page.status: Stato
 panel.pages.pages: Pagine
 panel.pages.pages.collapseAll: Riduci tutte
 panel.pages.pages.expandAll: Espandi tutte

--- a/panel/translations/nl.yaml
+++ b/panel/translations/nl.yaml
@@ -240,7 +240,6 @@ panel.pages.page.edited: Pagina bewerkt
 panel.pages.page.lastModified: Laatste wijziging
 panel.pages.page.moved: Pagina verplaatst!
 panel.pages.page.notFound: Pagina niet gevonden
-panel.pages.page.status: Status
 panel.pages.pages: Pagina's
 panel.pages.pages.collapseAll: Vouw alles in
 panel.pages.pages.expandAll: Vouw alles uit

--- a/panel/translations/pl.yaml
+++ b/panel/translations/pl.yaml
@@ -240,7 +240,6 @@ panel.pages.page.edited: Strona edytowana
 panel.pages.page.lastModified: Ostatnia modyfikacja
 panel.pages.page.moved: Strona przeniesiona!
 panel.pages.page.notFound: Strona nie została znaleziona
-panel.pages.page.status: Status
 panel.pages.pages: Strony
 panel.pages.pages.collapseAll: Zwiń wszystkie
 panel.pages.pages.expandAll: Rozwiń wszystkie

--- a/panel/translations/pt.yaml
+++ b/panel/translations/pt.yaml
@@ -240,7 +240,6 @@ panel.pages.page.edited: Página editada
 panel.pages.page.lastModified: Última modificação
 panel.pages.page.moved: Página movida!
 panel.pages.page.notFound: Página não encontrada
-panel.pages.page.status: Estado
 panel.pages.pages: Páginas
 panel.pages.pages.collapseAll: Recolher todas
 panel.pages.pages.expandAll: Expandir todas

--- a/panel/translations/ro.yaml
+++ b/panel/translations/ro.yaml
@@ -240,7 +240,6 @@ panel.pages.page.edited: Pagină editată
 panel.pages.page.lastModified: Ultima modificare
 panel.pages.page.moved: Pagină mutată!
 panel.pages.page.notFound: Pagina nu a fost găsită
-panel.pages.page.status: Stare
 panel.pages.pages: Pagini
 panel.pages.pages.collapseAll: Restrânge tot
 panel.pages.pages.expandAll: Extinde tot

--- a/panel/translations/ru.yaml
+++ b/panel/translations/ru.yaml
@@ -240,7 +240,6 @@ panel.pages.page.edited: Страница отредактирован
 panel.pages.page.lastModified: Последнее изменение
 panel.pages.page.moved: Страница переехала!
 panel.pages.page.notFound: Страница не найдена
-panel.pages.page.status: Статус
 panel.pages.pages: Страницы
 panel.pages.pages.collapseAll: Свернуть все
 panel.pages.pages.expandAll: Расширить все

--- a/panel/translations/uk.yaml
+++ b/panel/translations/uk.yaml
@@ -240,7 +240,6 @@ panel.pages.page.edited: Сторінка відредагована
 panel.pages.page.lastModified: Останнє редагування
 panel.pages.page.moved: Сторінка переміщена!
 panel.pages.page.notFound: Сторінка не знайдена
-panel.pages.page.status: Статус
 panel.pages.pages: Сторінки
 panel.pages.pages.collapseAll: Згорнути всі
 panel.pages.pages.expandAll: Розгорнути всі

--- a/panel/views/fields.php
+++ b/panel/views/fields.php
@@ -1,1 +1,1 @@
-<?php $this->insert('fields.layout.' . ($fields->layout()->sections()->isEmpty() ? 'default' : 'sections'), ['sections' => $fields->layout()->sections(), 'tabs' => $fields->layout()->tabs()]) ?>
+<?php $this->insert('fields.layout.' . ($fields->layout()->sections()->isEmpty() ? 'default' : 'sections'), ['layout' => $fields->layout()]) ?>

--- a/panel/views/fields.php
+++ b/panel/views/fields.php
@@ -1,1 +1,1 @@
-<?php $this->insert('fields.layout.' . $fields->layout()->type(), ['sections' => $fields->layout()->sections()]) ?>
+<?php $this->insert('fields.layout.' . ($fields->layout()->sections()->isEmpty() ? 'default' : 'sections'), ['sections' => $fields->layout()->sections(), 'tabs' => $fields->layout()->tabs()]) ?>

--- a/panel/views/fields/layout/sections.php
+++ b/panel/views/fields/layout/sections.php
@@ -5,8 +5,8 @@
 <?php foreach ($layout->sections()->groupBy('tab', $layout->tabs()->first()?->name()) as $tabName => $sections): ?>
     <?php $this->define('sections') ?>
     <div class="sections">
-        <?php foreach ($sections as $id => $section) : ?>
-            <section class="<?= $this->classes(['section',  'collapsible' => $section->is('collapsible'), 'collapsed' => $section->is('collapsed')]) ?>" id="section-<?= $this->escapeAttr($id) ?>">
+        <?php foreach ($sections as $section) : ?>
+            <section class="<?= $this->classes(['section',  'collapsible' => $section->is('collapsible'), 'collapsed' => $section->is('collapsed')]) ?>" id="section-<?= $this->escapeAttr($section->name()) ?>">
                 <div class="section-header">
                     <?php if ($section->is('collapsible')) : ?>
                         <button type="button" class="button section-toggle mr-2" title="<?= $this->translate('panel.sections.toggle') ?>" aria-label="<?= $this->translate('panel.sections.toggle') ?>"><?= $this->icon('chevron-up') ?></button>

--- a/panel/views/fields/layout/sections.php
+++ b/panel/views/fields/layout/sections.php
@@ -1,23 +1,45 @@
-<div class="sections">
-    <?php foreach ($sections as $id => $section) : ?>
-        <section class="<?= $this->classes(['section',  'collapsible' => $section->is('collapsible'), 'collapsed' => $section->is('collapsed')]) ?>" id="section-<?= $id ?>">
-            <div class="section-header">
-                <?php if ($section->is('collapsible')) : ?>
-                    <button type="button" class="button section-toggle mr-2" title="<?= $this->translate('panel.sections.toggle') ?>" aria-label="<?= $this->translate('panel.sections.toggle') ?>"><?= $this->icon('chevron-up') ?></button>
-                <?php endif ?>
-                <span class="caption"><?= $this->escape($section->label()) ?></span>
-            </div>
-            <div class="section-content">
-                <div class="row">
-                    <?php foreach ($fields->getMultiple($section->get('fields', [])) as $field) : ?>
-                        <?php if ($field->isVisible()) : ?>
-                            <div class="<?= $this->classes(['col-md-' . $field->get('width', '12-12')]) ?>">
-                                <?php $this->insert('fields.' . $field->type(), ['field' => $field]) ?>
-                            </div>
-                        <?php endif ?>
-                    <?php endforeach ?>
+<?php if (!$tabs->isEmpty()): ?>
+    <div class="tabs">
+        <?php foreach ($tabs as $tab): ?>
+            <button type="button" class="<?= $this->classes(['button', 'button-link', 'tabs-tab', 'active' => $tab === $tabs->first()]) ?>" data-tab="<?= $tab->name() ?>"><?= $this->escape($tab->label()) ?></button>
+        <?php endforeach ?>
+    </div>
+<?php endif ?>
+
+<?php foreach ($sections->groupBy('tab', 'default') as $tabName => $sections): ?>
+    <?php $this->define('sections') ?>
+    <div class="sections">
+        <?php foreach ($sections as $id => $section) : ?>
+            <section class="<?= $this->classes(['section',  'collapsible' => $section->is('collapsible'), 'collapsed' => $section->is('collapsed')]) ?>" id="section-<?= $id ?>">
+                <div class="section-header">
+                    <?php if ($section->is('collapsible')) : ?>
+                        <button type="button" class="button section-toggle mr-2" title="<?= $this->translate('panel.sections.toggle') ?>" aria-label="<?= $this->translate('panel.sections.toggle') ?>"><?= $this->icon('chevron-up') ?></button>
+                    <?php endif ?>
+                    <span class="caption"><?= $this->escape($section->label()) ?></span>
                 </div>
+                <div class="section-content">
+                    <div class="row">
+                        <?php foreach ($fields->getMultiple($section->get('fields', [])) as $field) : ?>
+                            <?php if ($field->isVisible()) : ?>
+                                <div class="<?= $this->classes(['col-md-' . $field->get('width', '12-12')]) ?>">
+                                    <?php $this->insert('fields.' . $field->type(), ['field' => $field]) ?>
+                                </div>
+                            <?php endif ?>
+                        <?php endforeach ?>
+                    </div>
+                </div>
+            </section>
+        <?php endforeach ?>
+    </div>
+    <?php $this->end() ?>
+
+    <?php if (!$tabs->isEmpty()): ?>
+        <div class="tabs-content">
+            <div class="<?= $this->classes(['tabs-panel', 'visible' => $tabs->first()->name() === $tabName]) ?>" data-tab="<?= $tabName ?>">
+                <?= $this->block('sections') ?>
             </div>
-        </section>
-    <?php endforeach ?>
-</div>
+        </div>
+    <?php else: ?>
+        <?= $this->block('sections') ?>
+    <?php endif ?>
+<?php endforeach ?>

--- a/panel/views/fields/layout/sections.php
+++ b/panel/views/fields/layout/sections.php
@@ -1,16 +1,12 @@
-<?php if (!$tabs->isEmpty()): ?>
-    <div class="tabs">
-        <?php foreach ($tabs as $tab): ?>
-            <button type="button" class="<?= $this->classes(['button', 'button-link', 'tabs-tab', 'active' => $tab === $tabs->first()]) ?>" data-tab="<?= $tab->name() ?>"><?= $this->escape($tab->label()) ?></button>
-        <?php endforeach ?>
-    </div>
+<?php if (!$layout->tabs()->isEmpty()): ?>
+    <?php $this->layout('fields.section-tabs') ?>
 <?php endif ?>
 
-<?php foreach ($sections->groupBy('tab', 'default') as $tabName => $sections): ?>
+<?php foreach ($layout->sections()->groupBy('tab', $layout->tabs()->first()?->name()) as $tabName => $sections): ?>
     <?php $this->define('sections') ?>
     <div class="sections">
         <?php foreach ($sections as $id => $section) : ?>
-            <section class="<?= $this->classes(['section',  'collapsible' => $section->is('collapsible'), 'collapsed' => $section->is('collapsed')]) ?>" id="section-<?= $id ?>">
+            <section class="<?= $this->classes(['section',  'collapsible' => $section->is('collapsible'), 'collapsed' => $section->is('collapsed')]) ?>" id="section-<?= $this->escapeAttr($id) ?>">
                 <div class="section-header">
                     <?php if ($section->is('collapsible')) : ?>
                         <button type="button" class="button section-toggle mr-2" title="<?= $this->translate('panel.sections.toggle') ?>" aria-label="<?= $this->translate('panel.sections.toggle') ?>"><?= $this->icon('chevron-up') ?></button>
@@ -32,12 +28,9 @@
         <?php endforeach ?>
     </div>
     <?php $this->end() ?>
-
-    <?php if (!$tabs->isEmpty()): ?>
-        <div class="tabs-content">
-            <div class="<?= $this->classes(['tabs-panel', 'visible' => $tabs->first()->name() === $tabName]) ?>" data-tab="<?= $tabName ?>">
-                <?= $this->block('sections') ?>
-            </div>
+    <?php if (!$layout->tabs()->isEmpty()): ?>
+        <div class="<?= $this->classes(['tabs-panel', 'visible' => $layout->tabs()->first()->name() === $tabName]) ?>" role="tabpanel" aria-labelledby="tab-<?= $this->escapeAttr($tabName) ?>" data-tab="<?= $this->escapeAttr($tabName) ?>">
+            <?= $this->block('sections') ?>
         </div>
     <?php else: ?>
         <?= $this->block('sections') ?>

--- a/panel/views/layouts/fields/section-tabs.php
+++ b/panel/views/layouts/fields/section-tabs.php
@@ -1,0 +1,8 @@
+<div class="tabs" role="tablist">
+    <?php foreach ($layout->tabs() as $tab): ?>
+        <button type="button" class="<?= $this->classes(['button', 'button-link', 'tabs-tab', 'active' => $tab === $layout->tabs()->first()]) ?>" id="tab-<?= $this->escapeAttr($tab->name()) ?>" role="tab" aria-selected="<?= $tab === $layout->tabs()->first() ? 'true' : 'false' ?>" data-tab="<?= $this->escapeAttr($tab->name()) ?>"><?= $this->escape($tab->label()) ?></button>
+    <?php endforeach ?>
+</div>
+<div class="tabs-content">
+    <?= $this->content() ?>
+</div>

--- a/panel/views/pages/editor.php
+++ b/panel/views/pages/editor.php
@@ -67,9 +67,7 @@
             </div>
         </div>
     </div>
-    <div>
-        <?php $this->insert('fields', ['fields' => $fields]) ?>
-    </div>
+    <?php $this->insert('fields', ['fields' => $fields]) ?>
     <input type="hidden" name="csrf-token" value="<?= $csrfToken ?>">
     <?php if ($history !== null && !$history->items()->isEmpty()): ?>
         <div class="text-size-sm text-color-gray-medium"><?= $this->icon('clock-rotate-left') ?>

--- a/panel/views/pages/tree.php
+++ b/panel/views/pages/tree.php
@@ -5,7 +5,7 @@
     <div class="pages-tree-headers" aria-hidden="true">
         <div class="pages-tree-headers-cell page-details truncate"><?= $this->translate('page.title') ?></div>
         <div class="pages-tree-headers-cell page-date truncate show-from-lg"><?= $this->translate('panel.pages.page.lastModified') ?></div>
-        <div class="pages-tree-headers-cell page-status truncate show-from-xs"><?= $this->translate('panel.pages.page.status') ?></div>
+        <div class="pages-tree-headers-cell page-status truncate show-from-xs"><?= $this->translate('page.status') ?></div>
         <div class="pages-tree-headers-cell page-actions"><span class="show-from-xs mr-6"><?= $this->translate('panel.pages.page.actions') ?></span></div>
     </div>
 <?php endif ?>

--- a/site/schemes/pages/blog.yaml
+++ b/site/schemes/pages/blog.yaml
@@ -21,10 +21,12 @@ options:
     icon: page-listing
 
 layout:
-    type: sections
     sections:
-        options:
-            fields: [postsPerPage, published, publishDate, unpublishDate, routable, listed, cacheable]
+        blog:
+            label: Blog
+            fields: [postsPerPage]
+            tab: options
+            order: 1
 
 fields:
     content:

--- a/site/schemes/pages/page.yaml
+++ b/site/schemes/pages/page.yaml
@@ -5,30 +5,36 @@ options:
     icon: page
 
 layout:
-    type: sections
-
-    sections:
+    tabs:
         content:
             label: '{{page.content}}'
-            active: true
-            fields: [title, content]
 
         options:
-            collapsible: true
             label: '{{page.options}}'
-            fields: [published, publishDate, unpublishDate, routable, listed, cacheable]
 
-        attributes:
-            collapsible: true
-            collapsed: true
-            label: '{{page.attributes}}'
-            fields: [slug, parent, template]
+    sections:
+        page:
+            label: '{{page.page}}'
+            active: true
+            fields: [title, content]
+            tab: content
 
         files:
             collapsible: true
-            collapsed: false
             label: '{{page.files}}'
             fields: [files]
+            tab: content
+
+        status:
+            label: '{{page.status}}'
+            fields: [published, publishDate, unpublishDate, routable, listed, cacheable]
+            tab: options
+
+        attributes:
+            collapsible: true
+            label: '{{page.attributes}}'
+            fields: [slug, parent, template]
+            tab: options
 
 fields:
     title:

--- a/site/schemes/pages/post.yaml
+++ b/site/schemes/pages/post.yaml
@@ -9,7 +9,7 @@ options:
 
 layout:
     sections:
-        content:
+        page:
             fields: [title, coverImage, taxonomy.tag, summary, content]
 
 fields:


### PR DESCRIPTION
This pull request introduces a new tab system for layouts in the Formwork CMS, including backend PHP classes for managing tabs, frontend SCSS and TypeScript for rendering and interaction, and updates to translation files to support the new "status" field in multiple languages. The changes are grouped into backend logic for tabs, frontend tab UI implementation, and translation updates.

**Backend: Tab System Implementation**

* Added new `Tab` and `TabCollection` classes to manage tab data within layouts, similar to how sections are managed. (`formwork/src/Fields/Layout/Tab.php` [[1]](diffhunk://#diff-573ac04c6c1b1461b5fe9b17af0e38de9df4aee05afd4108a827be9ad859c84bR1-R58) `formwork/src/Fields/Layout/TabCollection.php` [[2]](diffhunk://#diff-bca4dbbe57478b634cb4fe8c387e8aef1fbb5a6cf52f6945db9b677ca07b057aR1-R22)
* Updated the `Layout` class to support tabs: added a `tabs` property, a `tabs()` method for retrieving them, and adjusted the constructor and type property handling. (`formwork/src/Fields/Layout/Layout.php` [[1]](diffhunk://#diff-cc96e9fca1c6c2cf8848425a0713548279c331ad10ac1babf8ffd00b827cfe3eL12-R29) [[2]](diffhunk://#diff-cc96e9fca1c6c2cf8848425a0713548279c331ad10ac1babf8ffd00b827cfe3eR47-R55)
* Modified the `Section` and `SectionCollection` classes to include section names as properties and constructor arguments, aligning them with the new tab structure. (`formwork/src/Fields/Layout/Section.php` [[1]](diffhunk://#diff-136f96d73b458596262925f30aceb3b642dc138f5c86be2020088d0ece7dc5c9R20-R34) [[2]](diffhunk://#diff-136f96d73b458596262925f30aceb3b642dc138f5c86be2020088d0ece7dc5c9L35-R44) `formwork/src/Fields/Layout/SectionCollection.php` [[3]](diffhunk://#diff-12555a29a1773af2fa92f1b802480e6fa1937073565b928320ee16bff6746178L20-R20)

**Frontend: Tab UI Implementation**

* Added new SCSS styles for tabs and panels, including focus, active, and visibility states. (`panel/src/scss/components/_tabs.scss` [panel/src/scss/components/_tabs.scssR18-R55](diffhunk://#diff-d07fbc4ebb485d8c6936d231726cffad812091c62cc185a30f22e43e38f0e327R18-R55))
* Implemented a new `Tabs` TypeScript class to handle tab switching logic in the panel UI, and registered it in the main app initialization. (`panel/src/ts/components/tabs.ts` [[1]](diffhunk://#diff-6049a4cc3839dc3e361cda3a71c9e0ff77c4f80d87fd27002400f14f2f497802R1-R27) `panel/src/ts/app.ts` [[2]](diffhunk://#diff-0ce5a00f05124ebd6c3c925842cf986670c066027072cc41938086eb5e95f3a5R9) [[3]](diffhunk://#diff-0ce5a00f05124ebd6c3c925842cf986670c066027072cc41938086eb5e95f3a5R62)

**Translations**

* Added the "page.status" translation key and related status labels to all supported languages, enabling translated status display in the UI. (`formwork/translations/de.yaml` [[1]](diffhunk://#diff-800c335cf3c0ea280f1cd5da48d056b7bcb65ed861065c79dc77df24f5a7bfd2R55) `formwork/translations/en.yaml` [[2]](diffhunk://#diff-e704adff630f207c6ec0fd3c2a4396972afb38414f49cb1d35d13d8910eef95eR64) `formwork/translations/es.yaml` [[3]](diffhunk://#diff-21b3d720a97bfb0ebdbed815270be96b0c6c1c343d8d117127efcdfc4ed3f76aR55) `formwork/translations/fr.yaml` [[4]](diffhunk://#diff-0e07bb7b1ead263a6dc7949c1fd8e1d5341b7b5d64feec93c095c2b67d5cedfcR55) `formwork/translations/it.yaml` [[5]](diffhunk://#diff-bcc44dfacf8b5f30d67a05a2fcfddc5f56d46ce16e468f88c396a9274d2d561bR55) `formwork/translations/nl.yaml` [[6]](diffhunk://#diff-3136b4c0caf92bf90a02ad17a81577ee132416badc4833f03523b80265cee889R55) `formwork/translations/pl.yaml` [[7]](diffhunk://#diff-d9ee8254d1bc2176ed80404ca843271d4f2e2a13d2243a39f2e251c52fccaf6dR55) `formwork/translations/pt.yaml` [[8]](diffhunk://#diff-67a6857381a98bfc6479d3dc5f20ba028bb64309bcbeb081c9b96158dd9d55cbR55) `formwork/translations/ro.yaml` [[9]](diffhunk://#diff-dc019a62165396d1ca102de8e8779beebe1aa5351f91708ea03f5c88ad0c3d8bR55) `formwork/translations/ru.yaml` [[10]](diffhunk://#diff-9f987c50f8dc7d718050ddc00b50751d095e4bc04845bb3290b9adea3eff1adeR55) `formwork/translations/uk.yaml` [[11]](diffhunk://#diff-a01e5bdcd90497978625afbbb3c4b179ab6d3637587b1bf4502c5194ffe856daR55)

These changes lay the groundwork for layouts with tabbed interfaces in both backend data structures and the frontend panel, and ensure that the new "status" field is properly localized.