### PR TITLE
Improved model data storage

### DIFF
--- a/formwork/src/Cms/Site.php
+++ b/formwork/src/Cms/Site.php
@@ -8,6 +8,7 @@ use Formwork\Files\FileFactory;
 use Formwork\Languages\Languages;
 use Formwork\Languages\LanguagesFactory;
 use Formwork\Metadata\MetadataCollection;
+use Formwork\Model\Attributes\ReadonlyModelProperty;
 use Formwork\Model\Model;
 use Formwork\Pages\ContentFile;
 use Formwork\Pages\Exceptions\PageNotFoundException;
@@ -46,27 +47,32 @@ class Site extends Model implements Stringable
     /**
      * Site content file
      */
+    #[ReadonlyModelProperty]
     protected ?ContentFile $contentFile = null;
 
     /**
      * Site last modified time
      */
+    #[ReadonlyModelProperty]
     protected int $lastModifiedTime;
 
     /**
      * Site route
      */
-    protected ?string $route = null;
+    #[ReadonlyModelProperty]
+    protected ?string $route = '/';
 
     /**
      * Site canonical route
      */
+    #[ReadonlyModelProperty]
     protected ?string $canonicalRoute = null;
 
     /**
      * Site slug
      */
-    protected ?string $slug = null;
+    #[ReadonlyModelProperty]
+    protected ?string $slug = '';
 
     /**
      * Site languages
@@ -76,11 +82,13 @@ class Site extends Model implements Stringable
     /**
      * Site templates
      */
+    #[ReadonlyModelProperty]
     protected Templates $templates;
 
     /**
      * Site users
      */
+    #[ReadonlyModelProperty]
     protected Users $users;
 
     /**
@@ -93,6 +101,7 @@ class Site extends Model implements Stringable
      *
      * @var array<string, Page>
      */
+    #[ReadonlyModelProperty]
     protected array $storage = [];
 
     /**
@@ -110,6 +119,7 @@ class Site extends Model implements Stringable
     /**
      * Site files
      */
+    #[ReadonlyModelProperty]
     protected FileCollection $files;
 
     /**
@@ -538,10 +548,6 @@ class Site extends Model implements Stringable
     protected function setContentPath(string $path): void
     {
         $this->contentPath = FileSystem::normalizePath($path . '/');
-
-        $this->route = '/';
-
-        $this->slug = '';
     }
 
     /**

--- a/formwork/src/Cms/Site.php
+++ b/formwork/src/Cms/Site.php
@@ -127,7 +127,6 @@ class Site extends Model implements Stringable
      */
     public function __construct(
         array $data,
-        protected App $app,
         protected Config $config,
         protected LanguagesFactory $languagesFactory,
         protected PageFactory $pageFactory,
@@ -457,7 +456,7 @@ class Site extends Model implements Stringable
      */
     public function schemes(): Schemes
     {
-        return $this->app->schemes();
+        return $this->app()->schemes();
     }
 
     /**
@@ -465,9 +464,9 @@ class Site extends Model implements Stringable
      */
     public function load(): void
     {
-        $this->scheme = $this->app->schemes()->get('config.site');
-        $this->templates = $this->app->getService(Templates::class);
-        $this->users = $this->app->getService(Users::class);
+        $this->scheme = $this->app()->schemes()->get('config.site');
+        $this->templates = $this->app()->getService(Templates::class);
+        $this->users = $this->app()->getService(Users::class);
 
         $this->fields = $this->scheme->fields();
         $this->fields->setModel($this);
@@ -494,7 +493,7 @@ class Site extends Model implements Stringable
                 continue;
             }
             if (in_array($extension, $this->config->get('system.files.allowedExtensions'), true)) {
-                $files[] = $this->app->getService(FileFactory::class)->make(FileSystem::joinPaths($path, $file));
+                $files[] = $this->app()->getService(FileFactory::class)->make(FileSystem::joinPaths($path, $file));
             }
         }
 
@@ -512,7 +511,7 @@ class Site extends Model implements Stringable
         $this->languages = $this->languagesFactory->make($config);
 
         if (($currentTranslation = $this->languages->current() ?? $this->languages->default()) !== null) {
-            $this->app->translations()->setCurrent($currentTranslation->code());
+            $this->app()->translations()->setCurrent($currentTranslation->code());
         }
     }
 

--- a/formwork/src/Model/Model.php
+++ b/formwork/src/Model/Model.php
@@ -25,13 +25,23 @@ class Model implements Arrayable
     protected const string MODEL_IDENTIFIER = 'model';
 
     /**
+     * Model data
+     *
+     * @var array<string, mixed>
+     */
+    #[ReadonlyModelProperty]
+    protected array $data = [];
+
+    /**
      * Model scheme
      */
+    #[ReadonlyModelProperty]
     protected Scheme $scheme;
 
     /**
      * Model fields
      */
+    #[ReadonlyModelProperty]
     protected FieldCollection $fields;
 
     /**

--- a/formwork/src/Model/Model.php
+++ b/formwork/src/Model/Model.php
@@ -136,15 +136,18 @@ class Model implements Arrayable
             return;
         }
 
-        Arr::set($this->data, $key, $value);
-
         // Set value in the corresponding field if exists
         if (isset($this->fields) && $this->fields->has($key)) {
             /** @var Field */
             $field = $this->fields->get($key);
             $field->set('value', $value);
             $field->validate();
+
+            // Update value according to field validation
+            $value = $field->value();
         }
+
+        Arr::set($this->data, $key, $value);
     }
 
     /**

--- a/formwork/src/Model/Model.php
+++ b/formwork/src/Model/Model.php
@@ -135,6 +135,10 @@ class Model implements Arrayable
 
     /**
      * Set a data value by key
+     *
+     * This method updates both the data array and the corresponding field
+     * (if it exists). The field's validation may transform the value before
+     * it's stored in the data array.
      */
     public function set(string $key, mixed $value): void
     {
@@ -154,6 +158,8 @@ class Model implements Arrayable
         }
 
         // Set value in the corresponding field if exists
+        // Note: This updates the field in $this->fields, which may not be
+        // the same instance as a cloned field collection used elsewhere
         if (isset($this->fields) && $this->fields->has($key)) {
             /** @var Field */
             $field = $this->fields->get($key);

--- a/formwork/src/Model/Model.php
+++ b/formwork/src/Model/Model.php
@@ -3,6 +3,7 @@
 namespace Formwork\Model;
 
 use BadMethodCallException;
+use Formwork\Cms\App;
 use Formwork\Data\Contracts\Arrayable;
 use Formwork\Data\Traits\DataMultipleGetter;
 use Formwork\Data\Traits\DataMultipleSetter;
@@ -31,6 +32,12 @@ class Model implements Arrayable
      */
     #[ReadonlyModelProperty]
     protected array $data = [];
+
+    /**
+     * Application instance
+     */
+    #[ReadonlyModelProperty]
+    protected App $app;
 
     /**
      * Model scheme
@@ -185,6 +192,14 @@ class Model implements Arrayable
     public function data(): array
     {
         return $this->data;
+    }
+
+    /**
+     * Get the application instance
+     */
+    protected function app(): App
+    {
+        return $this->app ?? App::instance();
     }
 
     /**

--- a/formwork/src/Pages/Page.php
+++ b/formwork/src/Pages/Page.php
@@ -536,6 +536,20 @@ class Page extends Model implements Stringable
      *
      * @internal
      */
+    /**
+     * Reload the page from disk
+     *
+     * This method completely resets all page properties and reconstructs
+     * the page by re-reading from disk. This ensures the page state matches
+     * the file system after external changes (e.g., file uploads).
+     *
+     * After calling reload(), the page's internal fields ($this->fields) are
+     * recreated and populated with fresh data from disk.
+     *
+     * @param array<string, mixed> $data Additional data to merge during reconstruction
+     *
+     * @throws RuntimeException If the page has not been loaded yet
+     */
     public function reload(array $data = []): void
     {
         if (!$this->hasLoaded()) {
@@ -747,7 +761,17 @@ class Page extends Model implements Stringable
     }
 
     /**
-     * Load page properties
+     * Load page from disk and initialize fields
+     *
+     * Data loading order (later sources override earlier ones):
+     * 1. Page defaults from scheme
+     * 2. Data passed to constructor ($this->data)
+     * 3. Content file frontmatter
+     * 4. Content file body (sets 'content' key)
+     *
+     * After data is loaded, fields are initialized and validated against
+     * the merged data. This ensures field values are consistent with the
+     * page's actual state.
      */
     protected function load(): void
     {

--- a/formwork/src/Pages/Page.php
+++ b/formwork/src/Pages/Page.php
@@ -854,7 +854,7 @@ class Page extends Model implements Stringable
             $this->contentFile()?->frontmatter() ?? []
         );
 
-        if ($content = $this->contentFile?->content()) {
+        if (($content = $this->contentFile?->content()) !== null) {
             $this->data['content'] = $content;
         }
 

--- a/formwork/src/Pages/Page.php
+++ b/formwork/src/Pages/Page.php
@@ -158,8 +158,6 @@ class Page extends Model implements Stringable
         $this->setMultiple($data);
 
         $this->load();
-
-        $this->fields->setValues([...$this->data, 'slug' => $this->slug, 'parent' => $this->parent()?->route(), 'template' => $this->template]);
     }
 
     public function __toString(): string
@@ -1015,6 +1013,9 @@ class Page extends Model implements Stringable
         if ($content = $this->contentFile?->content()) {
             $this->data['content'] = $content;
         }
+
+        $this->fields->setValues([...$this->data, 'slug' => $this->slug, 'parent' => $this->parent()?->route(), 'template' => $this->template])
+            ->validate();
 
         $this->loaded = true;
     }

--- a/formwork/src/Pages/Traits/PageStatus.php
+++ b/formwork/src/Pages/Traits/PageStatus.php
@@ -11,11 +11,6 @@ use UnexpectedValueException;
 trait PageStatus
 {
     /**
-     * App instance
-     */
-    protected App $app;
-
-    /**
      * Page data
      *
      * @var array<string, mixed>
@@ -46,8 +41,8 @@ trait PageStatus
         $now = time();
 
         $formats = [
-            $this->app->config()->get('system.date.dateFormat'),
-            $this->app->config()->get('system.date.datetimeFormat'),
+            $this->app()->config()->get('system.date.dateFormat'),
+            $this->app()->config()->get('system.date.datetimeFormat'),
         ];
 
         if ($publishDate = ($this->data['publishDate'] ?? null)) {
@@ -73,4 +68,9 @@ trait PageStatus
 
         return $this->status;
     }
+
+    /**
+     * Get the application instance
+     */
+    abstract protected function app(): App;
 }

--- a/formwork/src/Pages/Traits/PageStatus.php
+++ b/formwork/src/Pages/Traits/PageStatus.php
@@ -3,6 +3,7 @@
 namespace Formwork\Pages\Traits;
 
 use Formwork\Cms\App;
+use Formwork\Model\Attributes\ReadonlyModelProperty;
 use Formwork\Pages\Page;
 use Formwork\Utils\Date;
 use UnexpectedValueException;
@@ -19,11 +20,13 @@ trait PageStatus
      *
      * @var array<string, mixed>
      */
+    #[ReadonlyModelProperty]
     protected array $data = [];
 
     /**
      * Page status
      */
+    #[ReadonlyModelProperty]
     protected string $status;
 
     /**

--- a/formwork/src/Pages/Traits/PageStatus.php
+++ b/formwork/src/Pages/Traits/PageStatus.php
@@ -11,14 +11,6 @@ use UnexpectedValueException;
 trait PageStatus
 {
     /**
-     * Page data
-     *
-     * @var array<string, mixed>
-     */
-    #[ReadonlyModelProperty]
-    protected array $data = [];
-
-    /**
      * Page status
      */
     #[ReadonlyModelProperty]

--- a/formwork/src/Pages/Traits/PageTraversal.php
+++ b/formwork/src/Pages/Traits/PageTraversal.php
@@ -2,6 +2,7 @@
 
 namespace Formwork\Pages\Traits;
 
+use Formwork\Cms\App;
 use Formwork\Cms\Site;
 use Formwork\Pages\Page;
 use Formwork\Pages\PageCollection;
@@ -15,11 +16,6 @@ trait PageTraversal
      * Parent page
      */
     protected Page|Site|null $parent;
-
-    /**
-     * Page collection factory
-     */
-    protected PageCollectionFactory $pageCollectionFactory;
 
     /**
      * Collection of page children
@@ -114,7 +110,7 @@ trait PageTraversal
         }
 
         if ($this->contentPath() === null) {
-            return $this->children = $this->pageCollectionFactory->make([]);
+            return $this->children = $this->app()->getService(PageCollectionFactory::class)->make([]);
         }
 
         return $this->children = $this->site()->retrievePages($this->contentPath());
@@ -146,7 +142,7 @@ trait PageTraversal
         }
 
         if ($this->contentPath() === null) {
-            return $this->descendants = $this->pageCollectionFactory->make([]);
+            return $this->descendants = $this->app()->getService(PageCollectionFactory::class)->make([]);
         }
 
         return $this->descendants = $this->site()->retrievePages($this->contentPath(), recursive: true);
@@ -186,7 +182,7 @@ trait PageTraversal
             $page = $parent;
         }
 
-        return $this->ancestors = $this->pageCollectionFactory->make($ancestors);
+        return $this->ancestors = $this->app()->getService(PageCollectionFactory::class)->make($ancestors);
     }
 
     /**
@@ -223,7 +219,7 @@ trait PageTraversal
         }
 
         if ($this->contentPath() === null || $this->parent() === null) {
-            return $this->inclusiveSiblings = $this->pageCollectionFactory->make([$this->route() ?? '' => $this]);
+            return $this->inclusiveSiblings = $this->app()->getService(PageCollectionFactory::class)->make([$this->route() ?? '' => $this]);
         }
 
         return $this->inclusiveSiblings = $this->parent()->children();
@@ -277,4 +273,9 @@ trait PageTraversal
     {
         return $this->ancestors()->count();
     }
+
+    /**
+     * Get the application instance
+     */
+    abstract protected function app(): App;
 }

--- a/formwork/src/Pages/Traits/PageUid.php
+++ b/formwork/src/Pages/Traits/PageUid.php
@@ -2,6 +2,7 @@
 
 namespace Formwork\Pages\Traits;
 
+use Formwork\Model\Attributes\ReadonlyModelProperty;
 use Formwork\Utils\Str;
 
 trait PageUid
@@ -9,6 +10,7 @@ trait PageUid
     /**
      * Page uid (unique identifier)
      */
+    #[ReadonlyModelProperty]
     protected string $uid;
 
     /**

--- a/formwork/src/Pages/Traits/PageUri.php
+++ b/formwork/src/Pages/Traits/PageUri.php
@@ -4,15 +4,11 @@ namespace Formwork\Pages\Traits;
 
 use Formwork\Cms\App;
 use Formwork\Cms\Site;
-use Formwork\Model\Attributes\ReadonlyModelProperty;
 use Formwork\Utils\Path;
 use Formwork\Utils\Uri;
 
 trait PageUri
 {
-    #[ReadonlyModelProperty]
-    protected App $app;
-
     /**
      * Get page or site route
      */
@@ -33,7 +29,7 @@ trait PageUri
      */
     public function uri(string $path = '', bool|string $includeLanguage = true): string
     {
-        $base = $this->app->request()->root();
+        $base = $this->app()->request()->root();
 
         $route = $this->canonicalRoute() ?? $this->route();
 
@@ -56,6 +52,11 @@ trait PageUri
      */
     public function absoluteUri(string $path = '', bool|string $includeLanguage = true): string
     {
-        return Uri::resolveRelative($this->uri($path, $includeLanguage), $this->app->request()->absoluteUri());
+        return Uri::resolveRelative($this->uri($path, $includeLanguage), $this->app()->request()->absoluteUri());
     }
+
+    /**
+     * Get the application instance
+     */
+    abstract protected function app(): App;
 }

--- a/formwork/src/Pages/Traits/PageUri.php
+++ b/formwork/src/Pages/Traits/PageUri.php
@@ -4,11 +4,13 @@ namespace Formwork\Pages\Traits;
 
 use Formwork\Cms\App;
 use Formwork\Cms\Site;
+use Formwork\Model\Attributes\ReadonlyModelProperty;
 use Formwork\Utils\Path;
 use Formwork\Utils\Uri;
 
 trait PageUri
 {
+    #[ReadonlyModelProperty]
     protected App $app;
 
     /**

--- a/formwork/src/Panel/Controllers/PagesController.php
+++ b/formwork/src/Panel/Controllers/PagesController.php
@@ -204,7 +204,7 @@ final class PagesController extends AbstractController
             }
 
             if ($page->languages()->available()->has($language)) {
-                $page->setLanguage($language);
+                $page->set('language', $language);
             }
         } elseif ($this->site->languages()->hasMultiple() && $page->language() !== null) {
             if ($page->route() === null) {
@@ -404,7 +404,7 @@ final class PagesController extends AbstractController
         if ($routeParams->has('language')) {
             $language = $routeParams->get('language');
             if ($page->languages()->available()->has($language)) {
-                $page->setLanguage($language);
+                $page->set('language', $language);
             } else {
                 if ($this->request->isXmlHttpRequest()) {
                     return JsonResponse::error($this->translate('panel.pages.page.cannotDelete.invalidLanguage', $language), ResponseStatus::InternalServerError);

--- a/formwork/src/Users/User.php
+++ b/formwork/src/Users/User.php
@@ -13,6 +13,7 @@ use Formwork\Schemes\Schemes;
 use Formwork\Users\Exceptions\AuthenticationFailedException;
 use Formwork\Users\Exceptions\UserImageNotFoundException;
 use Formwork\Users\Exceptions\UserNotLoggedException;
+use Formwork\Utils\Arr;
 use Formwork\Utils\FileSystem;
 use SensitiveParameter;
 
@@ -64,7 +65,7 @@ class User extends Model
         $this->fields = $this->scheme->fields();
         $this->fields->setModel($this);
 
-        $this->data = [...$this->defaults, ...$data];
+        $this->data = array_replace_recursive($this->defaults, Arr::undot($data));
 
         $this->fields->setValues($this->data);
     }


### PR DESCRIPTION
This pull request introduces a series of changes to improve model property immutability and refactor how application dependencies are accessed throughout the codebase. The main enhancements include marking key model properties as read-only using the new `ReadonlyModelProperty` attribute, standardizing access to the application instance via an abstract `app()` method, and updating usages to reflect these changes. These updates increase code safety and consistency, especially around object state management and dependency injection.

**Model property immutability improvements:**

* Added the `ReadonlyModelProperty` attribute to several important properties in `Site`, `Model`, and page-related traits, enforcing immutability for fields such as `data`, `status`, `uid`, `contentFile`, `route`, `slug`, `templates`, `users`, `storage`, `files`, and others (`formwork/src/Cms/Site.php`, `formwork/src/Model/Model.php`, `formwork/src/Pages/Traits/PageStatus.php`, `formwork/src/Pages/Traits/PageUid.php`) [[1]](diffhunk://#diff-37d492248bf063a3470cbb7f9dff4937b3ea1d132a8148885a45d754f8f1b7d5R11) [[2]](diffhunk://#diff-37d492248bf063a3470cbb7f9dff4937b3ea1d132a8148885a45d754f8f1b7d5R50-R75) [[3]](diffhunk://#diff-37d492248bf063a3470cbb7f9dff4937b3ea1d132a8148885a45d754f8f1b7d5R85-R91) [[4]](diffhunk://#diff-37d492248bf063a3470cbb7f9dff4937b3ea1d132a8148885a45d754f8f1b7d5R104) [[5]](diffhunk://#diff-37d492248bf063a3470cbb7f9dff4937b3ea1d132a8148885a45d754f8f1b7d5R122) [[6]](diffhunk://#diff-560931c9ca094b6074728b44d6c80ff64fc924b8d0db7567494511f40e7378efR28-R51) [[7]](diffhunk://#diff-ac892038bc4dd22ea3a5415070e0074fac097abb1b5f5803536e4179c34aa3b3R6-R24) [[8]](diffhunk://#diff-8c0cdd13a02e4b0c10235797fc5a157380cdeccf68d5a93358cd9d2a6bad4eceR5-R13).

**Application instance access refactoring:**

* Standardized access to the application instance by introducing an abstract `app()` method in several traits, replacing direct property access; updated all usages of `$this->app` to `$this->app()` in relevant traits and methods (`formwork/src/Pages/Traits/PageStatus.php`, `formwork/src/Pages/Traits/PageTraversal.php`, `formwork/src/Pages/Traits/PageUri.php`) [[1]](diffhunk://#diff-560931c9ca094b6074728b44d6c80ff64fc924b8d0db7567494511f40e7378efR197-R204) [[2]](diffhunk://#diff-ac892038bc4dd22ea3a5415070e0074fac097abb1b5f5803536e4179c34aa3b3L46-R45) [[3]](diffhunk://#diff-ac892038bc4dd22ea3a5415070e0074fac097abb1b5f5803536e4179c34aa3b3R71-R75) [[4]](diffhunk://#diff-fb6c21245e44cf721807fbae7befc6b7d8df329b3a7f4cad65b4921f9846fce4L117-R113) [[5]](diffhunk://#diff-fb6c21245e44cf721807fbae7befc6b7d8df329b3a7f4cad65b4921f9846fce4L149-R145) [[6]](diffhunk://#diff-fb6c21245e44cf721807fbae7befc6b7d8df329b3a7f4cad65b4921f9846fce4L189-R185) [[7]](diffhunk://#diff-fb6c21245e44cf721807fbae7befc6b7d8df329b3a7f4cad65b4921f9846fce4L226-R222) [[8]](diffhunk://#diff-fb6c21245e44cf721807fbae7befc6b7d8df329b3a7f4cad65b4921f9846fce4R276-R280) [[9]](diffhunk://#diff-65c6c14faba7d7fbbe7bf5f91a73e0953f0396725c00f19079fe48bbe145ef3eL12-L13) [[10]](diffhunk://#diff-65c6c14faba7d7fbbe7bf5f91a73e0953f0396725c00f19079fe48bbe145ef3eL34-R32) [[11]](diffhunk://#diff-65c6c14faba7d7fbbe7bf5f91a73e0953f0396725c00f19079fe48bbe145ef3eL57-R61).

**Internal logic and API consistency:**

* Updated the logic in `Model::set()` to ensure that field values are validated and updated before setting them in the model data array, improving data consistency and validation flow (`formwork/src/Model/Model.php`).
* Changed usages of the page language setter to use the new `set('language', ...)` API instead of the previous `setLanguage()` method, reflecting the standardized model API (`formwork/src/Panel/Controllers/PagesController.php`) [[1]](diffhunk://#diff-c8b238be663183da229ed13ae8e0602420592d770a9c16e71b8987712713b719L207-R207) [[2]](diffhunk://#diff-c8b238be663183da229ed13ae8e0602420592d770a9c16e71b8987712713b719L407-R407).

**Code cleanup and removal of unused properties:**

* Removed direct `$app` and `$pageCollectionFactory` properties from page traits, as their functionality is now accessed via the `app()` method and service container (`formwork/src/Pages/Traits/PageStatus.php`, `formwork/src/Pages/Traits/PageTraversal.php`, `formwork/src/Pages/Traits/PageUri.php`) [[1]](diffhunk://#diff-ac892038bc4dd22ea3a5415070e0074fac097abb1b5f5803536e4179c34aa3b3R6-R24) [[2]](diffhunk://#diff-fb6c21245e44cf721807fbae7befc6b7d8df329b3a7f4cad65b4921f9846fce4L19-L23) [[3]](diffhunk://#diff-65c6c14faba7d7fbbe7bf5f91a73e0953f0396725c00f19079fe48bbe145ef3eL12-L13).

**Default property value adjustments:**

* Set default values for certain properties in `Site` (e.g., `route` to `'/'`, `slug` to `''`) and removed redundant assignments from `setContentPath()` to ensure consistency with the new read-only property approach (`formwork/src/Cms/Site.php`) [[1]](diffhunk://#diff-37d492248bf063a3470cbb7f9dff4937b3ea1d132a8148885a45d754f8f1b7d5R50-R75) [[2]](diffhunk://#diff-37d492248bf063a3470cbb7f9dff4937b3ea1d132a8148885a45d754f8f1b7d5L541-L544).