### PR TITLE
Add `User::save()`, `User::delete()` and `User::deleteImage()`

### DIFF
--- a/formwork/src/Panel/Controllers/UsersController.php
+++ b/formwork/src/Panel/Controllers/UsersController.php
@@ -269,7 +269,7 @@ final class UsersController extends AbstractController
         }
 
         // Ensure that user role can be changed
-        if ($formData->has('role') && $formData->get('role') !== $user->role() && !$this->panel->user()->canChangeRoleOf($user)) {
+        if ($formData->has('role') && $formData->get('role') !== $user->role()->id() && !$this->panel->user()->canChangeRoleOf($user)) {
             throw new TranslatedException(sprintf('Cannot change the role of %s', $user->username()), 'panel.users.user.cannotChangeRole');
         }
 

--- a/formwork/src/Panel/Controllers/UsersController.php
+++ b/formwork/src/Panel/Controllers/UsersController.php
@@ -67,8 +67,13 @@ final class UsersController extends AbstractController
 
         $user = $userFactory->make([]);
 
-        $user->setMultiple($form->data()->toArray());
-        $user->save();
+        try {
+            $user->setMultiple($form->data()->toArray());
+            $user->save();
+        } catch (TranslatedException $e) {
+            $this->panel->notify($this->translate($e->getLanguageString()), 'error');
+            return $this->redirectToReferer(default: $this->generateRoute('panel.users'), base: $this->panel->panelRoot());
+        }
 
         $this->panel->notify($this->translate('panel.users.user.created'), 'success');
         return $this->redirect($this->generateRoute('panel.users'));

--- a/formwork/src/Panel/Controllers/UsersController.php
+++ b/formwork/src/Panel/Controllers/UsersController.php
@@ -2,6 +2,7 @@
 
 namespace Formwork\Panel\Controllers;
 
+use Formwork\Data\Exceptions\InvalidValueException;
 use Formwork\Exceptions\TranslatedException;
 use Formwork\Fields\Field;
 use Formwork\Forms\FormData;
@@ -72,6 +73,10 @@ final class UsersController extends AbstractController
             $user->save();
         } catch (TranslatedException $e) {
             $this->panel->notify($this->translate($e->getLanguageString()), 'error');
+            return $this->redirectToReferer(default: $this->generateRoute('panel.users'), base: $this->panel->panelRoot());
+        } catch (InvalidValueException $e) {
+            $identifier = $e->getIdentifier() ?? 'invalidFields';
+            $this->panel->notify($this->translate('panel.users.user.cannotCreate.' . $identifier), 'error');
             return $this->redirectToReferer(default: $this->generateRoute('panel.users'), base: $this->panel->panelRoot());
         }
 
@@ -201,6 +206,9 @@ final class UsersController extends AbstractController
                     $this->panel->notify($this->translate('panel.users.user.edited'), 'success');
                 } catch (TranslatedException $e) {
                     $this->panel->notify($this->translate($e->getLanguageString(), $user->username()), 'error');
+                } catch (InvalidValueException $e) {
+                    $identifier = $e->getIdentifier() ?? 'invalidFields';
+                    $this->panel->notify($this->translate('panel.users.user.cannotEdit.' . $identifier), 'error');
                 }
             }
 

--- a/formwork/src/Services/Loaders/UsersServiceLoader.php
+++ b/formwork/src/Services/Loaders/UsersServiceLoader.php
@@ -5,7 +5,7 @@ namespace Formwork\Services\Loaders;
 use Formwork\Config\Config;
 use Formwork\Parsers\Yaml;
 use Formwork\Services\Container;
-use Formwork\Services\ServiceLoaderInterface;
+use Formwork\Services\ResolutionAwareServiceLoaderInterface;
 use Formwork\Translations\Translations;
 use Formwork\Users\Permissions;
 use Formwork\Users\Role;
@@ -14,7 +14,7 @@ use Formwork\Users\UserFactory;
 use Formwork\Users\Users;
 use Formwork\Utils\FileSystem;
 
-final class UsersServiceLoader implements ServiceLoaderInterface
+final class UsersServiceLoader implements ResolutionAwareServiceLoaderInterface
 {
     private RoleCollection $roleCollection;
 
@@ -28,14 +28,17 @@ final class UsersServiceLoader implements ServiceLoaderInterface
 
     public function load(Container $container): Users
     {
+        return $this->users = new Users([], $this->roleCollection = new RoleCollection());
+    }
+
+    public function onResolved(object $service, Container $container): void
+    {
         $this->loadRoles();
         $this->loadUsers();
-        return $this->users;
     }
 
     private function loadRoles(): void
     {
-        $this->roleCollection = new RoleCollection();
         foreach (FileSystem::listFiles($path = $this->config->get('system.users.paths.roles')) as $file) {
             /**
              * @var array{title: string, permissions?: array<string, bool>}
@@ -49,15 +52,13 @@ final class UsersServiceLoader implements ServiceLoaderInterface
 
     private function loadUsers(): void
     {
-        $this->users = new Users([], $this->roleCollection);
         foreach (FileSystem::listFiles($path = $this->config->get('system.users.paths.accounts')) as $file) {
             /**
              * @var array{username: string, fullname: string, hash: string, email: string, language: string, role?: string, image?: string, colorScheme?: string}
              */
             $data = Yaml::parseFile(FileSystem::joinPaths($path, $file));
-            $role = $this->roleCollection->get($data['role'] ?? 'user');
             $username = $data['username'];
-            $this->users->set($username, $this->userFactory->make($data, $role));
+            $this->users->set($username, $this->userFactory->make($data));
         }
     }
 }

--- a/formwork/src/Users/User.php
+++ b/formwork/src/Users/User.php
@@ -353,7 +353,7 @@ class User extends Model
         }
 
         // Delete old image if exists
-        if ($this->image() !== null) {
+        if ($this->image() !== null && ($image === null || $image !== $this->image()->name())) {
             $this->deleteImageFile();
         }
 

--- a/formwork/src/Users/User.php
+++ b/formwork/src/Users/User.php
@@ -233,6 +233,17 @@ class User extends Model
         return $this->lastAccess = $registry->has($this->username()) ? (int) $registry->get($this->username()) : null;
     }
 
+    /**
+     * Set a data value by key
+     *
+     * When setting the `email` key, the value is validated before being stored.
+     * When setting the `password` key, the password is hashed and the plain value
+     * is not stored in the internal data array.
+     *
+     * This method updates both the data array and the corresponding field
+     * (if it exists). The field's validation may transform the value before
+     * it's stored in the data array.
+     */
     public function set(string $key, mixed $value): void
     {
         if ($key === 'email') {

--- a/formwork/src/Users/User.php
+++ b/formwork/src/Users/User.php
@@ -3,23 +3,30 @@
 namespace Formwork\Users;
 
 use Formwork\Config\Config;
+use Formwork\Data\Exceptions\InvalidValueException;
+use Formwork\Exceptions\TranslatedException;
 use Formwork\Files\FileFactory;
 use Formwork\Http\Request;
 use Formwork\Images\Image;
 use Formwork\Log\Registry;
 use Formwork\Model\Model;
-use Formwork\Panel\Security\Password;
+use Formwork\Parsers\Yaml;
 use Formwork\Schemes\Schemes;
 use Formwork\Users\Exceptions\AuthenticationFailedException;
 use Formwork\Users\Exceptions\UserImageNotFoundException;
 use Formwork\Users\Exceptions\UserNotLoggedException;
+use Formwork\Users\Utils\Password;
 use Formwork\Utils\Arr;
 use Formwork\Utils\FileSystem;
+use Formwork\Utils\Str;
+use LogicException;
 use SensitiveParameter;
 
 class User extends Model
 {
     public const string SESSION_LOGGED_USER_KEY = '_formwork_logged_user';
+
+    public const int MINIMUM_PASSWORD_LENGTH = 8;
 
     protected const string MODEL_IDENTIFIER = 'user';
 
@@ -54,20 +61,15 @@ class User extends Model
      */
     public function __construct(
         array $data,
-        protected Role $role,
         protected Schemes $schemes,
         protected Config $config,
         protected Request $request,
         protected FileFactory $fileFactory,
+        protected Users $users,
     ) {
-        $this->scheme = $this->schemes->get('users.user');
-
-        $this->fields = $this->scheme->fields();
-        $this->fields->setModel($this);
-
         $this->data = Arr::override($this->defaults, Arr::undot($data));
 
-        $this->fields->setValues($this->data);
+        $this->load();
     }
 
     public function __debugInfo(): array
@@ -89,7 +91,7 @@ class User extends Model
             return $this->image;
         }
 
-        $path = FileSystem::joinPaths($this->config->get('system.users.paths.images'), (string) $this->data['image']);
+        $path = FileSystem::joinPaths($this->config->get('system.users.paths.images'), (string) ($this->data['image'] ?? null));
 
         if (!FileSystem::isFile($path, assertExists: false)) {
             return $this->image = null;
@@ -109,7 +111,7 @@ class User extends Model
      */
     public function role(): Role
     {
-        return $this->role;
+        return $this->users->roles()->get($this->data['role']);
     }
 
     /**
@@ -125,7 +127,7 @@ class User extends Model
      */
     public function permissions(): Permissions
     {
-        return $this->role->permissions();
+        return $this->role()->permissions();
     }
 
     /**
@@ -229,5 +231,127 @@ class User extends Model
         }
         $registry = new Registry(FileSystem::joinPaths($this->config->get('system.panel.paths.logs'), 'lastAccess.json'));
         return $this->lastAccess = $registry->has($this->username()) ? (int) $registry->get($this->username()) : null;
+    }
+
+    public function set(string $key, mixed $value): void
+    {
+        if ($key === 'email') {
+            $this->validateEmail((string) $value);
+        } elseif ($key === 'password') {
+            $this->setPasswordHash((string) $value);
+
+            // Do not store plain password in data array
+            return;
+        }
+
+        parent::set($key, $value);
+    }
+
+    /**
+     * Save user data to file
+     */
+    public function save(): void
+    {
+        Yaml::encodeToFile($this->data, FileSystem::joinPaths($this->config->get('system.users.paths.accounts'), $this->username() . '.yaml'));
+    }
+
+    /**
+     * Delete the user account file and image
+     */
+    public function delete(): void
+    {
+        // Delete user file
+        FileSystem::delete(FileSystem::joinPaths($this->config->get('system.users.paths.accounts'), $this->username() . '.yaml'));
+
+        // Delete user image if exists
+        if ($this->image() !== null) {
+            $this->deleteImage();
+        }
+    }
+
+    /**
+     * Delete the user image
+     *
+     * @throws TranslatedException If the user has no image
+     */
+    public function deleteImage(): void
+    {
+        if ($this->image() === null) {
+            throw new TranslatedException('Cannot delete default user image', 'panel.user.image.cannotDelete.defaultImage');
+        }
+
+        $path = $this->image()->path();
+
+        if (FileSystem::isFile($path, assertExists: false)) {
+            FileSystem::delete($path);
+        }
+
+        Arr::remove($this->data, 'image');
+        $this->save();
+    }
+
+    /**
+     * Load user scheme and fields
+     */
+    protected function load(): void
+    {
+        $this->scheme = $this->schemes->get('users.user');
+
+        $this->fields = $this->scheme->fields();
+        $this->fields->setModel($this);
+
+        $this->fields->setValues($this->data);
+    }
+
+    /**
+     * Set user image
+     */
+    protected function setImage(string|Image|null $image): void
+    {
+        if ($image instanceof Image) {
+            $imagesPath = FileSystem::joinPaths($this->config->get('system.users.paths.images'));
+
+            if (!Str::startsWith($image->path(), $imagesPath)) {
+                throw new LogicException('User image must be located in the user images directory');
+            }
+
+            $image = $image->name();
+        }
+
+        // Delete old image if exists
+        if ($this->image() !== null) {
+            $this->deleteImage();
+        }
+
+        Arr::set($this->data, 'image', $image);
+    }
+
+    /**
+     * Validate user email
+     *
+     * @throws TranslatedException   If email is already used by another user
+     * @throws InvalidValueException If the e-mail address is not valid
+     */
+    protected function validateEmail(string $email): void
+    {
+        if ($email !== $this->email() && $this->users->some(fn(User $user) => $user->email() === $email)) {
+            throw new TranslatedException(sprintf('Cannot change the email of %s, the address is already used', $this->username()), 'panel.users.user.cannotChangeEmail.alreadyUsed');
+        }
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new InvalidValueException(sprintf('Invalid e-mail address "%s"', $email));
+        }
+    }
+
+    /**
+     * Set user password hash
+     *
+     * @throws InvalidValueException If the password is too short
+     */
+    protected function setPasswordHash(string $password): void
+    {
+        if (strlen($password) < self::MINIMUM_PASSWORD_LENGTH) {
+            throw new InvalidValueException(sprintf('Password must be at least %d characters long', self::MINIMUM_PASSWORD_LENGTH));
+        }
+        Arr::set($this->data, 'hash', Password::hash($password));
     }
 }

--- a/formwork/src/Users/User.php
+++ b/formwork/src/Users/User.php
@@ -276,7 +276,7 @@ class User extends Model
 
         // Delete user image if exists
         if ($this->image() !== null) {
-            $this->deleteImage();
+            $this->deleteImageFile();
         }
     }
 
@@ -287,15 +287,7 @@ class User extends Model
      */
     public function deleteImage(): void
     {
-        if ($this->image() === null) {
-            throw new TranslatedException('Cannot delete default user image', 'panel.user.image.cannotDelete.defaultImage');
-        }
-
-        $path = $this->image()->path();
-
-        if (FileSystem::isFile($path, assertExists: false)) {
-            FileSystem::delete($path);
-        }
+        $this->deleteImageFile();
 
         Arr::remove($this->data, 'image');
         $this->save();
@@ -331,10 +323,28 @@ class User extends Model
 
         // Delete old image if exists
         if ($this->image() !== null) {
-            $this->deleteImage();
+            $this->deleteImageFile();
         }
 
         Arr::set($this->data, 'image', $image);
+    }
+
+    /**
+     * Delete the user image file
+     *
+     * @throws TranslatedException If the user has no image
+     */
+    protected function deleteImageFile(): void
+    {
+        if ($this->image() === null) {
+            throw new TranslatedException('Cannot delete default user image', 'panel.user.image.cannotDelete.defaultImage');
+        }
+
+        $path = $this->image()->path();
+
+        if (FileSystem::isFile($path, assertExists: false)) {
+            FileSystem::delete($path);
+        }
     }
 
     /**

--- a/formwork/src/Users/User.php
+++ b/formwork/src/Users/User.php
@@ -114,7 +114,14 @@ class User extends Model
         if (!isset($this->data['role'])) {
             throw new LogicException(sprintf('User "%s" has no role assigned', $this->username()));
         }
-        return $this->users->roles()->get($this->data['role']);
+
+        $role = $this->data['role'];
+
+        if (!$this->users->roles()->has($role)) {
+            throw new LogicException(sprintf('User "%s" has an invalid role assigned: "%s"', $this->username(), $role));
+        }
+
+        return $this->users->roles()->get($role);
     }
 
     /**

--- a/formwork/src/Users/User.php
+++ b/formwork/src/Users/User.php
@@ -111,6 +111,9 @@ class User extends Model
      */
     public function role(): Role
     {
+        if (!isset($this->data['role'])) {
+            throw new LogicException(sprintf('User "%s" has no role assigned', $this->username()));
+        }
         return $this->users->roles()->get($this->data['role']);
     }
 

--- a/formwork/src/Users/User.php
+++ b/formwork/src/Users/User.php
@@ -236,8 +236,10 @@ class User extends Model
     /**
      * Set a data value by key
      *
-     * When setting the `email` key, the value is validated before being stored.
-     * When setting the `password` key, the password is hashed and the plain value
+     * * When setting the `username` key, an exception is thrown if the user
+     * already has a username assigned.
+     * * When setting the `email` key, the value is validated before being stored.
+     * * When setting the `password` key, the password is hashed and the plain value
      * is not stored in the internal data array.
      *
      * This method updates both the data array and the corresponding field
@@ -246,6 +248,10 @@ class User extends Model
      */
     public function set(string $key, mixed $value): void
     {
+        if ($key === 'username' && $this->get('username') !== null) {
+            throw new LogicException('Cannot change username of an existing user');
+        }
+
         if ($key === 'email') {
             $this->validateEmail((string) $value);
         } elseif ($key === 'password') {

--- a/formwork/src/Users/User.php
+++ b/formwork/src/Users/User.php
@@ -291,6 +291,10 @@ class User extends Model
      */
     public function delete(): void
     {
+        if ($this->username() === null) {
+            throw new LogicException('Cannot delete a user with no username assigned');
+        }
+
         // Delete user file
         FileSystem::delete(FileSystem::joinPaths($this->config->get('system.users.paths.accounts'), $this->username() . '.yaml'));
 

--- a/formwork/src/Users/UserCollection.php
+++ b/formwork/src/Users/UserCollection.php
@@ -23,7 +23,15 @@ class UserCollection extends AbstractCollection
     }
 
     /**
-     * Get all available roles
+     * Get roles collection
+     */
+    public function roles(): RoleCollection
+    {
+        return $this->roleCollection;
+    }
+
+    /**
+     * Get all available roles as an array of role titles
      *
      * @return array<string, string>
      */

--- a/formwork/src/Users/UserFactory.php
+++ b/formwork/src/Users/UserFactory.php
@@ -15,8 +15,8 @@ final class UserFactory
      *
      * @param array<string, mixed> $data
      */
-    public function make(array $data, Role $role): User
+    public function make(array $data): User
     {
-        return $this->container->build(User::class, compact('data', 'role'));
+        return $this->container->build(User::class, compact('data'));
     }
 }

--- a/formwork/src/Users/Utils/Password.php
+++ b/formwork/src/Users/Utils/Password.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Formwork\Panel\Security;
+namespace Formwork\Users\Utils;
 
 use Formwork\Traits\StaticClass;
 


### PR DESCRIPTION
This pull request refactors user management in the Panel by introducing a `UserFactory` for user creation and centralizing user data handling within the `User` model. The changes improve code maintainability, encapsulate user-related logic, and standardize how user data is persisted and manipulated. Key changes include updating controllers to use the factory and new model methods, simplifying user creation, update, and deletion, and updating the user service loader to support these changes.

**User management refactoring:**

* Controllers now use `UserFactory` to create users and rely on `User` model methods (`setMultiple`, `save`, `delete`, `deleteImage`) for all user data operations, removing direct YAML file manipulation and password hashing from controllers. [[1]](diffhunk://#diff-b018aa2f351e50f43b3157560e4443f5489a8ebf618a839b35e6d143a8dc72daL9-R19) [[2]](diffhunk://#diff-b018aa2f351e50f43b3157560e4443f5489a8ebf618a839b35e6d143a8dc72daL47-R58) [[3]](diffhunk://#diff-c6321e6321f67eb62e7ae1130dc2b6a548fb9c5020bb178f7b9c9b319a7d46beL13-R15) [[4]](diffhunk://#diff-c6321e6321f67eb62e7ae1130dc2b6a548fb9c5020bb178f7b9c9b319a7d46beL40-R38) [[5]](diffhunk://#diff-c6321e6321f67eb62e7ae1130dc2b6a548fb9c5020bb178f7b9c9b319a7d46beL56-R71) [[6]](diffhunk://#diff-c6321e6321f67eb62e7ae1130dc2b6a548fb9c5020bb178f7b9c9b319a7d46beL108-R99) [[7]](diffhunk://#diff-c6321e6321f67eb62e7ae1130dc2b6a548fb9c5020bb178f7b9c9b319a7d46beL145-R132)
* The user update logic is moved into the `User` model, with controllers calling `setMultiple` and `save` instead of manually updating YAML files. The `updateUser` and image upload/delete logic in `UsersController` are simplified accordingly. [[1]](diffhunk://#diff-c6321e6321f67eb62e7ae1130dc2b6a548fb9c5020bb178f7b9c9b319a7d46beL207-R192) [[2]](diffhunk://#diff-c6321e6321f67eb62e7ae1130dc2b6a548fb9c5020bb178f7b9c9b319a7d46beL245-R230) [[3]](diffhunk://#diff-c6321e6321f67eb62e7ae1130dc2b6a548fb9c5020bb178f7b9c9b319a7d46beL320-R284)

**User model and factory improvements:**

* The `User` model now loads its data, role, and permissions internally, removing the need to pass a `Role` object to the constructor. The model accesses the roles collection via the `Users` service. [[1]](diffhunk://#diff-35cdd84261e3cf9c8030f7c559e761ab878d48dc43059efa3f2421673645df7aL57-R72) [[2]](diffhunk://#diff-35cdd84261e3cf9c8030f7c559e761ab878d48dc43059efa3f2421673645df7aL112-R114) [[3]](diffhunk://#diff-35cdd84261e3cf9c8030f7c559e761ab878d48dc43059efa3f2421673645df7aL128-R130)
* The `User` model provides new methods for deleting users and images, and for setting multiple fields at once, encapsulating all persistence logic. [[1]](diffhunk://#diff-c6321e6321f67eb62e7ae1130dc2b6a548fb9c5020bb178f7b9c9b319a7d46beL108-R99) [[2]](diffhunk://#diff-c6321e6321f67eb62e7ae1130dc2b6a548fb9c5020bb178f7b9c9b319a7d46beL145-R132) [[3]](diffhunk://#diff-c6321e6321f67eb62e7ae1130dc2b6a548fb9c5020bb178f7b9c9b319a7d46beL207-R192) [[4]](diffhunk://#diff-c6321e6321f67eb62e7ae1130dc2b6a548fb9c5020bb178f7b9c9b319a7d46beL320-R284)

**Service loader updates:**

* The `UsersServiceLoader` now implements `ResolutionAwareServiceLoaderInterface` and loads roles and users in the `onResolved` method. Users are created via the `UserFactory`, which now handles role assignment internally. [[1]](diffhunk://#diff-5c3300b5dbc2c7d568fd56e96ad41b2c96b54da305e3632c5ca70bb894225f7bL8-R8) [[2]](diffhunk://#diff-5c3300b5dbc2c7d568fd56e96ad41b2c96b54da305e3632c5ca70bb894225f7bL17-R17) [[3]](diffhunk://#diff-5c3300b5dbc2c7d568fd56e96ad41b2c96b54da305e3632c5ca70bb894225f7bR30-L38) [[4]](diffhunk://#diff-5c3300b5dbc2c7d568fd56e96ad41b2c96b54da305e3632c5ca70bb894225f7bL52-R61)

**Other improvements:**

* The user image handling logic is more robust, with null checks and improved defaults.
* Minimum password length and additional validation constants are introduced in the `User` model.

These changes collectively modernize and streamline user management in the application, making the codebase easier to maintain and extend.