### PR TITLE
Improve sorting based on a second array with `Arr::sort()`

### DIFF
--- a/formwork/src/Data/AbstractCollection.php
+++ b/formwork/src/Data/AbstractCollection.php
@@ -355,7 +355,11 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
      *
      * Keys are preserved by default in associative collections
      *
-     * @param array<string>|callable|null $sortBy
+     * @param \SORT_ASC|\SORT_DESC                                   $direction     Direction of sorting. Possible values are `SORT_ASC` and `SORT_DESC`.
+     * @param \SORT_NATURAL|\SORT_NUMERIC|\SORT_REGULAR|\SORT_STRING $type          Type of sorting. Possible values are `SORT_NATURAL`, `SORT_NUMERIC`, `SORT_REGULAR` and `SORT_STRING`.
+     * @param array<mixed>|callable|null                             $sortBy        A callback or second array of values used to sort the first
+     * @param                                                        $caseSensitive Whether to perform a case-sensitive sorting
+     * @param                                                        $preserveKeys  Whether to preserve array keys after sorting. If `null`, keys are preserved only in associative collections
      */
     public function sort(
         int $direction = SORT_ASC,
@@ -462,6 +466,11 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
     /**
      * Sort the collection using the given key from each item
+     *
+     * @param \SORT_ASC|\SORT_DESC                                   $direction     Direction of sorting. Possible values are `SORT_ASC` and `SORT_DESC`.
+     * @param \SORT_NATURAL|\SORT_NUMERIC|\SORT_REGULAR|\SORT_STRING $type          Type of sorting. Possible values are `SORT_NATURAL`, `SORT_NUMERIC`, `SORT_REGULAR` and `SORT_STRING`.
+     * @param                                                        $caseSensitive Whether to perform a case-sensitive sorting
+     * @param                                                        $preserveKeys  Whether to preserve array keys after sorting
      */
     public function sortBy(
         string $key,


### PR DESCRIPTION
This pull request improves the type annotations and logic for sorting methods in the codebase, with a focus on clarifying parameters and enhancing array sorting behavior. The main updates include more precise PHPDoc types for sorting options, better handling of the `$sortBy` parameter, and improved error checking in the array sorting utility.

**Type annotation improvements:**

* Updated PHPDoc comments in `AbstractCollection.php` and `Arr.php` to specify accepted types for sorting parameters such as `$direction`, `$type`, and `$sortBy`, making the documentation clearer and more accurate. [[1]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbL358-R362) [[2]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR469-R473) [[3]](diffhunk://#diff-6eec44a2eda55bc97ee34680e770943dd7c1b472a808610d827b7525593a0512L641-L644)

**Array sorting logic enhancements:**

* Refactored `Arr::sort()` to handle the `$sortBy` parameter more robustly, including:
  - Returning early when a callable is used.
  - Throwing an exception if `$sortBy` and the array to sort have mismatched counts.
  - Throwing an exception if a key in `$sortBy` is not present in the array.
  - Simplifying the sorting logic and result construction to ensure keys are preserved or not based on the `$preserveKeys` flag.