### PR TITLE
Add default values support to field configs

### DIFF
--- a/formwork/fields/array.php
+++ b/formwork/fields/array.php
@@ -12,6 +12,8 @@ use Formwork\Utils\Str;
 
 return function (App $app, FieldFactory $fieldFactory): array {
     return [
+        'default' => [],
+
         'methods' => [
             /**
              * Return whether the field is associative

--- a/formwork/fields/checkbox.php
+++ b/formwork/fields/checkbox.php
@@ -7,6 +7,8 @@ use Formwork\Utils\Constraint;
 
 return function (App $app) {
     return [
+        'default' => false,
+
         'methods' => [
             /**
              * Validate the field value

--- a/formwork/fields/files.php
+++ b/formwork/fields/files.php
@@ -11,6 +11,8 @@ use Formwork\Utils\Constraint;
 
 return function (App $app) {
     return [
+        'default' => [],
+
         'methods' => [
             /**
              * Get the collection of files associated with the field

--- a/formwork/fields/images.php
+++ b/formwork/fields/images.php
@@ -11,6 +11,8 @@ use Formwork\Utils\Constraint;
 
 return function (App $app) {
     return [
+        'default' => [],
+
         'methods' => [
             /**
              * Get the collection of images associated with the field

--- a/formwork/fields/select.php
+++ b/formwork/fields/select.php
@@ -8,6 +8,8 @@ use Formwork\Utils\Constraint;
 
 return function (App $app) {
     return [
+        'default' => '',
+
         'methods' => [
             /**
              * Get the field dropdown options

--- a/formwork/fields/slug.php
+++ b/formwork/fields/slug.php
@@ -8,6 +8,8 @@ use Formwork\Utils\Constraint;
 
 return function (App $app) {
     return [
+        'default' => '',
+
         'methods' => [
             /**
              * Validate the field value

--- a/formwork/fields/tags.php
+++ b/formwork/fields/tags.php
@@ -9,6 +9,8 @@ use Formwork\Utils\Constraint;
 
 return function (App $app) {
     return [
+        'default' => [],
+
         'methods' => [
             'toString' => function ($field) {
                 return implode(', ', $field->value() ?? []);

--- a/formwork/fields/text.php
+++ b/formwork/fields/text.php
@@ -7,6 +7,8 @@ use Formwork\Utils\Constraint;
 
 return function (App $app) {
     return [
+        'default' => '',
+
         'methods' => [
             /**
              * Return the minimum allowed length for the field

--- a/formwork/fields/textarea.php
+++ b/formwork/fields/textarea.php
@@ -7,6 +7,8 @@ use Formwork\Utils\Constraint;
 
 return function (App $app) {
     return [
+        'default' => '',
+
         'methods' => [
             /**
              * Return the minimum allowed length for the field

--- a/formwork/src/Fields/FieldFactory.php
+++ b/formwork/src/Fields/FieldFactory.php
@@ -46,15 +46,20 @@ final class FieldFactory
             $config = Arr::extend($baseConfig, $config);
         }
 
+        // Set a default if defined in the config and not already set in the field data
+        if (!$field->has('default') && array_key_exists('default', $config)) {
+            $field->set('default', $config['default']);
+        }
+
         $field->setMethods($config['methods'] ?? []);
 
         return $field;
     }
 
     /**
-     * @param array{extend?: string, methods?: array<string, Closure>} $default
+     * @param array{extend?: string, default?: mixed, methods?: array<string, Closure>} $default
      *
-     * @return array{extend?: string, methods?: array<string, Closure>}
+     * @return array{extend?: string, default?: mixed, methods?: array<string, Closure>}
      */
     private function getFieldConfig(string $type, ?array $default = null): array
     {


### PR DESCRIPTION
This pull request adds support for specifying default values for various field types in the form system. Default values are now defined in the configuration for each field type and are automatically set during field creation if not already provided. This improves consistency and reduces the need for manual default value handling across the codebase.

**Default value support for fields:**

* Added a `default` value to the configuration arrays for the following field types: `array`, `checkbox`, `files`, `images`, `select`, `slug`, `tags`, `text`, and `textarea` (`formwork/fields/array.php` [[1]](diffhunk://#diff-2baac558075b7e4228bd8d6d210cf481840be8c5d3709c8b852473c9e310b432R15-R16) `formwork/fields/checkbox.php` [[2]](diffhunk://#diff-567dac7d19f140bfd66501745f425603d36b4295fabaae7e7a8c6d2ac6b7e499R10-R11) `formwork/fields/files.php` [[3]](diffhunk://#diff-f14d7c8a9ceee3f80f607ff7d486b5aa0e89fcf883e9df3692ea6f2f824c7b9fR14-R15) `formwork/fields/images.php` [[4]](diffhunk://#diff-c7acdadfe5b41852883283bf8810825763021898d402ba5a6df877e6b3479720R14-R15) `formwork/fields/select.php` [[5]](diffhunk://#diff-18be6afe43779bc0ae77b98ef7ac757b448cdcc247c99d8975c7b9bf607d7c8bR11-R12) `formwork/fields/slug.php` [[6]](diffhunk://#diff-82831fa1652e48fa2e3fdbeb90770e11469b444c50f684568715a0ba3b77fe1bR11-R12) `formwork/fields/tags.php` [[7]](diffhunk://#diff-b3d418a535709fea98ec2c8e22bd42fd754fcc364073212b742014de7689b06fR12-R13) `formwork/fields/text.php` [[8]](diffhunk://#diff-5e79403bf6c677ddbf6c84bb97a8e7dc28ab09469d5e15168efadb866c216f50R10-R11) `formwork/fields/textarea.php` [[9]](diffhunk://#diff-b040d85ec711af8511bf2f2d694c71bf966b14744778b720e026dc2c619c6109R10-R11).

**Field factory enhancements:**

* Updated the `FieldFactory::make` method to automatically set the `default` value from the field configuration if it exists and is not already set in the field data (`formwork/src/Fields/FieldFactory.php` [formwork/src/Fields/FieldFactory.phpR49-R62](diffhunk://#diff-ba4808952762bc10efadaaa13b0a483d416d6f93f816dd0d84cc63164d94d901R49-R62)).
* Updated the type annotations for configuration arrays in `FieldFactory` to include the new `default` key (`formwork/src/Fields/FieldFactory.php` [formwork/src/Fields/FieldFactory.phpR49-R62](diffhunk://#diff-ba4808952762bc10efadaaa13b0a483d416d6f93f816dd0d84cc63164d94d901R49-R62)).