### PR TITLE
Fix HTTP Range handling for file responses (RFC 7233–compliance and Safari compatibility)

### DIFF
--- a/formwork/src/Http/FileResponse.php
+++ b/formwork/src/Http/FileResponse.php
@@ -111,6 +111,11 @@ class FileResponse extends Response
 
         parent::prepare($request);
 
+        if ($this->requiresEmptyContent()) {
+            $this->length = 0;
+            return $this;
+        }
+
         if (in_array($request->method(), [RequestMethod::HEAD, RequestMethod::GET], true)) {
             if (!$this->headers->has('Accept-Ranges')) {
                 $this->headers->set('Accept-Ranges', 'bytes');
@@ -142,7 +147,7 @@ class FileResponse extends Response
             }
         }
 
-        if ($request->method() === RequestMethod::HEAD || $this->requiresEmptyContent()) {
+        if ($request->method() === RequestMethod::HEAD) {
             $this->length = 0;
         }
 

--- a/formwork/src/Http/FileResponse.php
+++ b/formwork/src/Http/FileResponse.php
@@ -124,6 +124,11 @@ class FileResponse extends Response
             if (preg_match('/^bytes=(\d+)?-(\d+)?$/', $request->headers()->get('Range', ''), $matches, PREG_UNMATCHED_AS_NULL)) {
                 [, $start, $end] = $matches;
 
+                // RFC 7233: ignore invalid "bytes=-"
+                if ($start === null && $end === null) {
+                    return $this;
+                }
+
                 if ($start === null) {
                     $start = max(0, $this->fileSize - (int) $end);
                     $end = $this->fileSize - 1;


### PR DESCRIPTION
This pull request refines the handling of HTTP file responses, particularly for range requests and HEAD requests in the `FileResponse` class. The changes improve standards compliance and ensure correct header and content length handling for various request scenarios.

**Improvements to HTTP range and HEAD request handling:**

* Refactored the logic in `prepare()` to always set the `Accept-Ranges` header for GET and HEAD requests, regardless of whether it was previously set.
* Improved parsing and handling of the `Range` header by ensuring range logic is only applied to GET requests and that the `Content-Length` header is set to `0` for unsatisfiable ranges. [[1]](diffhunk://#diff-75e767f2c3ee62d7b67083368f58411675b5acbc64711ef524b75e723a2d6903L114-R119) [[2]](diffhunk://#diff-75e767f2c3ee62d7b67083368f58411675b5acbc64711ef524b75e723a2d6903R135-R147)
* Moved the logic for setting `$this->length = 0` for HEAD requests and empty content to the end of the method, ensuring that content length is always correct for these cases.

**File streaming optimization:**

* Updated the file streaming loop to avoid reading more bytes than necessary by adjusting the chunk size to the remaining length, preventing over-reading.