### PR TITLE
Add `Arr::extend()`, `Arr::override()` and `Arr::exclude()` to handle data with more consistency

### DIFF
--- a/formwork/src/Config/Config.php
+++ b/formwork/src/Config/Config.php
@@ -138,7 +138,7 @@ class Config implements ArraySerializable
         }
 
         $key = $prefix !== null ? $prefix . '.' . $name : $name;
-        $this->config = array_replace_recursive($this->config, Arr::undot([$key => $data]));
+        $this->config = Arr::extend($this->config, Arr::undot([$key => $data]));
     }
 
     /**

--- a/formwork/src/Fields/FieldCollection.php
+++ b/formwork/src/Fields/FieldCollection.php
@@ -122,7 +122,7 @@ class FieldCollection extends AbstractCollection
      */
     public function setValuesFromRequest(Request $request, mixed $default = null): static
     {
-        return $this->setValues(array_merge_recursive(
+        return $this->setValues(Arr::extend(
             $request->query()->toArray(),
             $request->input()->toArray(),
             $request->files()->toArray()

--- a/formwork/src/Fields/FieldFactory.php
+++ b/formwork/src/Fields/FieldFactory.php
@@ -6,6 +6,7 @@ use Closure;
 use Formwork\Config\Config;
 use Formwork\Services\Container;
 use Formwork\Translations\Translations;
+use Formwork\Utils\Arr;
 use Formwork\Utils\FileSystem;
 use InvalidArgumentException;
 
@@ -42,7 +43,7 @@ final class FieldFactory
 
             unset($baseConfig['extend']);
 
-            $config = array_replace_recursive($baseConfig, $config);
+            $config = Arr::extend($baseConfig, $config);
         }
 
         $field->setMethods($config['methods'] ?? []);

--- a/formwork/src/Http/Client.php
+++ b/formwork/src/Http/Client.php
@@ -4,6 +4,7 @@ namespace Formwork\Http;
 
 use Formwork\Cms\App;
 use Formwork\Http\Exceptions\ConnectionException;
+use Formwork\Utils\Arr;
 use Formwork\Utils\FileSystem;
 use InvalidArgumentException;
 use RuntimeException;
@@ -41,7 +42,7 @@ class Client
             throw new RuntimeException(sprintf('Class %s requires "allow_url_fopen" to be enabled in PHP configuration', static::class));
         }
 
-        $this->options = array_replace_recursive($this->defaults(), $options);
+        $this->options = Arr::extend($this->defaults(), $options);
     }
 
     /**
@@ -138,7 +139,7 @@ class Client
             throw new InvalidArgumentException(sprintf('Cannot connect to "%s": invalid URI', $uri));
         }
 
-        $options = array_replace_recursive($this->options, $options);
+        $options = Arr::extend($this->options, $options);
 
         $options['headers'] = $this->normalizeHeaders($options['headers']);
 

--- a/formwork/src/Panel/Controllers/FilesController.php
+++ b/formwork/src/Panel/Controllers/FilesController.php
@@ -356,20 +356,10 @@ final class FilesController extends AbstractController
      */
     private function updateFileMetadata(File $file, FieldCollection $fieldCollection): void
     {
-        $data = $file->data();
-
-        $scheme = $file->scheme();
-
-        $defaults = $scheme->fields()->extract('default');
-
-        foreach ($fieldCollection as $field) {
-            if ($field->isEmpty() || (Arr::has($defaults, $field->name()) && Arr::get($defaults, $field->name()) === $field->value())) {
-                unset($data[$field->name()]);
-                continue;
-            }
-
-            $data[$field->name()] = $field->value();
-        }
+        $data = Arr::exclude(
+            Arr::override($file->data(), Arr::undot($fieldCollection->extract('value'))),
+            Arr::undot($file->fields()->extract('default'))
+        );
 
         $metaFile = $file->path() . $this->config->get('system.files.metadataExtension');
 

--- a/formwork/src/Panel/Controllers/PagesController.php
+++ b/formwork/src/Panel/Controllers/PagesController.php
@@ -596,7 +596,7 @@ final class PagesController extends AbstractController
         // Extract validated values from remaining fields (upload fields have been removed)
         // These are the user's submitted values that were validated earlier
         /** @var array<string, mixed> */
-        $data = [...$fieldCollection->everyItem()->value()->toArray(), 'slug' => $requestData->get('slug')];
+        $data = [...$fieldCollection->extract('value'), 'slug' => $requestData->get('slug')];
 
         $page->setMultiple($data);
         $page->save($requestData->get('language'));

--- a/formwork/src/Schemes/Scheme.php
+++ b/formwork/src/Schemes/Scheme.php
@@ -122,7 +122,7 @@ class Scheme implements Arrayable
             throw new InvalidArgumentException(sprintf('Scheme "%s" cannot be extended by itself', $this->id));
         }
 
-        $this->data = array_replace_recursive($scheme->data, $this->data);
+        $this->data = Arr::extend($scheme->data, $this->data);
     }
 
     /**
@@ -132,7 +132,7 @@ class Scheme implements Arrayable
      */
     public function extendWith(array $data): void
     {
-        $this->data = array_replace_recursive($data, $this->data);
+        $this->data = Arr::extend($data, $this->data);
     }
 
     /**

--- a/formwork/src/Users/User.php
+++ b/formwork/src/Users/User.php
@@ -65,8 +65,7 @@ class User extends Model
         $this->fields = $this->scheme->fields();
         $this->fields->setModel($this);
 
-        // Use `array_replace()` instead of `array_replace_recursive()` to avoid overwriting array values
-        $this->data = array_replace($this->defaults, Arr::undot($data));
+        $this->data = Arr::override($this->defaults, Arr::undot($data));
 
         $this->fields->setValues($this->data);
     }


### PR DESCRIPTION
This pull request introduces new array utility methods (`extend`, `override`, and `exclude`) in `Arr` and refactors core logic throughout the codebase to use these methods instead of PHP's built-in array merging functions. These changes improve the handling of array merges, overrides, and exclusions, especially for nested and list arrays, resulting in more predictable and maintainable configuration and data management. The refactor affects configuration loading, field value management, HTTP client options, page and user data, and panel controllers.

### Array utility improvements

* Added `Arr::extend`, `Arr::override`, and `Arr::exclude` methods to provide more robust and predictable array merging, overriding, and exclusion behaviors, especially for nested associative arrays and lists. (`formwork/src/Utils/Arr.php`)

### Refactoring core merges and overrides

* Replaced usages of `array_replace_recursive` and `array_replace` with `Arr::extend` and `Arr::override` in configuration loading (`Config.php`), field factories (`FieldFactory.php`), HTTP client (`Client.php`), scheme extension (`Scheme.php`), and user/page data construction (`User.php`, `Page.php`). This ensures more accurate merging of configuration and data arrays. [[1]](diffhunk://#diff-ef1adb6401c6e94d15be64e0f144854bf66a500dcbcfe9dd81f298d80c35f5c9L141-R141) [[2]](diffhunk://#diff-ba4808952762bc10efadaaa13b0a483d416d6f93f816dd0d84cc63164d94d901L45-R46) [[3]](diffhunk://#diff-c185bc74f73897bf878af078d7d5875ecec6017e7c9fbb8ebcb24f196bb66e28L44-R45) [[4]](diffhunk://#diff-c185bc74f73897bf878af078d7d5875ecec6017e7c9fbb8ebcb24f196bb66e28L141-R142) [[5]](diffhunk://#diff-2c7c183c0202d1ef690a9d47d1d966600a420fae4cae3933ce0e986c16f0e6e0L125-R125) [[6]](diffhunk://#diff-2c7c183c0202d1ef690a9d47d1d966600a420fae4cae3933ce0e986c16f0e6e0L135-R135) [[7]](diffhunk://#diff-35cdd84261e3cf9c8030f7c559e761ab878d48dc43059efa3f2421673645df7aL68-R68) [[8]](diffhunk://#diff-41cde3f613679dfb74ed037d6b61206fb870d9a5118bf4810073330493ec2b70L835-R838)

### Improved exclusion of default values

* Introduced the use of `Arr::exclude` to remove default values from data arrays, notably in page frontmatter and file metadata, streamlining how defaults are omitted when saving or updating. [[1]](diffhunk://#diff-41cde3f613679dfb74ed037d6b61206fb870d9a5118bf4810073330493ec2b70L966-R969) [[2]](diffhunk://#diff-a4b5c8cd62ba47fc29ea8cd6e3249e26cd8c01753906191811e59a6603587abcL359-R362)

### Panel controller enhancements

* Refactored options and file metadata update logic in panel controllers to use the new array utilities, improving how upload fields are handled and how option updates exclude defaults and empty arrays. [[1]](diffhunk://#diff-42b973d64c5b91ea7e7067d79b0b65f863a3a7087cf9251de4ce7d5462405cb7L178-R186) [[2]](diffhunk://#diff-42b973d64c5b91ea7e7067d79b0b65f863a3a7087cf9251de4ce7d5462405cb7L201-R219) [[3]](diffhunk://#diff-42b973d64c5b91ea7e7067d79b0b65f863a3a7087cf9251de4ce7d5462405cb7R67-R68) [[4]](diffhunk://#diff-42b973d64c5b91ea7e7067d79b0b65f863a3a7087cf9251de4ce7d5462405cb7R127-R128) [[5]](diffhunk://#diff-c8b238be663183da229ed13ae8e0602420592d770a9c16e71b8987712713b719L599-R599)

### Miscellaneous improvements

* Updated imports to include the new `Arr` utility where needed. [[1]](diffhunk://#diff-ba4808952762bc10efadaaa13b0a483d416d6f93f816dd0d84cc63164d94d901R9) [[2]](diffhunk://#diff-c185bc74f73897bf878af078d7d5875ecec6017e7c9fbb8ebcb24f196bb66e28R7)

These changes make array operations throughout the codebase more consistent and reliable, especially when dealing with deeply nested configuration and data structures.