### PR TITLE
Add custom session handler for better control and flexibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /panel/logs/*
 /panel/node_modules/*
 
+/site/auth/*
 /site/config/plugins.yaml
 /site/plugins/*
 /site/statistics/*

--- a/formwork/config/system.yaml
+++ b/formwork/config/system.yaml
@@ -86,7 +86,6 @@ panel:
     loginAttempts: 10
     loginResetTime: 300
     logoutRedirect: login
-    sessionTimeout: 120
     userImageSize: 512
     colorScheme: light
     paths:

--- a/formwork/config/system.yaml
+++ b/formwork/config/system.yaml
@@ -11,6 +11,7 @@ backup:
         - '*.gitkeep'
         - 'backup/*'
         - 'cache/*'
+        - 'site/auth/*'
         - 'vendor/*'
         - '*node_modules/*'
 
@@ -116,6 +117,10 @@ schemes:
         panel: '${system.panel.path}/schemes'
         system: '${%SYSTEM_PATH%}/schemes'
         site: '${%ROOT_PATH%}/site/schemes'
+
+session:
+    path: '${%ROOT_PATH%}/site/auth/sessions'
+    duration: 7200
 
 templates:
     path: '${%ROOT_PATH%}/site/templates'

--- a/formwork/schemes/config/system.yaml
+++ b/formwork/schemes/config/system.yaml
@@ -23,10 +23,15 @@ layout:
             label: '{{panel.options.system.cache}}'
             fields: [cache.enabled, cache.time]
 
+        sessions:
+            collapsible: true
+            label: '{{panel.options.system.sessions}}'
+            fields: [session.duration]
+
         panel:
             collapsible: true
             label: '{{panel.options.system.adminPanel}}'
-            fields: [panel.translation, panel.logoutRedirect, panel.sessionTimeout, panel.colorScheme]
+            fields: [panel.translation, panel.logoutRedirect, panel.colorScheme]
 
         images:
             collapsible: true
@@ -99,6 +104,13 @@ fields:
         intervals: [weeks, days, hours, minutes]
         translate: [label]
 
+    session.duration:
+        type: duration
+        label: '{{panel.options.system.session.duration}}'
+        min: 0
+        intervals: [hours, minutes]
+        translate: [label]
+
     panel.translation:
         type: select
         label: '{{panel.options.system.adminPanel.defaultLanguage}}'
@@ -112,14 +124,6 @@ fields:
         options:
             login: '{{panel.options.system.adminPanel.logoutRedirectsTo.login}}'
             home: '{{panel.options.system.adminPanel.logoutRedirectsTo.home}}'
-
-    panel.sessionTimeout:
-        type: duration
-        label: '{{panel.options.system.adminPanel.sessionTimeout}}'
-        min: 0
-        unit: minutes
-        intervals: [hours, minutes]
-        translate: [label]
 
     panel.colorScheme:
         type: togglegroup

--- a/formwork/src/Http/Session/Handler/FileSessionHandler.php
+++ b/formwork/src/Http/Session/Handler/FileSessionHandler.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace Formwork\Http\Session\Handler;
+
+use Formwork\Utils\Exceptions\FileSystemException;
+use Formwork\Utils\FileSystem;
+use SessionHandlerInterface;
+use SessionUpdateTimestampHandlerInterface;
+
+class FileSessionHandler implements SessionHandlerInterface, SessionUpdateTimestampHandlerInterface
+{
+    /**
+     * Session files path
+     */
+    protected string $path;
+
+    /**
+     * Session files prefix
+     */
+    protected string $prefix = 'sess_';
+
+    /**
+     * Open file handles
+     *
+     * @var array<string, resource>
+     */
+    protected array $handles = [];
+
+    /**
+     * @param string|null $path Session files path. If null, the default path will be used (as per "session.save_path" ini setting or system temp directory)
+     */
+    public function __construct(?string $path = null)
+    {
+        $this->path = FileSystem::normalizePath($path ?? $this->getDefaultPath());
+    }
+
+    /**
+     * Initialize session
+     */
+    public function open(string $savePath, string $name): bool
+    {
+        try {
+            if (!FileSystem::isDirectory($this->path, false)) {
+                FileSystem::createDirectory($this->path, recursive: true);
+            }
+        } catch (FileSystemException) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Close session
+     */
+    public function close(): bool
+    {
+        $success = true;
+
+        foreach ($this->handles as $handle) {
+            if (@flock($handle, LOCK_UN) === false) {
+                $success = false;
+            }
+
+            @fclose($handle);
+        }
+
+        $this->handles = [];
+
+        return $success;
+    }
+
+    /**
+     * Read session data
+     */
+    public function read(string $sessionId): string|false
+    {
+        $file = $this->filePath($sessionId);
+
+        $handle = $this->handles[$sessionId] ?? null;
+
+        // Reuse a previously opened handle only if it's still a valid resource.
+        if ($handle === null || !is_resource($handle)) {
+            unset($this->handles[$sessionId]);
+            $handle = $this->getHandle($file);
+        }
+
+        if ($handle === false) {
+            return '';
+        }
+
+        clearstatcache(filename: $file);
+        rewind($handle);
+
+        $data = (string) stream_get_contents($handle);
+
+        $this->handles[$sessionId] = $handle;
+
+        return $data;
+    }
+
+    /**
+     * Write session data
+     */
+    public function write(string $sessionId, string $data): bool
+    {
+        $file = $this->filePath($sessionId);
+
+        $handle = $this->handles[$sessionId] ?? $this->getHandle($file);
+
+        if ($handle === false) {
+            return false;
+        }
+
+        unset($this->handles[$sessionId]);
+
+        if ($this->writeToHandle($handle, $data)) {
+            return chmod($file, 0o600 & ~umask());
+        }
+
+        return false;
+    }
+
+    /**
+     * Destroy a session
+     */
+    public function destroy(string $sessionId): bool
+    {
+        $file = $this->filePath($sessionId);
+
+        if (!FileSystem::isFile($file, false)) {
+            return true;
+        }
+
+        try {
+            FileSystem::deleteFile($file);
+            return true;
+        } catch (FileSystemException) {
+            return false;
+        }
+    }
+
+    /**
+     * Garbage collect old sessions
+     */
+    public function gc(int $maxLifetime): int|false
+    {
+        $now = time();
+        $deleted = 0;
+
+        if (!FileSystem::isDirectory($this->path, false)) {
+            return 0;
+        }
+
+        foreach (FileSystem::listFiles($this->path, true) as $item) {
+            if (!str_starts_with($item, $this->prefix)) {
+                continue;
+            }
+
+            $file = FileSystem::joinPaths($this->path, $item);
+
+            if (!FileSystem::isFile($file, false)) {
+                continue;
+            }
+
+            if (FileSystem::lastModifiedTime($file) + $maxLifetime < $now) {
+                try {
+                    FileSystem::deleteFile($file);
+                } catch (FileSystemException) {
+                    continue;
+                }
+                $deleted++;
+            }
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * Validate a session ID
+     */
+    public function validateId(string $sessionId): bool
+    {
+        return FileSystem::isFile($this->filePath($sessionId), false);
+    }
+
+    /**
+     * Update session timestamp
+     */
+    public function updateTimestamp(string $sessionId, string $data): bool
+    {
+        $file = $this->filePath($sessionId);
+
+        if (FileSystem::isFile($file, false)) {
+            try {
+                return FileSystem::touch($file);
+            } catch (FileSystemException) {
+                return false;
+            }
+        }
+
+        // If file does not exist, create it with provided data
+        return $this->write($sessionId, $data);
+    }
+
+    /**
+     * Get a file handle with exclusive lock
+     *
+     * @return false|resource
+     */
+    protected function getHandle(string $file)
+    {
+        if (($handle = @fopen($file, 'c+b')) === false) {
+            return false;
+        }
+
+        if (flock($handle, LOCK_EX) === false) {
+            fclose($handle);
+            return false;
+        }
+
+        return $handle;
+    }
+
+    /**
+     * Write data using an open handle, then release lock and close.
+     *
+     * @param resource $handle
+     */
+    protected function writeToHandle($handle, string $data): bool
+    {
+        if (!is_resource($handle)) {
+            return false;
+        }
+
+        if (ftruncate($handle, 0) === false) {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+            return false;
+        }
+
+        rewind($handle);
+
+        $written = fwrite($handle, $data);
+
+        fflush($handle);
+        flock($handle, LOCK_UN);
+        fclose($handle);
+
+        return $written !== false && $written === strlen($data);
+    }
+
+    /**
+     * Get the default session path from php.ini or system temp directory
+     */
+    protected function getDefaultPath(): string
+    {
+        $path = ini_get('session.save_path') ?: sys_get_temp_dir();
+
+        // session.save_path can be in the form "N;/path", use the part after the last semicolon
+        if (($pos = strrpos($path, ';')) !== false) {
+            return substr($path, $pos + 1);
+        }
+
+        return $path;
+    }
+
+    /**
+     * Get the file path for a given session ID
+     */
+    protected function filePath(string $sessionId): string
+    {
+        // Sanitize session ID to prevent directory traversal
+        $sessionId = basename($sessionId);
+        return FileSystem::joinPaths($this->path, "{$this->prefix}{$sessionId}");
+    }
+}

--- a/formwork/src/Http/Session/Handler/FileSessionHandler.php
+++ b/formwork/src/Http/Session/Handler/FileSessionHandler.php
@@ -114,11 +114,13 @@ class FileSessionHandler implements SessionHandlerInterface, SessionUpdateTimest
 
         unset($this->handles[$sessionId]);
 
-        if ($this->writeToHandle($handle, $data)) {
-            return chmod($file, 0o600 & ~umask());
+        $result = $this->writeToHandle($handle, $data);
+
+        if ($result) {
+            @chmod($file, 0o600 & ~umask());
         }
 
-        return false;
+        return $result;
     }
 
     /**

--- a/formwork/src/Http/Session/Session.php
+++ b/formwork/src/Http/Session/Session.php
@@ -7,6 +7,7 @@ use Formwork\Data\Traits\DataArrayable;
 use Formwork\Data\Traits\DataMultipleGetter;
 use Formwork\Data\Traits\DataMultipleSetter;
 use Formwork\Http\Request;
+use Formwork\Http\Session\Handler\FileSessionHandler;
 use Formwork\Http\Utils\Cookie;
 use Formwork\Http\Utils\Header;
 use Formwork\Utils\Str;
@@ -59,6 +60,11 @@ class Session implements Arrayable
      * Session duration in seconds
      */
     protected int $duration = 0;
+
+    /**
+     * Session save path
+     */
+    protected string $path;
 
     public function __construct(
         protected Request $request,
@@ -116,6 +122,8 @@ class Session implements Arrayable
 
             session_id($id);
         }
+
+        session_set_save_handler(new FileSessionHandler($this->path ?? null));
 
         session_start([
             'cache_limiter'   => '',
@@ -233,6 +241,18 @@ class Session implements Arrayable
             }
             Cookie::send($this->name, $id, $this->getCookieOptions());
         }
+    }
+
+    /**
+     * Set the session files path
+     */
+    public function setPath(string $path): void
+    {
+        if ($this->started) {
+            throw new RuntimeException('Cannot set session save path: session already started');
+        }
+
+        $this->path = $path;
     }
 
     /**

--- a/formwork/src/Services/Loaders/ConfigServiceLoader.php
+++ b/formwork/src/Services/Loaders/ConfigServiceLoader.php
@@ -52,6 +52,9 @@ final class ConfigServiceLoader implements ServiceLoaderInterface
 
         date_default_timezone_set($config->get('system.date.timezone'));
 
+        $this->request->session()->setPath($config->get('system.session.path'));
+        $this->request->session()->setDuration($config->get('system.session.duration'));
+
         return $config;
     }
 }

--- a/formwork/src/Services/Loaders/PanelServiceLoader.php
+++ b/formwork/src/Services/Loaders/PanelServiceLoader.php
@@ -42,7 +42,10 @@ final class PanelServiceLoader implements ResolutionAwareServiceLoaderInterface
         $container->define(Updater::class)
             ->parameter('options', $this->config->get('system.updates'));
 
-        $this->request->session()->setDuration($this->config->get('system.panel.sessionTimeout') * 60);
+        if ($this->config->has('system.panel.sessionTimeout')) {
+            trigger_error('The "system.panel.sessionTimeout" configuration option (in minutes) is deprecated since Formwork 2.3.0 and will be removed in a future release. Use "system.session.duration" (in seconds) instead.', E_USER_DEPRECATED);
+            $this->request->session()->setDuration($this->config->get('system.panel.sessionTimeout') * 60);
+        }
 
         $container->define(ModalFactory::class);
         $container->define(Modals::class);

--- a/panel/translations/de.yaml
+++ b/panel/translations/de.yaml
@@ -149,7 +149,6 @@ panel.options.system.adminPanel.defaultLanguage: Standardsprache
 panel.options.system.adminPanel.logoutRedirectsTo: Abmelden leitet weiter zu
 panel.options.system.adminPanel.logoutRedirectsTo.home: Startseite
 panel.options.system.adminPanel.logoutRedirectsTo.login: Anmeldung
-panel.options.system.adminPanel.sessionTimeout: Sitzungszeitüberschreitung
 panel.options.system.backup: Sicherung
 panel.options.system.backup.backupFilesToKeep: Auf dem Server zu behaltende Sicherungen
 panel.options.system.cache: Cache
@@ -189,6 +188,8 @@ panel.options.system.images.jpegSaveProgressive.disabled: Deaktiviert
 panel.options.system.images.jpegSaveProgressive.enabled: Aktiviert
 panel.options.system.images.pngCompressionLevel: PNG-Kompressionsniveau
 panel.options.system.images.webpQuality: WebP-Qualität
+panel.options.system.session.duration: Sitzungszeitüberschreitung
+panel.options.system.sessions: Sitzungen
 panel.options.system.uploads.processImages: Hochgeladene Bilder verarbeiten (optimieren)
 panel.options.system.uploads.processImages.disabled: Deaktiviert
 panel.options.system.uploads.processImages.enabled: Aktiviert

--- a/panel/translations/el.yaml
+++ b/panel/translations/el.yaml
@@ -149,7 +149,6 @@ panel.options.system.adminPanel.defaultLanguage: Προεπιλεγμένη γλ
 panel.options.system.adminPanel.logoutRedirectsTo: Μετά την αποσύνδεση, μετάβαση σε
 panel.options.system.adminPanel.logoutRedirectsTo.home: Αρχική
 panel.options.system.adminPanel.logoutRedirectsTo.login: Σύνδεση
-panel.options.system.adminPanel.sessionTimeout: Λήξη συνεδρίας
 panel.options.system.backup: Αντίγραφα ασφαλείας
 panel.options.system.backup.backupFilesToKeep: Αντίγραφα ασφαλείας που θα παραμείνουν στον διακομιστή
 panel.options.system.cache: Cache
@@ -189,6 +188,8 @@ panel.options.system.images.jpegSaveProgressive.disabled: Απενεργοποι
 panel.options.system.images.jpegSaveProgressive.enabled: Ενεργοποιημένο
 panel.options.system.images.pngCompressionLevel: Επίπεδο συμπίεσης PNG
 panel.options.system.images.webpQuality: Ποιότητα WebP
+panel.options.system.session.duration: Λήξη συνεδρίας
+panel.options.system.sessions: Συνεδρίες
 panel.options.system.uploads.processImages: Βελτιστοποίηση εικόνων κατά τη μεταφόρτωση
 panel.options.system.uploads.processImages.disabled: Απενεργοποιημένο
 panel.options.system.uploads.processImages.enabled: Ενεργοποιημένο

--- a/panel/translations/en.yaml
+++ b/panel/translations/en.yaml
@@ -149,7 +149,6 @@ panel.options.system.adminPanel.defaultLanguage: Default language
 panel.options.system.adminPanel.logoutRedirectsTo: Logout redirects to
 panel.options.system.adminPanel.logoutRedirectsTo.home: Home
 panel.options.system.adminPanel.logoutRedirectsTo.login: Login
-panel.options.system.adminPanel.sessionTimeout: Session timeout
 panel.options.system.backup: Backup
 panel.options.system.backup.backupFilesToKeep: Backups to keep on the server
 panel.options.system.cache: Cache
@@ -189,6 +188,8 @@ panel.options.system.images.jpegSaveProgressive.disabled: Disabled
 panel.options.system.images.jpegSaveProgressive.enabled: Enabled
 panel.options.system.images.pngCompressionLevel: PNG compression level
 panel.options.system.images.webpQuality: WebP quality
+panel.options.system.session.duration: Session timeout
+panel.options.system.sessions: Sessions
 panel.options.system.uploads.processImages: Process (optimize) uploaded images
 panel.options.system.uploads.processImages.disabled: Disabled
 panel.options.system.uploads.processImages.enabled: Enabled

--- a/panel/translations/es.yaml
+++ b/panel/translations/es.yaml
@@ -149,7 +149,6 @@ panel.options.system.adminPanel.defaultLanguage: Idioma predeterminado
 panel.options.system.adminPanel.logoutRedirectsTo: Redireccionamiento al cerrar sesión
 panel.options.system.adminPanel.logoutRedirectsTo.home: Inicio
 panel.options.system.adminPanel.logoutRedirectsTo.login: Iniciar sesión
-panel.options.system.adminPanel.sessionTimeout: Tiempo de sesión
 panel.options.system.backup: Respaldo
 panel.options.system.backup.backupFilesToKeep: Respaldo a mantener en el servidor
 panel.options.system.cache: Caché
@@ -189,6 +188,8 @@ panel.options.system.images.jpegSaveProgressive.disabled: Desactivado
 panel.options.system.images.jpegSaveProgressive.enabled: Activado
 panel.options.system.images.pngCompressionLevel: Nivel de compresión PNG
 panel.options.system.images.webpQuality: Calidad WebP
+panel.options.system.session.duration: Tiempo de sesión
+panel.options.system.sessions: Sesiones
 panel.options.system.uploads.processImages: Procesar (optimizar) imágenes cargadas
 panel.options.system.uploads.processImages.disabled: Desactivado
 panel.options.system.uploads.processImages.enabled: Activado

--- a/panel/translations/fr.yaml
+++ b/panel/translations/fr.yaml
@@ -149,7 +149,6 @@ panel.options.system.adminPanel.defaultLanguage: Langue par défaut
 panel.options.system.adminPanel.logoutRedirectsTo: Après déconnexion, redirection vers
 panel.options.system.adminPanel.logoutRedirectsTo.home: Page d’accueil
 panel.options.system.adminPanel.logoutRedirectsTo.login: Page d’identification
-panel.options.system.adminPanel.sessionTimeout: Expiration de la session
 panel.options.system.backup: Sauvegarde
 panel.options.system.backup.backupFilesToKeep: Sauvegardes à conserver sur le serveur
 panel.options.system.cache: Cache
@@ -189,6 +188,8 @@ panel.options.system.images.jpegSaveProgressive.disabled: Désactivé
 panel.options.system.images.jpegSaveProgressive.enabled: Activé
 panel.options.system.images.pngCompressionLevel: Niveau de compression PNG
 panel.options.system.images.webpQuality: Qualité WebP
+panel.options.system.session.duration: Expiration de la session
+panel.options.system.sessions: Sessions
 panel.options.system.uploads.processImages: Traitement (optimisé) des images envoyées
 panel.options.system.uploads.processImages.disabled: Désactivé
 panel.options.system.uploads.processImages.enabled: Activé

--- a/panel/translations/it.yaml
+++ b/panel/translations/it.yaml
@@ -149,7 +149,6 @@ panel.options.system.adminPanel.defaultLanguage: Lingua predefinita
 panel.options.system.adminPanel.logoutRedirectsTo: Reindirizza dopo la disconnessione
 panel.options.system.adminPanel.logoutRedirectsTo.home: Pagina iniziale
 panel.options.system.adminPanel.logoutRedirectsTo.login: Accedi
-panel.options.system.adminPanel.sessionTimeout: Durata sessione
 panel.options.system.backup: Backup
 panel.options.system.backup.backupFilesToKeep: Backup da tenere sul server
 panel.options.system.cache: Cache
@@ -189,6 +188,8 @@ panel.options.system.images.jpegSaveProgressive.disabled: Disabilitato
 panel.options.system.images.jpegSaveProgressive.enabled: Abilitato
 panel.options.system.images.pngCompressionLevel: Livello di compressione PNG
 panel.options.system.images.webpQuality: Qualità WebP
+panel.options.system.session.duration: Durata sessione
+panel.options.system.sessions: Sessioni
 panel.options.system.uploads.processImages: Elabora (ottimizza) le immagini caricate
 panel.options.system.uploads.processImages.disabled: Disabilitato
 panel.options.system.uploads.processImages.enabled: Abilitato

--- a/panel/translations/nl.yaml
+++ b/panel/translations/nl.yaml
@@ -149,7 +149,6 @@ panel.options.system.adminPanel.defaultLanguage: Standaardtaal
 panel.options.system.adminPanel.logoutRedirectsTo: Uitloggen doorsturen naar
 panel.options.system.adminPanel.logoutRedirectsTo.home: Startpagina
 panel.options.system.adminPanel.logoutRedirectsTo.login: Inlogpagina
-panel.options.system.adminPanel.sessionTimeout: Sessie time-out
 panel.options.system.backup: Backup
 panel.options.system.backup.backupFilesToKeep: Backups om op de server te bewaren
 panel.options.system.cache: Cache
@@ -189,6 +188,8 @@ panel.options.system.images.jpegSaveProgressive.disabled: Uitgeschakeld
 panel.options.system.images.jpegSaveProgressive.enabled: Ingeschakeld
 panel.options.system.images.pngCompressionLevel: PNG-compressieniveau
 panel.options.system.images.webpQuality: WebP-kwaliteit
+panel.options.system.session.duration: Sessie time-out
+panel.options.system.sessions: Sessies
 panel.options.system.uploads.processImages: Verwerk (optimaliseer) geüploade afbeeldingen
 panel.options.system.uploads.processImages.disabled: Uitgeschakeld
 panel.options.system.uploads.processImages.enabled: Ingeschakeld

--- a/panel/translations/pl.yaml
+++ b/panel/translations/pl.yaml
@@ -149,7 +149,6 @@ panel.options.system.adminPanel.defaultLanguage: Domyślny język
 panel.options.system.adminPanel.logoutRedirectsTo: Przekierowanie po wylogowaniu
 panel.options.system.adminPanel.logoutRedirectsTo.home: Strona główna
 panel.options.system.adminPanel.logoutRedirectsTo.login: Strona logowania
-panel.options.system.adminPanel.sessionTimeout: Limit czasu sesji
 panel.options.system.backup: Kopia zapasowa
 panel.options.system.backup.backupFilesToKeep: Liczba kopii zapasowych do przechowywania na serwerze
 panel.options.system.cache: Pamięć podręczna
@@ -189,6 +188,8 @@ panel.options.system.images.jpegSaveProgressive.disabled: Wyłączone
 panel.options.system.images.jpegSaveProgressive.enabled: Włączone
 panel.options.system.images.pngCompressionLevel: Poziom kompresji PNG
 panel.options.system.images.webpQuality: Jakość WebP
+panel.options.system.session.duration: Limit czasu sesji
+panel.options.system.sessions: Sesje
 panel.options.system.uploads.processImages: Przetwarzaj (optymalizuj) przesyłane obrazy
 panel.options.system.uploads.processImages.disabled: Wyłączone
 panel.options.system.uploads.processImages.enabled: Włączone

--- a/panel/translations/pt.yaml
+++ b/panel/translations/pt.yaml
@@ -149,7 +149,6 @@ panel.options.system.adminPanel.defaultLanguage: Idioma padrão
 panel.options.system.adminPanel.logoutRedirectsTo: Logout redireciona para
 panel.options.system.adminPanel.logoutRedirectsTo.home: Principal
 panel.options.system.adminPanel.logoutRedirectsTo.login: Login
-panel.options.system.adminPanel.sessionTimeout: Tempo limite da sessão
 panel.options.system.backup: Cópia de segurança
 panel.options.system.backup.backupFilesToKeep: Backups para manter no servidor
 panel.options.system.cache: Cache
@@ -189,6 +188,8 @@ panel.options.system.images.jpegSaveProgressive.disabled: Desactivado
 panel.options.system.images.jpegSaveProgressive.enabled: Activado
 panel.options.system.images.pngCompressionLevel: Nível de compressão PNG
 panel.options.system.images.webpQuality: Qualidade WebP
+panel.options.system.session.duration: Tempo limite da sessão
+panel.options.system.sessions: Sessões
 panel.options.system.uploads.processImages: Processar (optimizar) imagens enviadas
 panel.options.system.uploads.processImages.disabled: Desactivado
 panel.options.system.uploads.processImages.enabled: Activado

--- a/panel/translations/ro.yaml
+++ b/panel/translations/ro.yaml
@@ -149,7 +149,6 @@ panel.options.system.adminPanel.defaultLanguage: Limba implicită
 panel.options.system.adminPanel.logoutRedirectsTo: Redirecționare după logout
 panel.options.system.adminPanel.logoutRedirectsTo.home: Acasă
 panel.options.system.adminPanel.logoutRedirectsTo.login: Pagina de autentificare
-panel.options.system.adminPanel.sessionTimeout: Timp expirare sesiune
 panel.options.system.backup: Backup
 panel.options.system.backup.backupFilesToKeep: Backup-uri de păstrat pe server
 panel.options.system.cache: Cache
@@ -189,6 +188,8 @@ panel.options.system.images.jpegSaveProgressive.disabled: Dezactivat
 panel.options.system.images.jpegSaveProgressive.enabled: Activat
 panel.options.system.images.pngCompressionLevel: Nivel de compresie PNG
 panel.options.system.images.webpQuality: Calitate WebP
+panel.options.system.session.duration: Timp expirare sesiune
+panel.options.system.sessions: Sesiuni
 panel.options.system.uploads.processImages: Procesează (optimizează) imaginile încărcate
 panel.options.system.uploads.processImages.disabled: Dezactivat
 panel.options.system.uploads.processImages.enabled: Activat

--- a/panel/translations/ru.yaml
+++ b/panel/translations/ru.yaml
@@ -149,7 +149,6 @@ panel.options.system.adminPanel.defaultLanguage: Язык по умолчани�
 panel.options.system.adminPanel.logoutRedirectsTo: Выход Перенаправление
 panel.options.system.adminPanel.logoutRedirectsTo.home: Главная
 panel.options.system.adminPanel.logoutRedirectsTo.login: Логин
-panel.options.system.adminPanel.sessionTimeout: Тайм-аут сеанса
 panel.options.system.backup: Резервный
 panel.options.system.backup.backupFilesToKeep: Резервные копии, чтобы сохранить на сервере
 panel.options.system.cache: Кэш
@@ -189,6 +188,8 @@ panel.options.system.images.jpegSaveProgressive.disabled: Отключено
 panel.options.system.images.jpegSaveProgressive.enabled: Включено
 panel.options.system.images.pngCompressionLevel: PNG Уровень сжатия
 panel.options.system.images.webpQuality: Качество WebP
+panel.options.system.session.duration: Тайм-аут сеанса
+panel.options.system.sessions: Сессии
 panel.options.system.uploads.processImages: Обрабатывать (оптимизировать) загруженные изображения
 panel.options.system.uploads.processImages.disabled: Отключено
 panel.options.system.uploads.processImages.enabled: Включено

--- a/panel/translations/tr.yaml
+++ b/panel/translations/tr.yaml
@@ -149,7 +149,6 @@ panel.options.system.adminPanel.defaultLanguage: Varsayılan dil
 panel.options.system.adminPanel.logoutRedirectsTo: Çıkış sonrası yönlendirme
 panel.options.system.adminPanel.logoutRedirectsTo.home: Ana sayfa
 panel.options.system.adminPanel.logoutRedirectsTo.login: Giriş sayfası
-panel.options.system.adminPanel.sessionTimeout: Oturum zaman aşımı
 panel.options.system.backup: Yedekleme
 panel.options.system.backup.backupFilesToKeep: Sunucuda tutulacak yedek sayısı
 panel.options.system.cache: Önbellek
@@ -189,6 +188,8 @@ panel.options.system.images.jpegSaveProgressive.disabled: Devre dışı
 panel.options.system.images.jpegSaveProgressive.enabled: Etkin
 panel.options.system.images.pngCompressionLevel: PNG sıkıştırma seviyesi
 panel.options.system.images.webpQuality: WebP kalitesi
+panel.options.system.session.duration: Oturum zaman aşımı
+panel.options.system.sessions: Oturumlar
 panel.options.system.uploads.processImages: Yüklenen görselleri işle (optimize et)
 panel.options.system.uploads.processImages.disabled: Devre dışı
 panel.options.system.uploads.processImages.enabled: Etkin

--- a/panel/translations/uk.yaml
+++ b/panel/translations/uk.yaml
@@ -149,7 +149,6 @@ panel.options.system.adminPanel.defaultLanguage: Мова за замовчув�
 panel.options.system.adminPanel.logoutRedirectsTo: Перенаправлення після виходу
 panel.options.system.adminPanel.logoutRedirectsTo.home: Головна
 panel.options.system.adminPanel.logoutRedirectsTo.login: Вхід
-panel.options.system.adminPanel.sessionTimeout: Часова сесія
 panel.options.system.backup: Резервне копіювання
 panel.options.system.backup.backupFilesToKeep: Кількість резервних копій для збереження на сервері
 panel.options.system.cache: Кеш
@@ -189,6 +188,8 @@ panel.options.system.images.jpegSaveProgressive.disabled: Вимкнено
 panel.options.system.images.jpegSaveProgressive.enabled: Увімкнено
 panel.options.system.images.pngCompressionLevel: Рівень стиснення PNG
 panel.options.system.images.webpQuality: Якість WebP
+panel.options.system.session.duration: Часова сесія
+panel.options.system.sessions: Сесії
 panel.options.system.uploads.processImages: Обробляти (оптимізувати) завантажені зображення
 panel.options.system.uploads.processImages.disabled: Вимкнено
 panel.options.system.uploads.processImages.enabled: Увімкнено


### PR DESCRIPTION
This pull request introduces a new, configurable file-based session handler and migrates session duration and storage settings to a dedicated section in the configuration. It also deprecates the old `panel.sessionTimeout` option in favor of the new `session.duration`, and updates the admin panel configuration and translations accordingly.

**Session Handling and Configuration:**

* Added a new `FileSessionHandler` class to manage PHP sessions using files, with improved locking and garbage collection. (`formwork/src/Http/Session/Handler/FileSessionHandler.php`)
* Updated the `Session` class to support configurable session save paths and durations, and to use the new file session handler. (`formwork/src/Http/Session/Session.php`) [[1]](diffhunk://#diff-06afe2e6e25db4dd17ff6c7f0e9c7b1305d626f7e22869998748cdb4b064d449R10) [[2]](diffhunk://#diff-06afe2e6e25db4dd17ff6c7f0e9c7b1305d626f7e22869998748cdb4b064d449R64-R68) [[3]](diffhunk://#diff-06afe2e6e25db4dd17ff6c7f0e9c7b1305d626f7e22869998748cdb4b064d449R126-R127) [[4]](diffhunk://#diff-06afe2e6e25db4dd17ff6c7f0e9c7b1305d626f7e22869998748cdb4b064d449R246-R257)
* The configuration loader now sets the session path and duration from `system.session.path` and `system.session.duration`. (`formwork/src/Services/Loaders/ConfigServiceLoader.php`)
* Deprecated the old `system.panel.sessionTimeout` option, issuing a warning if used, and mapping it to the new duration setting for backward compatibility. (`formwork/src/Services/Loaders/PanelServiceLoader.php`)

**Configuration and Panel UI Updates:**

* Added a new `session` section to `system.yaml` for session path and duration, and removed `panel.sessionTimeout`. (`formwork/config/system.yaml`, `formwork/schemes/config/system.yaml`) [[1]](diffhunk://#diff-71266f382c699109f4896d337ad2621d64f601e47db3291fcdcbb2b9f673c49fR120-R123) [[2]](diffhunk://#diff-3a85243f9076a37c5382670cdb767b437bdc657a831b02726c304d3bb8ad69c0R26-R34) [[3]](diffhunk://#diff-3a85243f9076a37c5382670cdb767b437bdc657a831b02726c304d3bb8ad69c0R107-R113) [[4]](diffhunk://#diff-3a85243f9076a37c5382670cdb767b437bdc657a831b02726c304d3bb8ad69c0L116-L123) [[5]](diffhunk://#diff-71266f382c699109f4896d337ad2621d64f601e47db3291fcdcbb2b9f673c49fL88)
* Updated backup ignore patterns to include session files. (`formwork/config/system.yaml`)

**Translations:**

* Removed the old `panel.options.system.adminPanel.sessionTimeout` translation key and added new keys for session duration and sessions in all supported languages. (`panel/translations/en.yaml`, `panel/translations/de.yaml`, `panel/translations/fr.yaml`, `panel/translations/it.yaml`, `panel/translations/es.yaml`, `panel/translations/el.yaml`) [[1]](diffhunk://#diff-8879b7b36b8f36138da71764453d893c85d45c294f607d8594649b7e6f72ce13L152) [[2]](diffhunk://#diff-8879b7b36b8f36138da71764453d893c85d45c294f607d8594649b7e6f72ce13R191-R192) [[3]](diffhunk://#diff-c12f5f9b4cf99d3b35f6f5defea77cc57dbab76bf922fb7a27ff35b3f89d014aL152) [[4]](diffhunk://#diff-c12f5f9b4cf99d3b35f6f5defea77cc57dbab76bf922fb7a27ff35b3f89d014aR191-R192) [[5]](diffhunk://#diff-66893cfdc71e68c0c0f75a1db63b7270f916b01a9cde703f04abc11793b36996L152) [[6]](diffhunk://#diff-66893cfdc71e68c0c0f75a1db63b7270f916b01a9cde703f04abc11793b36996R191-R192) [[7]](diffhunk://#diff-c399a0648142bccc71e945864e68f61de8ec7e5edf5213d5c43673bdc7951c19L152) [[8]](diffhunk://#diff-3aef51d61250f8d6df37d1ea4b854af4649492fa8a5b2722367460e0bb6bad13L152) [[9]](diffhunk://#diff-3aef51d61250f8d6df37d1ea4b854af4649492fa8a5b2722367460e0bb6bad13R191-R192) [[10]](diffhunk://#diff-60a982db0fa7387cd39c9a38cbbce9eef7287eabe09b1cbc85c4d05bd59f12c3L152) [[11]](diffhunk://#diff-60a982db0fa7387cd39c9a38cbbce9eef7287eabe09b1cbc85c4d05bd59f12c3R191-R192)