### PR TITLE
Allow `Container::buildArguments()` to use default values for unspecified classes, interfaces and support variadic parameters

### DIFF
--- a/formwork/src/Services/Container.php
+++ b/formwork/src/Services/Container.php
@@ -242,6 +242,12 @@ class Container
                 continue;
             }
 
+            // Resolve class/interface if defined in the container
+            if ($type instanceof ReflectionNamedType && !$type->isBuiltin() && $this->has($type->getName())) {
+                $arguments[] = $this->get($type->getName());
+                continue;
+            }
+
             if ($reflectionParameter->isDefaultValueAvailable()) {
                 $arguments[] = $reflectionParameter->getDefaultValue();
                 continue;
@@ -252,11 +258,7 @@ class Container
                 continue;
             }
 
-            if (!$type instanceof ReflectionNamedType || $type->isBuiltin()) {
-                throw new LogicException(sprintf('Cannot instantiate argument $%s', $name));
-            }
-
-            $arguments[] = $this->get($type->getName());
+            throw new LogicException(sprintf('Cannot instantiate argument $%s', $name));
         }
 
         return $arguments;

--- a/formwork/src/Services/Container.php
+++ b/formwork/src/Services/Container.php
@@ -230,19 +230,29 @@ class Container
             $name = $reflectionParameter->getName();
 
             if (array_key_exists($name, $parameters)) {
+                if ($reflectionParameter->isVariadic()) {
+                    if (!is_array($parameters[$name])) {
+                        throw new LogicException(sprintf('The parameter for the variadic argument $%s must be an array', $name));
+                    }
+                    $arguments = [...$arguments, ...array_values($parameters[$name])];
+                    continue;
+                }
+
                 $arguments[] = $parameters[$name];
                 continue;
             }
 
-            if (!$type instanceof ReflectionNamedType || $type->isBuiltin()) {
-                if ($reflectionParameter->isOptional()) {
-                    continue;
-                }
-                if ($reflectionParameter->isDefaultValueAvailable()) {
-                    $arguments[] = $reflectionParameter->getDefaultValue();
-                    continue;
-                }
+            if ($reflectionParameter->isDefaultValueAvailable()) {
+                $arguments[] = $reflectionParameter->getDefaultValue();
+                continue;
+            }
 
+            // Skip optional parameters without default value (variadic parameters)
+            if ($reflectionParameter->isOptional()) {
+                continue;
+            }
+
+            if (!$type instanceof ReflectionNamedType || $type->isBuiltin()) {
                 throw new LogicException(sprintf('Cannot instantiate argument $%s', $name));
             }
 

--- a/formwork/src/Services/Container.php
+++ b/formwork/src/Services/Container.php
@@ -232,7 +232,7 @@ class Container
             if (array_key_exists($name, $parameters)) {
                 if ($reflectionParameter->isVariadic()) {
                     if (!is_array($parameters[$name])) {
-                        throw new LogicException(sprintf('The parameter for the variadic argument $%s must be an array', $name));
+                        throw new LogicException(sprintf('The parameter value for the variadic argument $%s must be an array', $name));
                     }
                     $arguments = [...$arguments, ...array_values($parameters[$name])];
                     continue;
@@ -253,12 +253,12 @@ class Container
                 continue;
             }
 
-            // Skip optional parameters without default value (variadic parameters)
+            // Skip optional parameters without default value (e.g., variadic parameters)
             if ($reflectionParameter->isOptional()) {
                 continue;
             }
 
-            throw new LogicException(sprintf('Cannot instantiate argument $%s', $name));
+            throw new LogicException(sprintf('Cannot instantiate argument $%s: no container definition satisfies the parameter type and no default value is available', $name));
         }
 
         return $arguments;


### PR DESCRIPTION
This pull request improves the handling of variadic parameters and optional parameters in the `buildArguments` method within the dependency injection container. The changes add stricter type checking and error handling for variadic arguments, and clarify the logic for optional parameters.

**Parameter handling improvements:**

* Added a check to ensure that values provided for variadic parameters are arrays, throwing a `LogicException` if not, and expanded the arguments list accordingly.
* Improved handling of optional parameters without default values, especially for variadic parameters, by skipping them appropriately.
* Refined the order of type checks and error handling for non-built-in types, ensuring that a `LogicException` is thrown only when necessary.