### PR TITLE
Allow and return an appropriate value for empty non-required fields

### DIFF
--- a/formwork/fields/color.php
+++ b/formwork/fields/color.php
@@ -11,7 +11,11 @@ return function (App $app) {
             /**
              * Validate the field value
              */
-            'validate' => function (Field $field, $value): string {
+            'validate' => function (Field $field, $value): ?string {
+                if (Constraint::isEmpty($value)) {
+                    return null;
+                }
+
                 if (!Constraint::matchesRegex($value, '#[0-9A-Fa-f]{6}')) {
                     throw new ValidationException(sprintf('Invalid value for field "%s" of type "%s"', $field->name(), $field->type()));
                 }

--- a/formwork/fields/duration.php
+++ b/formwork/fields/duration.php
@@ -3,6 +3,7 @@
 use Formwork\Cms\App;
 use Formwork\Fields\Exceptions\ValidationException;
 use Formwork\Fields\Field;
+use Formwork\Utils\Constraint;
 
 return function (App $app) {
     return [
@@ -32,7 +33,11 @@ return function (App $app) {
             /**
              * Validate the field value
              */
-            'validate' => function (Field $field, $value): int|float {
+            'validate' => function (Field $field, $value): int|float|null {
+                if (Constraint::isEmpty($value)) {
+                    return null;
+                }
+
                 if (!is_numeric($value)) {
                     throw new ValidationException(sprintf('Invalid value for field "%s" of type "%s"', $field->name(), $field->type()));
                 }

--- a/formwork/fields/number.php
+++ b/formwork/fields/number.php
@@ -3,6 +3,7 @@
 use Formwork\Cms\App;
 use Formwork\Fields\Exceptions\ValidationException;
 use Formwork\Fields\Field;
+use Formwork\Utils\Constraint;
 
 return function (App $app) {
     return [
@@ -37,7 +38,11 @@ return function (App $app) {
             /**
              * Validate the field value
              */
-            'validate' => function (Field $field, $value): int|float {
+            'validate' => function (Field $field, $value): int|float|null {
+                if (Constraint::isEmpty($value)) {
+                    return null;
+                }
+
                 if (!is_numeric($value)) {
                     throw new ValidationException(sprintf('Invalid value for field "%s" of type "%s"', $field->name(), $field->type()));
                 }

--- a/formwork/fields/page.php
+++ b/formwork/fields/page.php
@@ -5,6 +5,7 @@ use Formwork\Fields\Exceptions\ValidationException;
 use Formwork\Fields\Field;
 use Formwork\Pages\Page;
 use Formwork\Pages\PageCollection;
+use Formwork\Utils\Constraint;
 
 return function (Site $site) {
     return [
@@ -46,7 +47,7 @@ return function (Site $site) {
              * Validate the field value
              */
             'validate' => function (Field $field, $value) {
-                if ($value === '') {
+                if (Constraint::isEmpty($value)) {
                     return null;
                 }
 

--- a/formwork/fields/template.php
+++ b/formwork/fields/template.php
@@ -2,6 +2,7 @@
 
 use Formwork\Cms\Site;
 use Formwork\Fields\Field;
+use Formwork\Utils\Constraint;
 
 return function (Site $site) {
     return [
@@ -14,7 +15,7 @@ return function (Site $site) {
              * Validate the field value
              */
             'validate' => function (Field $field, $value) {
-                if ($value === '') {
+                if (Constraint::isEmpty($value)) {
                     return null;
                 }
 


### PR DESCRIPTION
This pull request introduces improvements to the validation logic for several field types by standardizing the handling of empty values. The main change is the use of the `Constraint::isEmpty()` utility to consistently check for empty field values, returning `null` when appropriate, and updating the return types of validation callbacks to allow `null`. This enhances code maintainability and ensures uniform validation behavior across different field types.

**Validation logic improvements:**

* Updated the `validate` callbacks in `color`, `duration`, and `number` field definitions to use `Constraint::isEmpty()` for checking empty values, and changed their return types to allow `null` when the value is empty. (`formwork/fields/color.php`, `formwork/fields/duration.php`, `formwork/fields/number.php`) [[1]](diffhunk://#diff-560d902c40b085b320a6cdeb67d8689410fbcf9ef93dddbbd4d5cd2f4d0a6439L14-R18) [[2]](diffhunk://#diff-62e8303a41389a459e964185d6994587395f9bcdeb6e8a5af221f9228768130eL35-R40) [[3]](diffhunk://#diff-119a48738ab72747225050e31df4d9ec809140652bbece08250bfa1144b42c4fL40-R45)
* Updated the `validate` callback in `page` and `template` field definitions to use `Constraint::isEmpty()` instead of a direct empty string comparison, improving consistency. (`formwork/fields/page.php`, `formwork/fields/template.php`) [[1]](diffhunk://#diff-f762fed1e958a87cb300148edb3ee1919e2db515418d680b5d6436af36c56637L49-R50) [[2]](diffhunk://#diff-50304881798dac4e2195391e820462919bd8b5d973145d0b87fc942b20b62e66L17-R18)

**Codebase consistency:**

* Added `use Formwork\Utils\Constraint;` to all affected field files to support the new validation logic. (`formwork/fields/duration.php`, `formwork/fields/number.php`, `formwork/fields/page.php`, `formwork/fields/template.php`) [[1]](diffhunk://#diff-62e8303a41389a459e964185d6994587395f9bcdeb6e8a5af221f9228768130eR6) [[2]](diffhunk://#diff-119a48738ab72747225050e31df4d9ec809140652bbece08250bfa1144b42c4fR6) [[3]](diffhunk://#diff-f762fed1e958a87cb300148edb3ee1919e2db515418d680b5d6436af36c56637R8) [[4]](diffhunk://#diff-50304881798dac4e2195391e820462919bd8b5d973145d0b87fc942b20b62e66R5)