### PR TITLE
Improve stack traces in debug output

### DIFF
--- a/formwork/src/Controllers/ErrorsController.php
+++ b/formwork/src/Controllers/ErrorsController.php
@@ -2,9 +2,13 @@
 
 namespace Formwork\Controllers;
 
+use Error;
+use ErrorException;
+use Formwork\Cms\App;
 use Formwork\Http\JsonResponse;
 use Formwork\Http\Response;
 use Formwork\Http\ResponseStatus;
+use Formwork\Utils\Str;
 use Throwable;
 
 final class ErrorsController extends AbstractController implements ErrorsControllerInterface
@@ -20,6 +24,7 @@ final class ErrorsController extends AbstractController implements ErrorsControl
 
         if ($this->config->get('system.debug.enabled') || $this->request->isLocalhost()) {
             $data['throwable'] = $throwable;
+            $data['stackTrace'] = $throwable !== null ? $this->getTrace($throwable) : [];
         }
 
         if ($this->request->isXmlHttpRequest()) {
@@ -83,5 +88,39 @@ final class ErrorsController extends AbstractController implements ErrorsControl
             $throwable->getLine(),
             $throwable->getTraceAsString()
         ));
+    }
+
+    /**
+     * Get full trace including the exception origin
+     *
+     * @return array<array{file?: string, line?: int, function?: string, class?: string, object?: object, type?: string, args?: list<mixed>}>
+     */
+    private function getTrace(Throwable $throwable): array
+    {
+        $trace = $throwable->getTrace();
+
+        $file = $throwable->getFile();
+        $line = $throwable->getLine();
+
+        if ($throwable instanceof Error || $throwable instanceof ErrorException) {
+            if (
+                isset($trace[0], $trace[0]['class'], $trace[0]['function'])
+                && $trace[0]['class'] === App::class
+                && Str::endsWith($trace[0]['function'], '{closure}')
+            ) {
+                array_shift($trace);
+            }
+
+            if (isset($trace[0], $trace[0]['file'], $trace[0]['line']) && $trace[0]['file'] === $file && $trace[0]['line'] === $line) {
+                return $trace;
+            }
+        }
+
+        array_unshift($trace, [
+            'file' => $file,
+            'line' => $line,
+        ]);
+
+        return $trace;
     }
 }

--- a/formwork/src/Panel/Controllers/ErrorsController.php
+++ b/formwork/src/Panel/Controllers/ErrorsController.php
@@ -120,7 +120,6 @@ final class ErrorsController extends AbstractController implements ErrorsControl
      */
     private function getTrace(Throwable $throwable): array
     {
-
         $trace = $throwable->getTrace();
 
         $file = $throwable->getFile();

--- a/formwork/views/errors/partials/debug.php
+++ b/formwork/views/errors/partials/debug.php
@@ -1,13 +1,9 @@
 </div>
 <div class="error-debug-details">
     <h3>Uncaught <code><?= $throwable::class ?></code>: <?= $throwable->getMessage() ?></h3>
-    <details open>
-        <summary><a class="error-debug-editor-uri" href="<?= Formwork\Utils\Str::interpolate($app->config()->get('system.debug.editorUri'), ['filename' => $throwable->getFile(), 'line' => $throwable->getLine()]) ?>"><span class="error-debug-filename"><?= preg_replace('/([^\/]+)$/', '<strong>$1</strong>', $throwable->getFile()) ?></span><span class="error-debug-line">:<?= $throwable->getLine() ?></span></a></summary>
-        <?= Formwork\Debug\CodeDumper::dumpLine($throwable->getFile(), $throwable->getLine(), $app->config()->get('system.debug.contextLines', 5)) ?>
-    </details>
-    <?php foreach ($throwable->getTrace() as $frame) : ?>
-        <?php if (isset($frame['file'], $frame['line']) && ($frame['file'] !== $throwable->getFile() || $frame['line'] !== $throwable->getLine())): ?>
-            <details>
+    <?php foreach ($stackTrace as $i => $frame) : ?>
+        <?php if (isset($frame['file'], $frame['line'])): ?>
+            <details <?= $this->attr(['open' => $i === 0]) ?>>
                 <summary><a class="error-debug-editor-uri" href="<?= Formwork\Utils\Str::interpolate($app->config()->get('system.debug.editorUri'), ['filename' => $frame['file'], 'line' => $frame['line']]) ?>"><span class="error-debug-filename"><?= preg_replace('/([^\/]+)$/', '<strong>$1</strong>', $frame['file']) ?></span><span class="error-debug-line">:<?= $frame['line'] ?></span></a></summary>
                 <?= Formwork\Debug\CodeDumper::dumpBacktraceFrame($frame, $app->config()->get('system.debug.contextLines', 5)) ?>
             </details>

--- a/panel/views/errors/error.php
+++ b/panel/views/errors/error.php
@@ -24,17 +24,13 @@
                 <?php if (isset($action)) : ?><a class="action" href="<?= $action['href'] ?>"><?= $action['label'] ?></a><?php endif ?>
             </div>
         </div>
-        <?php if (isset($throwable)) : ?>
+        <?php if (isset($throwable, $stackTrace)) : ?>
             <div class="container-full">
                 <div class="error-debug-details">
                     <h3>Uncaught <code><?= $throwable::class ?></code>: <?= $throwable->getMessage() ?></h3>
-                    <details open>
-                        <summary><a class="error-debug-editor-uri" href="<?= Formwork\Utils\Str::interpolate($app->config()->get('system.debug.editorUri'), ['filename' => $throwable->getFile(), 'line' => $throwable->getLine()]) ?>"><span class="error-debug-filename"><?= preg_replace('/([^\/]+)$/', '<strong>$1</strong>', $throwable->getFile()) ?></span><span class="error-debug-line">:<?= $throwable->getLine() ?></span></a></summary>
-                        <?= Formwork\Debug\CodeDumper::dumpLine($throwable->getFile(), $throwable->getLine(), $app->config()->get('system.debug.contextLines', 5)) ?>
-                    </details>
-                    <?php foreach ($throwable->getTrace() as $frame) : ?>
-                        <?php if (isset($frame['file'], $frame['line']) && ($frame['file'] !== $throwable->getFile() || $frame['line'] !== $throwable->getLine())): ?>
-                            <details>
+                    <?php foreach ($stackTrace as $i => $frame) : ?>
+                        <?php if (isset($frame['file'], $frame['line'])): ?>
+                            <details <?= $this->attr(['open' => $i === 0]) ?>>
                                 <summary><a class="error-debug-editor-uri" href="<?= Formwork\Utils\Str::interpolate($app->config()->get('system.debug.editorUri'), ['filename' => $frame['file'], 'line' => $frame['line']]) ?>"><span class="error-debug-filename"><?= preg_replace('/([^\/]+)$/', '<strong>$1</strong>', $frame['file']) ?></span><span class="error-debug-line">:<?= $frame['line'] ?></span></a></summary>
                                 <?= Formwork\Debug\CodeDumper::dumpBacktraceFrame($frame, $app->config()->get('system.debug.contextLines', 5)) ?>
                             </details>


### PR DESCRIPTION
This pull request improves error debugging and stack trace visualization across both the main application and the panel. The changes focus on consistently capturing and displaying the full stack trace for exceptions, refining trace formatting, and enhancing the robustness of code frame dumping.

**Stack trace handling and display:**

* Added a new `getTrace` method to both `formwork/src/Controllers/ErrorsController.php` and `formwork/src/Panel/Controllers/ErrorsController.php` to generate a complete stack trace, including the exception origin, and handle edge cases for `Error` and `ErrorException` types. This trace is now passed as `stackTrace` to error views. [[1]](diffhunk://#diff-9eac2c4d570abf7bd1e1759a02cb8cdff52dee3f2aff7b6acbd3c2c2f2d0ce1bR92-R125) [[2]](diffhunk://#diff-aac297d6a4c34cc2a5049b7da84ca111945afca587357c9261dce6be387f248aR116-R150)
* Updated error views (`formwork/views/errors/partials/debug.php` and `panel/views/errors/error.php`) to iterate over the new `stackTrace` array, ensuring all relevant frames are displayed and the first frame is expanded by default. [[1]](diffhunk://#diff-d34c5ff93330aa3174787d5b154b0ba84ed79d05302281864c3b127127599a19L4-R6) [[2]](diffhunk://#diff-3e34110135d9aabf430ec9d5610267ca3f49f6f1b1e231e4ab0a667d11b99975L27-R33)

**Robustness and formatting improvements:**

* Improved the `CodeDumper::dumpBacktraceFrame` method to validate frame structure, handle missing keys gracefully, and avoid errors when dumping code for incomplete frames.
* Refined argument handling in `CodeDumper::dumpBacktraceFrame` to prevent undefined index errors and ensure correct parameter display. [[1]](diffhunk://#diff-94fd56c4dc295308b02c13c15577a65e7f429662e73bcc8ee08ea7db2f22c9baL178-R187) [[2]](diffhunk://#diff-94fd56c4dc295308b02c13c15577a65e7f429662e73bcc8ee08ea7db2f22c9baL207-R216)
* Adjusted trace call margin styling in `CodeDumper` for a more compact and readable display.