### PR TITLE
Add Hungarian and Swedish translations

### DIFF
--- a/formwork/translations/hu.yaml
+++ b/formwork/translations/hu.yaml
@@ -1,0 +1,157 @@
+date.distance.ago: '%s ezelőtt'
+date.distance.in: '%s múlva'
+date.duration.days: ['nap', 'nap']
+date.duration.hours: ['óra', 'óra']
+date.duration.minutes: ['perc', 'perc']
+date.duration.months: ['hónap', 'hónap']
+date.duration.seconds: ['másodperc', 'másodperc']
+date.duration.weeks: ['hét', 'hét']
+date.duration.years: ['év', 'év']
+date.months.long: ['Január', 'Február', 'Március', 'Április', 'Május', 'Június', 'Július', 'Augusztus', 'Szeptember', 'Október', 'November', 'December']
+date.months.short: ['Jan', 'Feb', 'Már', 'Ápr', 'Máj', 'Jún', 'Júl', 'Aug', 'Szept', 'Okt', 'Nov', 'Dec']
+date.never: soha
+date.noDate: Nincs dátum
+date.now: most
+date.today: Ma
+date.weekdays.long: ['Vasárnap', 'Hétfő', 'Kedd', 'Szerda', 'Csütörtök', 'Péntek', 'Szombat']
+date.weekdays.short: ['Vas', 'Hét', 'Ked', 'Sze', 'Csü', 'Pén', 'Szo']
+fields.array.add: Hozzáadás
+fields.array.remove: Eltávolítás
+fields.date.nextHour: Következő óra
+fields.date.nextMinute: Következő perc
+fields.date.nextMonth: Következő hónap
+fields.date.previousHour: Előző óra
+fields.date.previousMinute: Előző perc
+fields.date.previousMonth: Előző hónap
+fields.error.invalidEmail: Érvénytelen e-mail cím
+fields.error.invalidValue: Érvénytelen érték
+fields.error.patternMismatch: Az érték nem felel meg az előírt mintának
+fields.error.requiredValue: A mező kitöltése kötelező
+fields.error.stepMismatch: 'Az érték nem felel meg a megadott lépésköznek: %d'
+fields.error.tooManyItems: 'A megengedett elemek maximális száma: %d'
+fields.error.valueAlreadyExists: Az érték már létezik
+fields.error.valueTooLarge: Az érték nagyobb mint %d
+fields.error.valueTooLong: Az érték hosszabb a megengedett %d karakternél
+fields.error.valueTooShort: Az érték rövidebb a megkövetelt %d karakternél
+fields.error.valueTooSmall: Az érték kisebb mint %d
+fields.file.none: (Nincs)
+fields.file.uploadLabel: <strong>Kattints</strong> a fájl kiválasztásához vagy <strong>húzd</strong> ide
+fields.image.none: (Nincs)
+fields.select.empty: Nincs megfelelő találat
+fields.tags.remove: Eltávolítás
+file.metadata: Metaadatok
+file.metadata.alternativeText: Alternatív szöveg
+page.attributes: Tulajdonságok
+page.cacheable: Gyorsítótárazható
+page.content: Tartalom
+page.files: Fájlok
+page.image: Kép
+page.listed: Listázva
+page.listed.description: A listázott oldalak láthatók a menüben
+page.noFiles: Nincsenek fájlok
+page.noImage: Nincs kép
+page.none: (Nincs)
+page.noTags: Nincsenek címkék
+page.notListed: Nincs listázva
+page.notRoutable: Nem elérhető útvonalon
+page.options: Beállítások
+page.page: Oldal
+page.parent: Szülő oldal
+page.postsPerPage: Bejegyzések oldalanként
+page.publishDate: Közzététel dátuma
+page.routable: Elérhető
+page.routable.description: Az elérhető oldalak az URL-jükön keresztül megnyithatók
+page.slug: Slug
+page.slug.suggestion: csak betűk, számok és kötőjelek
+page.status: Állapot
+page.status.notPublished: Nincs közzétéve
+page.status.published: Közzétéve
+page.status.published.description: A közzétett oldalak láthatók az oldalon és elérhetők az URL-jükön
+page.summary: Összefoglaló
+page.tags: Címkék
+page.template: Sablon
+page.text: Szöveg
+page.title: Cím
+page.unpublishDate: Közzététel visszavonásának dátuma
+plugin.author: Szerző
+plugin.description: Leírás
+plugin.homepage: Honlap
+plugin.license: Licenc
+plugin.plugin: Bővítmény
+plugin.status: Állapot
+plugin.status.disabled: Letiltva
+plugin.status.enabled: Engedélyezve
+plugin.title: Cím
+plugin.version: Verzió
+site.advanced: Speciális beállítások
+site.advanced.aliases: Aliasok
+site.advanced.aliases.alias: Alias
+site.advanced.aliases.description: Oldalútvonal-aliasok egyéni URI-k oldalakhoz rendeléséhez
+site.advanced.aliases.route: Útvonal
+site.advanced.metadata: HTML metaadatok
+site.advanced.metadata.content: Tartalom
+site.advanced.metadata.description: HTML metaadatok, amelyek `<meta>` címkékként kerülnek az oldal `<head>` részébe (pl. OpenGraph)
+site.advanced.metadata.name: Név
+site.info: Információ
+site.info.author: Szerző
+site.info.description: Leírás
+site.info.language: Nyelv
+site.info.title: Cím
+site.maintenance: Karbantartás
+site.maintenance.enabled: Karbantartási mód
+site.maintenance.enabled.disabled: Kikapcsolva
+site.maintenance.enabled.enabled: Bekapcsolva
+site.maintenance.page: Karbantartási oldal
+site.pages: Oldalak
+site.pages.defaultTemplate: Alapértelmezett sablon
+site.pages.taxonomies: Taxonómiák
+site.pages.taxonomies.description: Oldalak rendszerezésére szolgáló taxonómiák
+site.pages.taxonomies.noTaxonomies: Nincsenek taxonómiák
+site.statistics: Statisztikák
+site.statistics.enabled: Oldallátogatások követése
+site.statistics.enabled.disabled: Kikapcsolva
+site.statistics.enabled.enabled: Bekapcsolva
+site.statistics.trackLocalhost: Localhost látogatások követése
+site.statistics.trackLocalhost.disabled: Kikapcsolva
+site.statistics.trackLocalhost.enabled: Bekapcsolva
+site.statistics.visitsDelay: Látogatási késleltetés
+site.statistics.visitsDelay.description: Két azonos felhasználótól érkező látogatás közti idő
+upload.error: A fájl feltöltése sikertelen. %s.
+upload.error.alreadyExists: Már létezik ilyen nevű fájl
+upload.error.cannotMoveToDestination: A feltöltött fájl áthelyezése sikertelen
+upload.error.cannotWrite: Nem sikerült a fájlt lemezre írni
+upload.error.destinationTooLong: A célútvonal túl hosszú
+upload.error.fileName: Érvénytelen fájlnév
+upload.error.fileNameTooLong: A fájlnév túl hosszú
+upload.error.hiddenFiles: Ponttal kezdődő rejtett fájlok nem tölthetők fel
+upload.error.mimeType: Nem engedélyezett fájltípus
+upload.error.noFile: Nem lett fájl feltöltve
+upload.error.noTemp: Hiányzik az ideiglenes mappa
+upload.error.partial: A fájl csak részben lett feltöltve
+upload.error.phpExtension: A feltöltést egy PHP kiterjesztés leállította
+upload.error.size: A fájl meghaladja a maximális méretet
+user.colorScheme: Színséma
+user.colorScheme.auto: Automatikus
+user.colorScheme.dark: Sötét
+user.colorScheme.light: Világos
+user.email: E-mail
+user.fullname: Teljes név
+user.image: Kép
+user.language: Nyelv
+user.password: Jelszó
+user.password.placeholder: Új jelszó megadása…
+user.role: Szerepkör
+user.role.admin: Adminisztrátor
+user.role.editor: Szerkesztő
+user.role.user: Felhasználó
+user.user: Felhasználó
+user.username: Felhasználónév
+zip.error.alreadyExists: Az archívum már létezik
+zip.error.cannotOpen: Az archívum nem nyitható meg
+zip.error.cannotRead: Az archívum nem olvasható
+zip.error.inconsistentArchive: Inkonzisztens archívum
+zip.error.invalidArgument: Érvénytelen argumentum
+zip.error.memoryFailure: Memóriahiba
+zip.error.notFound: Az archívum nem található
+zip.error.notZipArchive: Nem ZIP archívum
+zip.error.unspecified: Nem meghatározott hiba

--- a/formwork/translations/sv.yaml
+++ b/formwork/translations/sv.yaml
@@ -1,0 +1,157 @@
+date.distance.ago: '%s sedan'
+date.distance.in: 'om %s'
+date.duration.days: ['dag', 'dagar']
+date.duration.hours: ['timme', 'timmar']
+date.duration.minutes: ['minut', 'minuter']
+date.duration.months: ['månad', 'månader']
+date.duration.seconds: ['sekund', 'sekunder']
+date.duration.weeks: ['vecka', 'veckor']
+date.duration.years: ['år', 'år']
+date.months.long: ['Januari', 'Februari', 'Mars', 'April', 'Maj', 'Juni', 'Juli', 'Augusti', 'September', 'Oktober', 'November', 'December']
+date.months.short: ['Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec']
+date.never: aldrig
+date.noDate: Inget datum
+date.now: nu
+date.today: Idag
+date.weekdays.long: ['Söndag', 'Måndag', 'Tisdag', 'Onsdag', 'Torsdag', 'Fredag', 'Lördag']
+date.weekdays.short: ['Sön', 'Mån', 'Tis', 'Ons', 'Tor', 'Fre', 'Lör']
+fields.array.add: Lägg till
+fields.array.remove: Ta bort
+fields.date.nextHour: Nästa timme
+fields.date.nextMinute: Nästa minut
+fields.date.nextMonth: Nästa månad
+fields.date.previousHour: Föregående timme
+fields.date.previousMinute: Föregående minut
+fields.date.previousMonth: Föregående månad
+fields.error.invalidEmail: Ogiltig e-postadress
+fields.error.invalidValue: Ogiltigt värde
+fields.error.patternMismatch: Värdet matchar inte det obligatoriska mönstret
+fields.error.requiredValue: Fältet är obligatoriskt
+fields.error.stepMismatch: Värdet överensstämmer inte med det obligatoriska stegintevallet %d
+fields.error.tooManyItems: Det maximala antalet tillåtna objekt är %d
+fields.error.valueAlreadyExists: Värdet finns redan
+fields.error.valueTooLarge: Värdet är större än %d
+fields.error.valueTooLong: Värdet är längre än de %d tecken som krävs
+fields.error.valueTooShort: Värdet är kortare än de %d tecken som krävs
+fields.error.valueTooSmall: Värdet är mindre än %d
+fields.file.none: (Ingen)
+fields.file.uploadLabel: <strong>Klicka</strong> för att välja en fil att ladda upp eller <strong>dra</strong> den hit
+fields.image.none: (Ingen)
+fields.select.empty: Inga matchande alternativ
+fields.tags.remove: Ta bort
+file.metadata: Metadata
+file.metadata.alternativeText: Alternativ text
+page.attributes: Attribut
+page.cacheable: Cachebar
+page.content: Innehåll
+page.files: Filer
+page.image: Bild
+page.listed: Listad
+page.listed.description: Listade sidor visas i menyn
+page.noFiles: Inga filer
+page.noImage: Ingen bild
+page.none: (Ingen)
+page.noTags: Inga taggar
+page.notListed: Inte listad
+page.notRoutable: Ej routbar
+page.options: Alternativ
+page.page: Sida
+page.parent: Föräldrasida
+page.postsPerPage: Inlägg per sida
+page.publishDate: Publiceringsdatum
+page.routable: Routbar
+page.routable.description: Routbara sidor är åtkomliga via sin adress
+page.slug: Slug
+page.slug.suggestion: endast bokstäver, siffror och bindestreck
+page.status: Status
+page.status.notPublished: Ej publicerad
+page.status.published: Publicerad
+page.status.published.description: Publicerade sidor är synliga på webbplatsen och åtkomliga via sin adress
+page.summary: Sammanfattning
+page.tags: Taggar
+page.template: Mall
+page.text: Text
+page.title: Titel
+page.unpublishDate: Avpubliceringsdatum
+plugin.author: Författare
+plugin.description: Beskrivning
+plugin.homepage: Hemsida
+plugin.license: Licens
+plugin.plugin: Tillägg
+plugin.status: Status
+plugin.status.disabled: Inaktiverad
+plugin.status.enabled: Aktiverad
+plugin.title: Titel
+plugin.version: Version
+site.advanced: Avancerade alternativ
+site.advanced.aliases: Alias
+site.advanced.aliases.alias: Alias
+site.advanced.aliases.description: Webbplatsruttalias för att mappa anpassade URI:er till specifika sidor
+site.advanced.aliases.route: Rutt
+site.advanced.metadata: HTML-metadata
+site.advanced.metadata.content: Innehåll
+site.advanced.metadata.description: HTML-metadata som ska läggas till som `<meta>`-taggar i sidornas `<head>`, till exempel OpenGraph-egenskaper för förhandsvisningar i sociala medier
+site.advanced.metadata.name: Namn
+site.info: Info
+site.info.author: Författare
+site.info.description: Beskrivning
+site.info.language: Språk
+site.info.title: Titel
+site.maintenance: Underhåll
+site.maintenance.enabled: Underhållsläge
+site.maintenance.enabled.disabled: Inaktiverat
+site.maintenance.enabled.enabled: Aktiverat
+site.maintenance.page: Underhållssida
+site.pages: Sidor
+site.pages.defaultTemplate: Standardmall
+site.pages.taxonomies: Taxonomier
+site.pages.taxonomies.description: Taxonomier för att organisera sidor, används i mallkontroller för att filtrera sidor
+site.pages.taxonomies.noTaxonomies: Inga taxonomier
+site.statistics: Statistik
+site.statistics.enabled: Spåra sidvisningar
+site.statistics.enabled.disabled: Inaktiverat
+site.statistics.enabled.enabled: Aktiverat
+site.statistics.trackLocalhost: Spåra besök från localhost
+site.statistics.trackLocalhost.disabled: Inaktiverat
+site.statistics.trackLocalhost.enabled: Aktiverat
+site.statistics.visitsDelay: Fördröjning mellan besök
+site.statistics.visitsDelay.description: Fördröjning mellan besök från samma användare till samma sida för att räknas som olika
+upload.error: Kan inte ladda upp filen. %s.
+upload.error.alreadyExists: En fil med samma namn finns redan
+upload.error.cannotMoveToDestination: Misslyckades med att flytta den uppladdade filen till destinationen
+upload.error.cannotWrite: Misslyckades med att skriva filen till disken
+upload.error.destinationTooLong: Sökvägen till destinationen är för lång
+upload.error.fileName: Ogiltigt filnamn
+upload.error.fileNameTooLong: Filnamnet är för långt
+upload.error.hiddenFiles: Kan inte ladda upp dolda filer som börjar med en punkt
+upload.error.mimeType: Filtypen är inte tillåten
+upload.error.noFile: Ingen fil laddades upp
+upload.error.noTemp: Saknar temporär mapp
+upload.error.partial: Den uppladdade filen laddades bara upp delvis
+upload.error.phpExtension: Filuppladdningen stoppades av ett tillägg
+upload.error.size: Den uppladdade filen överskrider den maximala filstorleken
+user.colorScheme: Färgschema
+user.colorScheme.auto: Auto
+user.colorScheme.dark: Mörkt
+user.colorScheme.light: Ljust
+user.email: E-post
+user.fullname: Fullständigt namn
+user.image: Bild
+user.language: Språk
+user.password: Lösenord
+user.password.placeholder: Skriv ett nytt lösenord för att ändra...
+user.role: Roll
+user.role.admin: Administratör
+user.role.editor: Redaktör
+user.role.user: Användare
+user.user: Användare
+user.username: Användarnamn
+zip.error.alreadyExists: Arkivet finns redan
+zip.error.cannotOpen: Kan inte öppna arkivet
+zip.error.cannotRead: Kan inte läsa arkivet
+zip.error.inconsistentArchive: Inkonsekvent arkiv
+zip.error.invalidArgument: Ogiltigt argument
+zip.error.memoryFailure: Minnesfel
+zip.error.notFound: Arkivet hittades inte
+zip.error.notZipArchive: Inte ett ZIP-arkiv
+zip.error.unspecified: Ospecificerat fel

--- a/panel/translations/hu.yaml
+++ b/panel/translations/hu.yaml
@@ -1,0 +1,364 @@
+panel.backup.backup: Biztonsági mentés
+panel.backup.deleted: Biztonsági mentés törölve
+panel.backup.error.cannotDelete: Nem lehet törölni a biztonsági mentést. %s.
+panel.backup.error.cannotDelete.invalidFilename: Érvénytelen biztonsági mentés fájl
+panel.backup.error.cannotDownload: Nem lehet letölteni a biztonsági mentést. %s.
+panel.backup.error.cannotDownload.invalidFilename: Érvénytelen biztonsági mentés fájl
+panel.backup.error.cannotMake: Nem lehet biztonsági mentést készíteni. %s.
+panel.backup.ready: A biztonsági mentés elkészült. Letöltés indítása...
+panel.cache.clear: Gyorsítótár törlése
+panel.cache.clear.images: Képek gyorsítótárának törlése
+panel.cache.clear.pages: Oldalak gyorsítótárának törlése
+panel.cache.cleared: Gyorsítótár törölve
+panel.cache.cleared.images: Képek gyorsítótára törölve
+panel.cache.cleared.pages: Oldalak gyorsítótára törölve
+panel.cache.error: Nem lehet törölni a gyorsítótárat
+panel.dashboard.dashboard: Vezérlőpult
+panel.dashboard.lastModifiedPages: Legutóbb szerkesztett oldalak
+panel.dashboard.quickActions: Gyorsműveletek
+panel.dashboard.statistics: Statisztikák
+panel.dashboard.statistics.uniqueVisitors: Egyedi látogatók
+panel.dashboard.statistics.visits: Látogatások
+panel.dashboard.welcome: Üdvözöljük
+panel.dragToReorder: Húzza az átrendezéshez
+panel.editor.bold: Félkövér
+panel.editor.bulletList: Felsorolás
+panel.editor.code: Kód
+panel.editor.decreaseIndent: Behúzás csökkentése
+panel.editor.heading1: Címsor 1
+panel.editor.heading2: Címsor 2
+panel.editor.heading3: Címsor 3
+panel.editor.heading4: Címsor 4
+panel.editor.heading5: Címsor 5
+panel.editor.heading6: Címsor 6
+panel.editor.image: Kép
+panel.editor.increaseIndent: Behúzás növelése
+panel.editor.italic: Dőlt
+panel.editor.link: Hivatkozás
+panel.editor.numberedList: Számozott lista
+panel.editor.paragraph: Bekezdés
+panel.editor.quote: Idézet
+panel.editor.redo: Ismét
+panel.editor.summary: Összefoglaló
+panel.editor.toggleMarkdown: Markdown váltása
+panel.editor.undo: Visszavonás
+panel.errors.action.reportToGithub: Hiba jelentése GitHubon
+panel.errors.action.returnToDashboard: Vissza a vezérlőpultra
+panel.errors.error.forbidden.description: Nincs jogosultsága az oldal megtekintéséhez.
+panel.errors.error.forbidden.heading: Hoppá, jogosultság szükséges!
+panel.errors.error.forbidden.status: Tiltott
+panel.errors.error.internalServerError.description: A Formwork hiba miatt nem tudta kiszolgálni a kérést. Ellenőrizze a konfigurációt vagy a szervernaplót.
+panel.errors.error.internalServerError.heading: Hoppá, valami hiba történt!
+panel.errors.error.internalServerError.status: Belső szerverhiba
+panel.errors.error.notFound.description: Az oldal nem létezik vagy a kérés érvénytelen.
+panel.errors.error.notFound.heading: Hoppá, az oldal nem található!
+panel.errors.error.notFound.status: Nem található
+panel.files.actions: Műveletek
+panel.files.backToPage: Vissza az oldalra
+panel.files.cannotDelete.fileNotFound: Nem lehet törölni a fájlt, a fájl nem található
+panel.files.cannotDelete.pageNotFound: Nem lehet törölni a fájlt, az oldal nem található
+panel.files.cannotRename.fileAlreadyExists: Nem lehet átnevezni a fájlt, már létezik ilyen nevű fájl
+panel.files.cannotRename.fileNotFound: Nem lehet átnevezni a fájlt, a fájl nem található
+panel.files.cannotRename.invalidFields: Nem lehet átnevezni a fájlt, egyes mezők érvénytelenek
+panel.files.cannotRename.pageNotFound: Nem lehet átnevezni a fájlt, az oldal nem található
+panel.files.cannotReplace.fileNotFound: Nem lehet lecserélni a fájlt, a fájl nem található
+panel.files.cannotReplace.multipleFiles: Nem lehet lecserélni a fájlt, több fájl lett megadva
+panel.files.cannotReplace.pageNotFound: Nem lehet lecserélni a fájlt, az oldal nem található
+panel.files.cannotUpload.invalidFields: Nem lehet feltölteni a fájlt, egyes mezők érvénytelenek
+panel.files.cannotUpload.pageNotFound: Nem lehet feltölteni a fájlt, az oldal nem található
+panel.files.deleted: Fájl törölve
+panel.files.exif: EXIF
+panel.files.fileNotFound: Nem lehet lekérni a fájl adatait, a fájl nem található
+panel.files.files: Fájlok
+panel.files.info: Információ
+panel.files.info.image.colorDepth: Színmélység
+panel.files.info.image.colorNumber: Színek száma
+panel.files.info.image.colorProfile: Színprofil
+panel.files.info.image.colorSpace: Színtér
+panel.files.info.image.dimensions: Méretek
+panel.files.info.image.dimensions.widthByHeightPixels: '%d × %d pixel'
+panel.files.info.image.exif.aperture: Rekesz
+panel.files.info.image.exif.camera: Kamera
+panel.files.info.image.exif.creationDateAndTime: Készítés dátuma és ideje
+panel.files.info.image.exif.exposureCompensation: Expozíció kompenzáció
+panel.files.info.image.exif.exposureProgram: Expozíciós program
+panel.files.info.image.exif.exposureTime: Expozíciós idő
+panel.files.info.image.exif.flash: Vaku
+panel.files.info.image.exif.focalLength: Gyújtótávolság
+panel.files.info.image.exif.lensModel: Objektív modell
+panel.files.info.image.exif.meteringMode: Fénymérési mód
+panel.files.info.image.exif.sensitivity: Érzékenység
+panel.files.info.image.exif.whiteBalance: Fehéregyensúly
+panel.files.info.image.frames: '%d képkocka'
+panel.files.info.image.framesCount: Képkockák száma
+panel.files.info.image.repeats: '%d ismétlés'
+panel.files.info.image.repeatsCount: Ismétlések száma
+panel.files.info.image.resolution: Felbontás
+panel.files.info.lastModifiedTime: Utolsó módosítás ideje
+panel.files.info.mimeType: MIME típus
+panel.files.info.name: Név
+panel.files.info.size: Méret
+panel.files.info.uri: URI
+panel.files.metadata.cannotUpdate.invalidFields: Nem lehet frissíteni a metaadatokat, egyes mezők érvénytelenek
+panel.files.metadata.updated: Fájl metaadatok frissítve
+panel.files.next: Következő fájl
+panel.files.pageNotFound: Nem lehet lekérni a fájl adatait, az oldal nem található
+panel.files.parent: Szülő
+panel.files.position: Pozíció
+panel.files.preview: Előnézet
+panel.files.previous: Előző fájl
+panel.files.renamed: Fájl átnevezve
+panel.files.search: Fájlok keresése...
+panel.files.upload: Fájlok feltöltése
+panel.files.uploaded: Fájlok feltöltve
+panel.files.viewAsList: Lista nézet
+panel.files.viewAsThumbnails: Miniatűr nézet
+panel.login.attempt.failed: Bejelentkezési kísérlet sikertelen! Próbálja újra.
+panel.login.attempt.tooMany: Túl sok bejelentkezési kísérlet. Próbálja újra %d perc múlva.
+panel.login.loggedOut: Kijelentkezett
+panel.login.login: Bejelentkezés
+panel.login.logout: Kijelentkezés
+panel.login.password: Jelszó
+panel.login.suspiciousRequestDetected: Gyanús kérés észlelve, biztonsági okokból kijelentkeztettük. Kérjük, jelentkezzen be újra.
+panel.login.usernameOrEmail: Felhasználónév vagy e-mail
+panel.manage: Kezelés
+panel.modal.action.cancel: Mégse
+panel.modal.action.continue: Folytatás
+panel.modal.action.delete: Törlés
+panel.modal.action.edit: Szerkesztés
+panel.modal.action.rename: Átnevezés
+panel.modal.action.save: Mentés
+panel.modal.action.upload: Feltöltés
+panel.modal.action.uploadFile: Fájl feltöltése
+panel.modal.images.noImages: Nincsenek képek
+panel.modal.images.noImages.upload: Kérjük, töltsön fel képeket
+panel.modal.images.title: Kép kiválasztása
+panel.modal.link.text: Szöveg
+panel.modal.link.title: Hivatkozás beszúrása
+panel.modal.link.uri: URI
+panel.navigation.toggle: Navigáció váltása
+panel.options.cannotUpdate.invalidFields: Nem lehet frissíteni a beállításokat, egyes mezők érvénytelenek
+panel.options.options: Beállítások
+panel.options.site: Oldal
+panel.options.system: Rendszer
+panel.options.system.adminPanel: Adminisztrációs felület
+panel.options.system.adminPanel.defaultColorScheme: Alapértelmezett színséma
+panel.options.system.adminPanel.defaultColorScheme.dark: Sötét
+panel.options.system.adminPanel.defaultColorScheme.light: Világos
+panel.options.system.adminPanel.defaultLanguage: Alapértelmezett nyelv
+panel.options.system.adminPanel.logoutRedirectsTo: Kijelentkezés utáni átirányítás
+panel.options.system.adminPanel.logoutRedirectsTo.home: Kezdőlap
+panel.options.system.adminPanel.logoutRedirectsTo.login: Bejelentkezés
+panel.options.system.backup: Biztonsági mentés
+panel.options.system.backup.backupFilesToKeep: Megtartandó biztonsági mentések száma
+panel.options.system.cache: Gyorsítótár
+panel.options.system.cache.disabled: Kikapcsolva
+panel.options.system.cache.enabled: Bekapcsolva
+panel.options.system.cache.time: Gyorsítótár ideje
+panel.options.system.content: Tartalom
+panel.options.system.content.allowHtml: HTML engedélyezése Markdown mezőkben
+panel.options.system.content.allowHtml.description: A potenciálisan veszélyes címkék, mint a `<script>` és `<style>`, mindig szöveggé alakulnak
+panel.options.system.content.allowHtml.disabled: Kikapcsolva
+panel.options.system.content.allowHtml.enabled: Bekapcsolva
+panel.options.system.dateAndTime: Dátum és idő
+panel.options.system.dateAndTime.dateFormat: Dátumformátum
+panel.options.system.dateAndTime.firstWeekday: A hét első napja
+panel.options.system.dateAndTime.firstWeekday.monday: Hétfő
+panel.options.system.dateAndTime.firstWeekday.sunday: Vasárnap
+panel.options.system.dateAndTime.hourFormat: Óraformátum
+panel.options.system.dateAndTime.timezone: Időzóna
+panel.options.system.debug: Hibakeresés
+panel.options.system.debug.editorUri: Szerkesztő URI
+panel.options.system.debug.editorUri.description: Használja a `{{filename}}` és `{{line}}` változókat a szerkesztő URI összeállításához
+panel.options.system.debug.mode: Hibakeresési mód
+panel.options.system.debug.mode.description: A hibakeresési mód részletes hibaadatokat jelenít meg, ezért éles környezetben ki kell kapcsolni
+panel.options.system.debug.mode.disabled: Kikapcsolva
+panel.options.system.debug.mode.enabled: Bekapcsolva
+panel.options.system.files: Fájlok
+panel.options.system.files.allowedExtensions: Engedélyezett kiterjesztések
+panel.options.system.files.allowedExtensions.noExtensions: Nincs kiterjesztés (fájl feltöltése nem engedélyezett)
+panel.options.system.images: Képek
+panel.options.system.images.avifQuality: AVIF minőség
+panel.options.system.images.clearCacheByDefault: Képek gyorsítótárának törlése alapértelmezetten
+panel.options.system.images.clearCacheByDefault.disabled: Kikapcsolva
+panel.options.system.images.clearCacheByDefault.enabled: Bekapcsolva
+panel.options.system.images.jpegQuality: JPEG minőség
+panel.options.system.images.jpegSaveProgressive: Progresszív JPEG mentése
+panel.options.system.images.jpegSaveProgressive.disabled: Kikapcsolva
+panel.options.system.images.jpegSaveProgressive.enabled: Bekapcsolva
+panel.options.system.images.pngCompressionLevel: PNG tömörítési szint
+panel.options.system.images.webpQuality: WebP minőség
+panel.options.system.session.duration: Munkamenet időtúllépés
+panel.options.system.sessions: Munkamenetek
+panel.options.system.uploads.processImages: Feltöltött képek feldolgozása (optimalizálása)
+panel.options.system.uploads.processImages.disabled: Kikapcsolva
+panel.options.system.uploads.processImages.enabled: Bekapcsolva
+panel.options.updated: Beállítások frissítve
+panel.pages.changes.continue: Folytatás mentés nélkül
+panel.pages.changes.detected: Változások észlelve
+panel.pages.changes.detected.prompt: Nem mentett módosítások vannak. Biztosan elhagyja az oldalt?
+panel.pages.changeSlug: Slug szerkesztése
+panel.pages.changeSlug.generate: Generálás a címből
+panel.pages.deleteFile: Fájl törlése
+panel.pages.deleteFile.prompt: Biztosan törli ezt a fájlt? A művelet nem vonható vissza.
+panel.pages.deletePage: Oldal törlése
+panel.pages.deletePage.prompt: Biztosan törli ezt az oldalt? A művelet nem vonható vissza.
+panel.pages.duplicatePage: Oldal duplikálása
+panel.pages.duplicatePage.title: '%s másolat'
+panel.pages.edit: Oldal szerkesztése
+panel.pages.editPage: 'Oldal szerkesztése: %s'
+panel.pages.history.event.created: Oldal létrehozva (%s %s).
+panel.pages.history.event.edited: Oldal szerkesztve (%s %s).
+panel.pages.languages: Nyelvek
+panel.pages.languages.addLanguage: '%s hozzáadása'
+panel.pages.languages.editLanguage: '%s szerkesztése'
+panel.pages.newPage: Új oldal
+panel.pages.newPage.site: Oldal
+panel.pages.next: Következő oldal
+panel.pages.page: Oldal
+panel.pages.page.actions: Műveletek
+panel.pages.page.cannotChangeNum: Nem lehet megváltoztatni az oldalszámot
+panel.pages.page.cannotCreate: Nem lehet oldalt létrehozni
+panel.pages.page.cannotCreate.alreadyExists: Nem lehet oldalt létrehozni, az URI már létezik
+panel.pages.page.cannotCreate.invalidFields: Nem lehet oldalt létrehozni, egyes mezők érvénytelenek
+panel.pages.page.cannotCreate.invalidParent: Nem lehet oldalt létrehozni, érvénytelen szülő oldal
+panel.pages.page.cannotCreate.invalidSlug: Nem lehet oldalt létrehozni, a slug csak betűket és számokat tartalmazhat kötőjelekkel elválasztva
+panel.pages.page.cannotCreate.invalidTemplate: Nem lehet oldalt létrehozni, érvénytelen sablon
+panel.pages.page.cannotCreate.varMissing: Nem lehet oldalt létrehozni, hiányzik egy változó
+panel.pages.page.cannotDelete.invalidLanguage: 'Nem lehet törölni az oldalt, érvénytelen nyelv: %s'
+panel.pages.page.cannotDelete.notDeletable: Nem lehet törölni az oldalt, az oldal nem törölhető
+panel.pages.page.cannotDelete.pageNotFound: Nem lehet törölni az oldalt, az oldal nem található
+panel.pages.page.cannotDuplicate.invalidFields: Nem lehet duplikálni az oldalt, egyes mezők érvénytelenek
+panel.pages.page.cannotDuplicate.notDuplicable: Nem lehet duplikálni az oldalt, az oldal nem duplikálható
+panel.pages.page.cannotDuplicate.pageNotFound: Nem lehet duplikálni az oldalt, az oldal nem található
+panel.pages.page.cannotEdit.alreadyExists: Nem lehet szerkeszteni az oldalt, az URI már létezik
+panel.pages.page.cannotEdit.indexOrErrorPageSlug: Nem lehet szerkeszteni az index- és hibaoldalak slugját
+panel.pages.page.cannotEdit.invalidFields: Nem lehet szerkeszteni az oldalt, egyes mezők érvénytelenek
+panel.pages.page.cannotEdit.invalidLanguage: 'Nem lehet szerkeszteni az oldalt, érvénytelen nyelv: %s'
+panel.pages.page.cannotEdit.invalidParent: Nem lehet szerkeszteni az oldalt, érvénytelen szülő oldal
+panel.pages.page.cannotEdit.invalidSlug: Nem lehet szerkeszteni a slugot, csak betűk és számok megengedettek kötőjelekkel elválasztva
+panel.pages.page.cannotEdit.invalidTemplate: Nem lehet szerkeszteni az oldalt, érvénytelen sablon
+panel.pages.page.cannotEdit.pageNotFound: Nem lehet szerkeszteni az oldalt, az oldal nem található
+panel.pages.page.cannotEdit.varMissing: Nem lehet szerkeszteni az oldalt, hiányzik egy változó
+panel.pages.page.cannotMove: Nem lehet áthelyezni az oldalt
+panel.pages.page.cannotPreview.pageNotFound: Nem lehet előnézetet megjeleníteni, az oldal nem található
+panel.pages.page.cannotPreview.parentChanged: Nem lehet előnézetet megjeleníteni, a szülő oldal megváltozott
+panel.pages.page.created: Oldal létrehozva!
+panel.pages.page.deleted: Oldal törölve
+panel.pages.page.edited: Oldal szerkesztve
+panel.pages.page.lastModified: Utolsó módosítás
+panel.pages.page.moved: Oldal áthelyezve!
+panel.pages.page.notFound: Oldal nem található
+panel.pages.pages: Oldalak
+panel.pages.pages.collapseAll: Összes összecsukása
+panel.pages.pages.expandAll: Összes kibontása
+panel.pages.pages.reorder: Átrendezés
+panel.pages.pages.search: Oldalak keresése...
+panel.pages.preview: Előnézet
+panel.pages.previewFile: Előnézet
+panel.pages.previous: Előző oldal
+panel.pages.publish: Közzététel
+panel.pages.renameFile: Fájl átnevezése
+panel.pages.renameFile.name: Név
+panel.pages.replaceFile: Fájl cseréje
+panel.pages.save: Mentés
+panel.pages.saveAndCreateNew: Mentés és új létrehozása
+panel.pages.saveOnly: Mentés közzététel nélkül
+panel.pages.toggleChildren: Gyermekoldalak váltása
+panel.pages.viewChildren: Gyermekoldalak megtekintése
+panel.pages.viewPage: Oldal megtekintése
+panel.panel: Adminisztrációs felület
+panel.plugins.info: Információ
+panel.plugins.nextPlugin: Következő bővítmény
+panel.plugins.plugin.cannotSave.invalidFields: Nem lehet menteni a bővítmény beállításait, egyes mezők érvénytelenek
+panel.plugins.plugin.disabled: Bővítmény letiltva
+panel.plugins.plugin.enabled: Bővítmény engedélyezve
+panel.plugins.plugin.notFound: Bővítmény nem található
+panel.plugins.plugin.saved: Bővítmény beállításai mentve
+panel.plugins.plugins: Bővítmények
+panel.plugins.previousPlugin: Előző bővítmény
+panel.register.createUser: A Formwork telepítve van, de nincs felhasználó. Kérjük, regisztráljon egyet most.
+panel.register.register: Új felhasználó regisztrálása
+panel.request.error.postMaxSize: A HTTP POST kérés meghaladja a megengedett maximális méretet
+panel.sections.toggle: Szakasz váltása
+panel.site.languages: Nyelvek
+panel.site.languages.availableLanguages: Elérhető nyelvek
+panel.site.languages.availableLanguages.noLanguages: Nincsenek nyelvek
+panel.site.languages.preferredLanguage: Böngésző által preferált nyelv használata
+panel.site.languages.preferredLanguage.disabled: Kikapcsolva
+panel.site.languages.preferredLanguage.enabled: Bekapcsolva
+panel.statistics.devices: Eszközök
+panel.statistics.devices.type: Típus
+panel.statistics.devices.type.desktop: Asztali
+panel.statistics.devices.type.mobile: Mobil
+panel.statistics.devices.type.tablet: Tablet
+panel.statistics.monthlyUniqueVisitors: Havi egyedi látogatók
+panel.statistics.monthlyVisits: Havi látogatások
+panel.statistics.sources: Források
+panel.statistics.sources.direct: Közvetlen
+panel.statistics.sources.site: Oldal
+panel.statistics.statistics: Statisztikák
+panel.statistics.totalVisits: Összes látogatás
+panel.statistics.totalVisits.percentTotal: '% összesen'
+panel.statistics.totalVisits.uri: URI
+panel.statistics.visits: Látogatások
+panel.statistics.weeklyUniqueVisitors: Heti egyedi látogatók
+panel.statistics.weeklyVisits: Heti látogatások
+panel.tools.backup.actions: Műveletek
+panel.tools.backup.date: Dátum
+panel.tools.backup.delete: Biztonsági mentés törlése
+panel.tools.backup.file: Fájl
+panel.tools.backup.size: Méret
+panel.tools.backups: Biztonsági mentések
+panel.tools.info: Információ
+panel.tools.latestBackup: 'Legutóbbi biztonsági mentés:'
+panel.tools.latestBackups: Legutóbbi biztonsági mentések
+panel.tools.tools: Eszközök
+panel.tools.updates: Frissítések
+panel.updates.availableForInstall: elérhető telepítésre
+panel.updates.check: Frissítések ellenőrzése
+panel.updates.install: Telepítés
+panel.updates.installed: Frissítés telepítve!
+panel.updates.installPrompt: Szeretné telepíteni a frissítést?
+panel.updates.latestVersionAvailable: a legfrissebb elérhető verzió
+panel.updates.status.cannotCheck: Nem lehet ellenőrizni a frissítéseket. Próbálja később.
+panel.updates.status.cannotInstall: Nem lehet telepíteni a frissítést
+panel.updates.status.cannotMakeBackup: Nem lehet biztonsági mentést készíteni frissítés előtt
+panel.updates.status.checking: Frissítések keresése...
+panel.updates.status.found: Frissítések találhatók
+panel.updates.status.installing: Frissítések telepítése...
+panel.updates.status.upToDate: Naprakész!
+panel.uploader.uploaded: Fájl feltöltve
+panel.user.actions: Műveletek
+panel.user.image.actions: Műveletek
+panel.user.image.cannotDelete.defaultImage: Az alapértelmezett felhasználói kép nem törölhető
+panel.user.image.delete: Felhasználói kép törlése
+panel.user.image.delete.prompt: Biztosan törli a felhasználói képet? A művelet nem vonható vissza.
+panel.user.image.deleted: Felhasználói kép törölve
+panel.user.image.uploaded: Felhasználói kép feltöltve
+panel.user.lastAccess: Utolsó hozzáférés
+panel.users.deleteUser: Felhasználó törlése
+panel.users.deleteUser.prompt: Biztosan törli ezt a felhasználót? A művelet nem vonható vissza.
+panel.users.newUser: Új felhasználó
+panel.users.newUser.password.suggestion: legalább 8 karakter
+panel.users.newUser.username.suggestion: 3–20 betű, szám és - . _
+panel.users.nextUser: Következő felhasználó
+panel.users.options: Beállítások
+panel.users.previousUser: Előző felhasználó
+panel.users.user.cannotChangeEmail.alreadyUsed: Nem lehet módosítani az e-mail címet, már használatban van
+panel.users.user.cannotChangePassword: Más felhasználó jelszava nem módosítható
+panel.users.user.cannotChangeRole: Nem lehet módosítani %s szerepkörét
+panel.users.user.cannotCreate.alreadyExists: Nem lehet létrehozni a felhasználót, már létezik ilyen nevű
+panel.users.user.cannotCreate.emailAlreadyUsed: Nem lehet létrehozni a felhasználót, az e-mail cím már használatban van
+panel.users.user.cannotCreate.invalidFields: Nem lehet létrehozni a felhasználót, egyes mezők érvénytelenek
+panel.users.user.cannotCreate.varMissing: Nem lehet létrehozni a felhasználót, hiányzik egy változó
+panel.users.user.cannotDelete: Nem lehet törölni a felhasználót. Adminisztrátor jogosultság szükséges, és a felhasználó nem lehet bejelentkezve.
+panel.users.user.cannotEdit: 'Nem lehet szerkeszteni a felhasználót: %s'
+panel.users.user.cannotEdit.invalidFields: Nem lehet szerkeszteni a felhasználót, egyes mezők érvénytelenek
+panel.users.user.created: Felhasználó létrehozva
+panel.users.user.deleted: Felhasználó törölve
+panel.users.user.edited: Felhasználói adatok frissítve
+panel.users.user.notFound: Felhasználó nem található
+panel.users.userProfile: '%s felhasználói profil'
+panel.users.users: Felhasználók
+panel.viewSite: Oldal megtekintése

--- a/panel/translations/sv.yaml
+++ b/panel/translations/sv.yaml
@@ -1,0 +1,364 @@
+panel.backup.backup: Säkerhetskopia
+panel.backup.deleted: Säkerhetskopian borttagen
+panel.backup.error.cannotDelete: Kan inte ta bort säkerhetskopian. %s.
+panel.backup.error.cannotDelete.invalidFilename: Ogiltig säkerhetskopifil
+panel.backup.error.cannotDownload: Kan inte ladda ner säkerhetskopian. %s.
+panel.backup.error.cannotDownload.invalidFilename: Ogiltig säkerhetskopifil
+panel.backup.error.cannotMake: Kan inte skapa säkerhetskopia. %s.
+panel.backup.ready: Säkerhetskopian är klar. Startar nedladdning...
+panel.cache.clear: Rensa cache
+panel.cache.clear.images: Rensa bildcache
+panel.cache.clear.pages: Rensa sidcache
+panel.cache.cleared: Cache rensad
+panel.cache.cleared.images: Bildcache rensad
+panel.cache.cleared.pages: Sidcache rensad
+panel.cache.error: Kan inte rensa cache
+panel.dashboard.dashboard: Kontrollpanel
+panel.dashboard.lastModifiedPages: Senast redigerade sidor
+panel.dashboard.quickActions: Snabba åtgärder
+panel.dashboard.statistics: Statistik
+panel.dashboard.statistics.uniqueVisitors: Unika besökare
+panel.dashboard.statistics.visits: Besök
+panel.dashboard.welcome: Välkommen
+panel.dragToReorder: Dra för att ändra ordning
+panel.editor.bold: Fetstil
+panel.editor.bulletList: Punktlista
+panel.editor.code: Kod
+panel.editor.decreaseIndent: Minska indrag
+panel.editor.heading1: Rubrik 1
+panel.editor.heading2: Rubrik 2
+panel.editor.heading3: Rubrik 3
+panel.editor.heading4: Rubrik 4
+panel.editor.heading5: Rubrik 5
+panel.editor.heading6: Rubrik 6
+panel.editor.image: Bild
+panel.editor.increaseIndent: Öka indrag
+panel.editor.italic: Kursiv
+panel.editor.link: Länk
+panel.editor.numberedList: Numrerad lista
+panel.editor.paragraph: Stycke
+panel.editor.quote: Citat
+panel.editor.redo: Gör om
+panel.editor.summary: Sammanfattning
+panel.editor.toggleMarkdown: Växla Markdown
+panel.editor.undo: Ångra
+panel.errors.action.reportToGithub: Rapportera ett problem på GitHub
+panel.errors.action.returnToDashboard: Gå tillbaka till kontrollpanelen
+panel.errors.error.forbidden.description: Du har inte behörighet att komma åt denna sida.
+panel.errors.error.forbidden.heading: Oj, behörighet krävs!
+panel.errors.error.forbidden.status: Förbjuden
+panel.errors.error.internalServerError.description: Formwork stötte på ett fel vid hantering av din begäran. Kontrollera Formwork-konfigurationen eller serverlogg för fel.
+panel.errors.error.internalServerError.heading: Oj, något gick fel!
+panel.errors.error.internalServerError.status: Intern serverfel
+panel.errors.error.notFound.description: Sidan finns inte eller begäran är ogiltig.
+panel.errors.error.notFound.heading: Oj, sidan hittades inte!
+panel.errors.error.notFound.status: Hittades inte
+panel.files.actions: Åtgärder
+panel.files.backToPage: Tillbaka till sidan
+panel.files.cannotDelete.fileNotFound: Kan inte ta bort fil, filen hittades inte
+panel.files.cannotDelete.pageNotFound: Kan inte ta bort fil, filen hittades inte
+panel.files.cannotRename.fileAlreadyExists: Kan inte byta namn på fil, en fil med samma namn finns redan
+panel.files.cannotRename.fileNotFound: Kan inte byta namn på fil, filen hittades inte
+panel.files.cannotRename.invalidFields: Kan inte byta namn på fil, vissa fält är ogiltiga
+panel.files.cannotRename.pageNotFound: Kan inte byta namn på fil, sidan hittades inte
+panel.files.cannotReplace.fileNotFound: Kan inte ersätta fil, filen hittades inte
+panel.files.cannotReplace.multipleFiles: Kan inte ersätta fil, flera filer angivna
+panel.files.cannotReplace.pageNotFound: Kan inte ersätta fil, sidan hittades inte
+panel.files.cannotUpload.invalidFields: Kan inte ladda upp fil, vissa fält är ogiltiga
+panel.files.cannotUpload.pageNotFound: Kan inte ladda upp fil, sidan hittades inte
+panel.files.deleted: Fil borttagen
+panel.files.exif: EXIF
+panel.files.fileNotFound: Kan inte hämta filinformation, filen hittades inte
+panel.files.files: Filer
+panel.files.info: Information
+panel.files.info.image.colorDepth: Färgdjup
+panel.files.info.image.colorNumber: Antal färger
+panel.files.info.image.colorProfile: Färgprofil
+panel.files.info.image.colorSpace: Färgrymd
+panel.files.info.image.dimensions: Dimensioner
+panel.files.info.image.dimensions.widthByHeightPixels: '%d × %d pixlar'
+panel.files.info.image.exif.aperture: Bländare
+panel.files.info.image.exif.camera: Kamera
+panel.files.info.image.exif.creationDateAndTime: Skapelsedatum och tid
+panel.files.info.image.exif.exposureCompensation: Exponeringskompensation
+panel.files.info.image.exif.exposureProgram: Exponeringsprogram
+panel.files.info.image.exif.exposureTime: Exponeringstid
+panel.files.info.image.exif.flash: Blitz
+panel.files.info.image.exif.focalLength: Brännvidd
+panel.files.info.image.exif.lensModel: Objektivmodell
+panel.files.info.image.exif.meteringMode: Mätläge
+panel.files.info.image.exif.sensitivity: Känslighet
+panel.files.info.image.exif.whiteBalance: Vitbalans
+panel.files.info.image.frames: '%d ramar'
+panel.files.info.image.framesCount: Antal ramar
+panel.files.info.image.repeats: '%d upprepningar'
+panel.files.info.image.repeatsCount: Antal upprepningar
+panel.files.info.image.resolution: Upplösning
+panel.files.info.lastModifiedTime: Senast ändrad
+panel.files.info.mimeType: MIME-typ
+panel.files.info.name: Namn
+panel.files.info.size: Storlek
+panel.files.info.uri: URI
+panel.files.metadata.cannotUpdate.invalidFields: Kan inte uppdatera filmetadata, vissa fält är ogiltiga
+panel.files.metadata.updated: Filmetadata uppdaterad
+panel.files.next: Nästa fil
+panel.files.pageNotFound: Kan inte hämta filinformation, sidan hittades inte
+panel.files.parent: Överordnad
+panel.files.position: Position
+panel.files.preview: Förhandsgranska
+panel.files.previous: Föregående fil
+panel.files.renamed: Fil namnändrad
+panel.files.search: Sök filer...
+panel.files.upload: Ladda upp filer
+panel.files.uploaded: Filer uppladdade
+panel.files.viewAsList: Visa som lista
+panel.files.viewAsThumbnails: Visa som miniatyrer
+panel.login.attempt.failed: Inloggningsförsök misslyckades! Försök igen.
+panel.login.attempt.tooMany: För många inloggningsförsök. Försök igen om %d minuter.
+panel.login.loggedOut: Du har loggats ut
+panel.login.login: Logga in
+panel.login.logout: Logga ut
+panel.login.password: Lösenord
+panel.login.suspiciousRequestDetected: En misstänkt begäran har upptäckts och av säkerhetsskäl har du loggats ut. Logga in igen.
+panel.login.usernameOrEmail: Användarnamn eller e-post
+panel.manage: Hantera
+panel.modal.action.cancel: Avbryt
+panel.modal.action.continue: Fortsätt
+panel.modal.action.delete: Ta bort
+panel.modal.action.edit: Redigera
+panel.modal.action.rename: Byt namn
+panel.modal.action.save: Spara
+panel.modal.action.upload: Ladda upp
+panel.modal.action.uploadFile: Ladda upp fil
+panel.modal.images.noImages: Inga bilder här
+panel.modal.images.noImages.upload: Ladda upp några bilder
+panel.modal.images.title: Välj en bild
+panel.modal.link.text: Text
+panel.modal.link.title: Infoga länk
+panel.modal.link.uri: URI
+panel.navigation.toggle: Växla navigation
+panel.options.cannotUpdate.invalidFields: Kan inte uppdatera alternativ, vissa fält är ogiltiga
+panel.options.options: Alternativ
+panel.options.site: Webbplats
+panel.options.system: System
+panel.options.system.adminPanel: Administrationspanel
+panel.options.system.adminPanel.defaultColorScheme: Standardfärgschema
+panel.options.system.adminPanel.defaultColorScheme.dark: Mörkt
+panel.options.system.adminPanel.defaultColorScheme.light: Ljust
+panel.options.system.adminPanel.defaultLanguage: Standardspråk
+panel.options.system.adminPanel.logoutRedirectsTo: Vid utloggning, omdirigera till
+panel.options.system.adminPanel.logoutRedirectsTo.home: Startsida
+panel.options.system.adminPanel.logoutRedirectsTo.login: Inloggning
+panel.options.system.backup: Säkerhetskopia
+panel.options.system.backup.backupFilesToKeep: Säkerhetskopior att behålla på servern
+panel.options.system.cache: Cache
+panel.options.system.cache.disabled: Inaktiverad
+panel.options.system.cache.enabled: Aktiverad
+panel.options.system.cache.time: Cache-tid
+panel.options.system.content: Innehåll
+panel.options.system.content.allowHtml: Tillåt HTML i Markdown-fält
+panel.options.system.content.allowHtml.description: Potentiellt farliga taggar som `<script>` och `<style>` konverteras alltid till text
+panel.options.system.content.allowHtml.disabled: Inaktiverad
+panel.options.system.content.allowHtml.enabled: Aktiverad
+panel.options.system.dateAndTime: Datum och tid
+panel.options.system.dateAndTime.dateFormat: Datumformat
+panel.options.system.dateAndTime.firstWeekday: Första veckodagen
+panel.options.system.dateAndTime.firstWeekday.monday: Måndag
+panel.options.system.dateAndTime.firstWeekday.sunday: Söndag
+panel.options.system.dateAndTime.hourFormat: Tidsformat
+panel.options.system.dateAndTime.timezone: Tidszon
+panel.options.system.debug: Felsökning
+panel.options.system.debug.editorUri: Editor-URI
+panel.options.system.debug.editorUri.description: Använd `{{filename}}` och `{{line}}` för att bygga URI till kodeditorn
+panel.options.system.debug.mode: Felsökningsläge
+panel.options.system.debug.mode.description: Felsökningsläge visar felinformation och bör inaktiveras i produktion då det kan avslöja känslig data
+panel.options.system.debug.mode.disabled: Inaktiverad
+panel.options.system.debug.mode.enabled: Aktiverad
+panel.options.system.files: Filer
+panel.options.system.files.allowedExtensions: Tillåtna filändelser
+panel.options.system.files.allowedExtensions.noExtensions: Inga filändelser (ingen fil tillåten)
+panel.options.system.images: Bilder
+panel.options.system.images.avifQuality: AVIF-kvalitet
+panel.options.system.images.clearCacheByDefault: Rensa bildcache som standard
+panel.options.system.images.clearCacheByDefault.disabled: Inaktiverad
+panel.options.system.images.clearCacheByDefault.enabled: Aktiverad
+panel.options.system.images.jpegQuality: JPEG-kvalitet
+panel.options.system.images.jpegSaveProgressive: Spara JPEG-bilder som progressiva
+panel.options.system.images.jpegSaveProgressive.disabled: Inaktiverad
+panel.options.system.images.jpegSaveProgressive.enabled: Aktiverad
+panel.options.system.images.pngCompressionLevel: PNG-komprimeringsnivå
+panel.options.system.images.webpQuality: WebP-kvalitet
+panel.options.system.session.duration: Sessionstid
+panel.options.system.sessions: Sessioner
+panel.options.system.uploads.processImages: Behandla (optimera) uppladdade bilder
+panel.options.system.uploads.processImages.disabled: Inaktiverad
+panel.options.system.uploads.processImages.enabled: Aktiverad
+panel.options.updated: Alternativ uppdaterade
+panel.pages.changes.continue: Fortsätt utan att spara
+panel.pages.changes.detected: Ändringar upptäckta
+panel.pages.changes.detected.prompt: Du har ändringar som inte har sparats. Är du säker på att du vill lämna denna sida?
+panel.pages.changeSlug: Ändra slug
+panel.pages.changeSlug.generate: Generera från titel
+panel.pages.deleteFile: Ta bort fil
+panel.pages.deleteFile.prompt: Är du säker på att du vill ta bort denna fil? Åtgärden kan inte ångras.
+panel.pages.deletePage: Ta bort sida
+panel.pages.deletePage.prompt: Är du säker på att du vill ta bort denna sida? Åtgärden kan inte ångras.
+panel.pages.duplicatePage: Duplicera sida
+panel.pages.duplicatePage.title: '%s kopia'
+panel.pages.edit: Redigera sida
+panel.pages.editPage: Redigera sida %s
+panel.pages.history.event.created: Sida skapad av %s %s.
+panel.pages.history.event.edited: Sida redigerad av %s %s.
+panel.pages.languages: Språk
+panel.pages.languages.addLanguage: Lägg till %s
+panel.pages.languages.editLanguage: Redigera %s
+panel.pages.newPage: Ny sida
+panel.pages.newPage.site: Webbplats
+panel.pages.next: Nästa sida
+panel.pages.page: Sida
+panel.pages.page.actions: Åtgärder
+panel.pages.page.cannotChangeNum: Kan inte ändra sidnummer
+panel.pages.page.cannotCreate: Kan inte skapa sida
+panel.pages.page.cannotCreate.alreadyExists: Kan inte skapa sida, en sida med samma URI finns redan
+panel.pages.page.cannotCreate.invalidFields: Kan inte skapa sida, vissa fält är ogiltiga
+panel.pages.page.cannotCreate.invalidParent: Kan inte skapa sida, ogiltig överordnad sida
+panel.pages.page.cannotCreate.invalidSlug: Kan inte skapa sida, sidslug måste innehålla endast bokstäver och siffror separerade med bindestreck
+panel.pages.page.cannotCreate.invalidTemplate: Kan inte skapa sida, ogiltig mall
+panel.pages.page.cannotCreate.varMissing: Kan inte skapa sida, variabel saknas
+panel.pages.page.cannotDelete.invalidLanguage: 'Kan inte ta bort sida, ogiltigt språk: %s'
+panel.pages.page.cannotDelete.notDeletable: Kan inte ta bort sida, sidan kan inte tas bort
+panel.pages.page.cannotDelete.pageNotFound: Kan inte ta bort sida, sidan hittades inte
+panel.pages.page.cannotDuplicate.invalidFields: Kan inte duplicera sida, vissa fält är ogiltiga
+panel.pages.page.cannotDuplicate.notDuplicable: Kan inte duplicera sida, sidan kan inte dupliceras
+panel.pages.page.cannotDuplicate.pageNotFound: Kan inte duplicera sida, sidan hittades inte
+panel.pages.page.cannotEdit.alreadyExists: Kan inte redigera sida, en sida med samma URI finns redan
+panel.pages.page.cannotEdit.indexOrErrorPageSlug: Kan inte redigera sidslug för index- eller felsida
+panel.pages.page.cannotEdit.invalidFields: Kan inte redigera sida, vissa fält är ogiltiga
+panel.pages.page.cannotEdit.invalidLanguage: 'Kan inte redigera sida, ogiltigt språk: %s'
+panel.pages.page.cannotEdit.invalidParent: Kan inte redigera sida, ogiltig överordnad sida
+panel.pages.page.cannotEdit.invalidSlug: Kan inte redigera sidslug, den måste innehålla endast bokstäver och siffror separerade med bindestreck
+panel.pages.page.cannotEdit.invalidTemplate: Kan inte redigera sida, ogiltig mall
+panel.pages.page.cannotEdit.pageNotFound: Kan inte redigera sida, sidan hittades inte
+panel.pages.page.cannotEdit.varMissing: Kan inte redigera sida, variabel saknas
+panel.pages.page.cannotMove: Kan inte flytta sida
+panel.pages.page.cannotPreview.pageNotFound: Kan inte förhandsgranska sida, sidan hittades inte
+panel.pages.page.cannotPreview.parentChanged: Kan inte förhandsgranska sida, överordnad sida har ändrats
+panel.pages.page.created: Sida skapad!
+panel.pages.page.deleted: Sida borttagen
+panel.pages.page.edited: Sida redigerad
+panel.pages.page.lastModified: Senast ändrad
+panel.pages.page.moved: Sida flyttad!
+panel.pages.page.notFound: Sida hittades inte
+panel.pages.pages: Sidor
+panel.pages.pages.collapseAll: Kollapsa alla
+panel.pages.pages.expandAll: Expandera alla
+panel.pages.pages.reorder: Ändra ordning
+panel.pages.pages.search: Sök sidor...
+panel.pages.preview: Förhandsgranska
+panel.pages.previewFile: Förhandsgranska
+panel.pages.previous: Föregående sida
+panel.pages.publish: Publicera
+panel.pages.renameFile: Byt namn på fil
+panel.pages.renameFile.name: Namn
+panel.pages.replaceFile: Ersätt fil
+panel.pages.save: Spara
+panel.pages.saveAndCreateNew: Spara och skapa ny
+panel.pages.saveOnly: Spara utan publicering
+panel.pages.toggleChildren: Växla barn-sidor
+panel.pages.viewChildren: Visa barn-sidor
+panel.pages.viewPage: Visa sida
+panel.panel: Administrationspanel
+panel.plugins.info: Information
+panel.plugins.nextPlugin: Nästa plugin
+panel.plugins.plugin.cannotSave.invalidFields: Kan inte spara plugin-alternativ, vissa fält är ogiltiga
+panel.plugins.plugin.disabled: Plugin inaktiverad
+panel.plugins.plugin.enabled: Plugin aktiverad
+panel.plugins.plugin.notFound: Plugin hittades inte
+panel.plugins.plugin.saved: Plugin-alternativ sparade
+panel.plugins.plugins: Plugins
+panel.plugins.previousPlugin: Föregående plugin
+panel.register.createUser: Formwork är installerat men inga användare hittades. Registrera en användare nu.
+panel.register.register: Registrera ny användare
+panel.request.error.postMaxSize: HTTP POST-begäran överskrider maximal tillåten storlek
+panel.sections.toggle: Växla sektion
+panel.site.languages: Språk
+panel.site.languages.availableLanguages: Tillgängliga språk
+panel.site.languages.availableLanguages.noLanguages: Inga språk
+panel.site.languages.preferredLanguage: Använd webbläsarens föredragna språk
+panel.site.languages.preferredLanguage.disabled: Inaktiverad
+panel.site.languages.preferredLanguage.enabled: Aktiverad
+panel.statistics.devices: Enheter
+panel.statistics.devices.type: Typ
+panel.statistics.devices.type.desktop: Stationär dator
+panel.statistics.devices.type.mobile: Mobil
+panel.statistics.devices.type.tablet: Surfplatta
+panel.statistics.monthlyUniqueVisitors: Månatliga unika besökare
+panel.statistics.monthlyVisits: Månatliga besök
+panel.statistics.sources: Källor
+panel.statistics.sources.direct: Direkt
+panel.statistics.sources.site: Webbplats
+panel.statistics.statistics: Statistik
+panel.statistics.totalVisits: Totalt antal besök
+panel.statistics.totalVisits.percentTotal: '% av total'
+panel.statistics.totalVisits.uri: URI
+panel.statistics.visits: Besök
+panel.statistics.weeklyUniqueVisitors: Veckovisa unika besökare
+panel.statistics.weeklyVisits: Veckovisa besök
+panel.tools.backup.actions: Åtgärder
+panel.tools.backup.date: Datum
+panel.tools.backup.delete: Ta bort säkerhetskopia
+panel.tools.backup.file: Fil
+panel.tools.backup.size: Storlek
+panel.tools.backups: Säkerhetskopior
+panel.tools.info: Information
+panel.tools.latestBackup: 'Senaste säkerhetskopian:'
+panel.tools.latestBackups: Senaste säkerhetskopiorna
+panel.tools.tools: Verktyg
+panel.tools.updates: Uppdateringar
+panel.updates.availableForInstall: finns tillgänglig för installation
+panel.updates.check: Kontrollera uppdateringar
+panel.updates.install: Installera
+panel.updates.installed: Uppdatering installerad!
+panel.updates.installPrompt: Vill du installera uppdateringen?
+panel.updates.latestVersionAvailable: är den senaste tillgängliga versionen
+panel.updates.status.cannotCheck: Kan inte kontrollera uppdateringar. Försök senare.
+panel.updates.status.cannotInstall: Kan inte installera uppdatering
+panel.updates.status.cannotMakeBackup: Kan inte skapa säkerhetskopia före uppdatering
+panel.updates.status.checking: Kontrollerar uppdateringar...
+panel.updates.status.found: Uppdateringar hittades
+panel.updates.status.installing: Installerar uppdateringar...
+panel.updates.status.upToDate: Uppdaterad!
+panel.uploader.uploaded: Fil uppladdad
+panel.user.actions: Åtgärder
+panel.user.image.actions: Åtgärder
+panel.user.image.cannotDelete.defaultImage: Kan inte ta bort standardanvändarbilden
+panel.user.image.delete: Ta bort användarbild
+panel.user.image.delete.prompt: Är du säker på att du vill ta bort användarbilden? Åtgärden kan inte ångras.
+panel.user.image.deleted: Användarbild borttagen
+panel.user.image.uploaded: Användarbild uppladdad
+panel.user.lastAccess: Senaste åtkomst
+panel.users.deleteUser: Ta bort användare
+panel.users.deleteUser.prompt: Är du säker på att du vill ta bort denna användare? Åtgärden kan inte ångras.
+panel.users.newUser: Ny användare
+panel.users.newUser.password.suggestion: minst 8 tecken
+panel.users.newUser.username.suggestion: mellan 3-20 bokstäver, siffror och - . _
+panel.users.nextUser: Nästa användare
+panel.users.options: Alternativ
+panel.users.previousUser: Föregående användare
+panel.users.user.cannotChangeEmail.alreadyUsed: Kan inte ändra användarens e-post, adressen är redan associerad med ett konto
+panel.users.user.cannotChangePassword: Kan inte ändra lösenordet för en annan användare. Åtgärden är inte tillåten.
+panel.users.user.cannotChangeRole: Kan inte ändra rollen för %s. Åtgärden är inte tillåten.
+panel.users.user.cannotCreate.alreadyExists: Kan inte skapa användare, en användare med samma namn finns redan
+panel.users.user.cannotCreate.emailAlreadyUsed: Kan inte skapa användare, e-postadressen är redan associerad med ett konto
+panel.users.user.cannotCreate.invalidFields: Kan inte skapa användare, vissa fält är ogiltiga
+panel.users.user.cannotCreate.varMissing: Kan inte skapa användare, variabel saknas
+panel.users.user.cannotDelete: Kan inte ta bort användare. Du måste vara administratör och användaren får inte vara inloggad.
+panel.users.user.cannotEdit: Kan inte redigera användare %s. Åtgärden är inte tillåten.
+panel.users.user.cannotEdit.invalidFields: Kan inte redigera användare, vissa fält är ogiltiga
+panel.users.user.created: Användare skapad
+panel.users.user.deleted: Användare borttagen
+panel.users.user.edited: Användardata uppdaterad
+panel.users.user.notFound: Användare hittades inte
+panel.users.userProfile: '%s användarprofil'
+panel.users.users: Användare
+panel.viewSite: Visa webbplats


### PR DESCRIPTION
This pull request adds new Hungarian and Swedish translation files for the application, significantly expanding language support. The translations cover a wide range of user interface elements, error messages, and system labels to provide a localized experience for Hungarian and Swedish users.

**Hungarian translations (`formwork/translations/hu.yaml`):**

* Added a comprehensive set of Hungarian translations for UI elements, error messages, date/time formats, and system labels.

**Swedish translations (`formwork/translations/sv.yaml`):**

* Added a comprehensive set of Swedish translations for UI elements, error messages, date/time formats, and system labels.