### PR TITLE
Use click event instead of mousedown to avoid unexpected actions in the panel

### DIFF
--- a/panel/src/ts/components/inputs/date-input.ts
+++ b/panel/src/ts/components/inputs/date-input.ts
@@ -432,7 +432,7 @@ class Calendar {
         ($(".prevMonth", element) as HTMLElement).innerHTML = chevronLeft;
         ($(".nextMonth", element) as HTMLElement).innerHTML = chevronRight;
 
-        ($(".currentMonth", element) as HTMLElement).addEventListener("mousedown", (event) => {
+        ($(".currentMonth", element) as HTMLElement).addEventListener("click", (event) => {
             this.now();
             this.dispatchChange();
             event.preventDefault();

--- a/panel/src/ts/components/inputs/select-input.ts
+++ b/panel/src/ts/components/inputs/select-input.ts
@@ -221,13 +221,15 @@ export class SelectInput {
         item.addEventListener("mousedown", (event) => {
             if (!item.classList.contains("disabled")) {
                 mousedownCaptured = true;
+                this.selectDropdownItem(item);
             }
             event.preventDefault();
             event.stopPropagation();
         });
 
         item.addEventListener("click", (event) => {
-            if (mousedownCaptured) {
+            const keyboardActivation = event.detail === 0;
+            if (mousedownCaptured || keyboardActivation) {
                 this.setCurrent(item);
                 this.labelInput.blur();
             }

--- a/panel/src/ts/components/inputs/select-input.ts
+++ b/panel/src/ts/components/inputs/select-input.ts
@@ -216,13 +216,23 @@ export class SelectInput {
             item.dataset[key] = option.dataset[key];
         }
 
+        let mousedownCaptured = false;
+
         item.addEventListener("mousedown", (event) => {
             if (!item.classList.contains("disabled")) {
-                this.selectDropdownItem(item);
-                this.setCurrent(item);
-            } else {
-                event.preventDefault();
+                mousedownCaptured = true;
             }
+            event.preventDefault();
+            event.stopPropagation();
+        });
+
+        item.addEventListener("click", (event) => {
+            if (mousedownCaptured) {
+                this.setCurrent(item);
+                this.labelInput.blur();
+            }
+            mousedownCaptured = false;
+            event.preventDefault();
             event.stopPropagation();
         });
 

--- a/panel/src/ts/components/inputs/tags-input.ts
+++ b/panel/src/ts/components/inputs/tags-input.ts
@@ -429,7 +429,8 @@ export class TagsInput {
         });
 
         tagRemove.addEventListener("click", (event) => {
-            if (mousedownCaptured) {
+            const keyboardActivation = event.detail === 0;
+            if (mousedownCaptured || keyboardActivation) {
                 this.removeTag(value);
                 parent.removeChild(tag);
             }

--- a/panel/src/ts/components/inputs/tags-input.ts
+++ b/panel/src/ts/components/inputs/tags-input.ts
@@ -130,7 +130,6 @@ export class TagsInput {
             Sortable.create(this.list, {
                 forceFallback: true,
                 animation: 150,
-                filter: ".tag-remove",
 
                 onChoose: () => {
                     if (this.dropdown) {
@@ -140,13 +139,6 @@ export class TagsInput {
 
                 onStart: () => {
                     this.field.classList.add("is-dragging");
-                },
-
-                onFilter: (event: SortableEvent) => {
-                    if (event.target.matches(".tag-remove")) {
-                        this.removeTag(event.item.innerText);
-                        this.list.removeChild(event.item);
-                    }
                 },
 
                 onEnd: (event: SortableEvent) => {
@@ -428,10 +420,22 @@ export class TagsInput {
         tagRemove.title = this.options.labels.remove;
         tagRemove.role = "button";
 
+        let mousedownCaptured = false;
+
         tagRemove.addEventListener("mousedown", (event) => {
-            this.removeTag(value);
-            parent.removeChild(tag);
+            mousedownCaptured = true;
             event.preventDefault();
+            event.stopPropagation();
+        });
+
+        tagRemove.addEventListener("click", (event) => {
+            if (mousedownCaptured) {
+                this.removeTag(value);
+                parent.removeChild(tag);
+            }
+            mousedownCaptured = false;
+            event.preventDefault();
+            event.stopPropagation();
         });
         tag.appendChild(tagRemove);
     }


### PR DESCRIPTION
This pull request improves the consistency and reliability of user interactions in several input components by refining event handling logic, particularly around mouse and click events. The changes help prevent unintended behaviors such as duplicate actions or event propagation issues, and also simplify the drag-and-drop functionality in the tags input.

**Event handling improvements:**

* Changed the event listener for the `.currentMonth` element in the `Calendar` component from `mousedown` to `click` to better align with standard user interaction expectations.
* Updated the `SelectInput` component to use a combination of `mousedown` and `click` event listeners with a `mousedownCaptured` flag, ensuring that selection logic and focus management are handled more predictably and preventing duplicate or missed actions.
* Refined the tag removal logic in the `TagsInput` component by introducing `mousedown` and `click` event listeners with a `mousedownCaptured` flag on the remove button, ensuring that tag removal is triggered only once per user action and preventing event propagation issues.

**Drag-and-drop simplification in tags input:**

* Removed the `filter` option and the `onFilter` handler from the `Sortable.create` call in the `TagsInput` component, streamlining the drag-and-drop implementation and centralizing tag removal logic. [[1]](diffhunk://#diff-cde8f2a93e15aa42d95453dd3f23c03edb70e46fd21a2d4088a4ec87059df794L133) [[2]](diffhunk://#diff-cde8f2a93e15aa42d95453dd3f23c03edb70e46fd21a2d4088a4ec87059df794L145-L151)