### PR TITLE
Implement PSR-11 `ContainerInterface`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "mobiledetect/mobiledetectlib": "^4.8",
         "symfony/polyfill-ctype": "^1.23",
         "symfony/process": "^7.3",
-        "symfony/yaml": "^7.0.3"
+        "symfony/yaml": "^7.0.3",
+        "psr/container": "^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3401b16f31d82d76621fc0029be2c7c8",
+    "content-hash": "e556167506a02a0028ec1dd05d04dce4",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -722,6 +722,59 @@
                 "source": "https://github.com/php-fig/cache/tree/3.0.0"
             },
             "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -1855,59 +1908,6 @@
                 }
             ],
             "time": "2025-11-11T15:18:17+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/2.0.2"
-            },
-            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "react/cache",
@@ -3692,5 +3692,5 @@
         "ext-zip": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/formwork/src/Services/Container.php
+++ b/formwork/src/Services/Container.php
@@ -3,14 +3,16 @@
 namespace Formwork\Services;
 
 use Closure;
+use Formwork\Services\Exceptions\ContainerException;
+use Formwork\Services\Exceptions\ServiceNotFoundException;
 use Formwork\Services\Exceptions\ServiceResolutionException;
-use LogicException;
+use Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionFunction;
 use ReflectionFunctionAbstract;
 use ReflectionNamedType;
 
-class Container
+class Container implements ContainerInterface
 {
     /**
      * Defined services
@@ -89,7 +91,7 @@ class Container
     public function alias(string $alias, string $target): void
     {
         if ($alias === $target) {
-            throw new LogicException(sprintf('Cannot alias "%s" to itself', $target));
+            throw new ContainerException(sprintf('Cannot alias "%s" to itself', $target));
         }
         $this->aliases[$alias] = $target;
     }
@@ -106,7 +108,7 @@ class Container
     public function get(string $name): object
     {
         if (!$this->has($name)) {
-            throw new LogicException(sprintf('Instance of "%s" not found', $name));
+            throw new ServiceNotFoundException(sprintf('Instance of "%s" not found', $name));
         }
         if (isset($this->aliases[$name])) {
             $alias = $this->aliases[$name];
@@ -232,7 +234,7 @@ class Container
             if (array_key_exists($name, $parameters)) {
                 if ($reflectionParameter->isVariadic()) {
                     if (!is_array($parameters[$name])) {
-                        throw new LogicException(sprintf('The parameter value for the variadic argument $%s must be an array', $name));
+                        throw new ContainerException(sprintf('The parameter value for the variadic argument $%s must be an array', $name));
                     }
                     $arguments = [...$arguments, ...array_values($parameters[$name])];
                     continue;
@@ -258,7 +260,11 @@ class Container
                 continue;
             }
 
-            throw new LogicException(sprintf('Cannot instantiate argument $%s: no container definition satisfies the parameter type and no default value is available', $name));
+            if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {
+                throw new ServiceNotFoundException(sprintf('Cannot instantiate argument $%s: no container definition satisfies the parameter type "%s" and no default value is available', $name, $type->getName()));
+            }
+
+            throw new ContainerException(sprintf('Cannot instantiate argument $%s: no default value is available', $name));
         }
 
         return $arguments;

--- a/formwork/src/Services/Exceptions/ContainerException.php
+++ b/formwork/src/Services/Exceptions/ContainerException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Formwork\Services\Exceptions;
+
+use LogicException;
+use Psr\Container\ContainerExceptionInterface;
+
+class ContainerException extends LogicException implements ContainerExceptionInterface {}

--- a/formwork/src/Services/Exceptions/ServiceNotFoundException.php
+++ b/formwork/src/Services/Exceptions/ServiceNotFoundException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Formwork\Services\Exceptions;
+
+use LogicException;
+use Psr\Container\NotFoundExceptionInterface;
+
+class ServiceNotFoundException extends LogicException implements NotFoundExceptionInterface {}

--- a/formwork/src/Services/Exceptions/ServiceResolutionException.php
+++ b/formwork/src/Services/Exceptions/ServiceResolutionException.php
@@ -2,6 +2,7 @@
 
 namespace Formwork\Services\Exceptions;
 
+use Psr\Container\ContainerExceptionInterface;
 use RuntimeException;
 
-class ServiceResolutionException extends RuntimeException {}
+class ServiceResolutionException extends RuntimeException implements ContainerExceptionInterface {}


### PR DESCRIPTION
This pull request updates the dependency injection container to implement the PSR-11 standard (`psr/container`) and improves error handling by introducing custom exception classes that conform to PSR-11 interfaces. The changes ensure better interoperability with other libraries and provide more precise exception types for container-related errors.

**PSR-11 Compliance:**

* The `Container` class now implements `Psr\Container\ContainerInterface`, making it PSR-11 compliant and compatible with other libraries expecting a standard container interface.

**Improved Exception Handling:**

* Introduced custom exceptions: `ContainerException` and `ServiceNotFoundException`, both implementing the corresponding PSR-11 interfaces for better error granularity and standardization. [[1]](diffhunk://#diff-b59360369a507f1812346ef5afb577c45615939af2fd6836fc7078c6fa174e01R1-R8) [[2]](diffhunk://#diff-70234f9e538bf8315f9b54757ef6a1f3ede788433c9d70943925a82c22ab747cR1-R8)
* Updated the container logic to throw these new exceptions instead of generic `LogicException` for various error cases, such as aliasing to self, missing services, and invalid variadic arguments. [[1]](diffhunk://#diff-00f523621f516620148576ff70c3fcebad04a6849d09682d6886165e81764a18L92-R94) [[2]](diffhunk://#diff-00f523621f516620148576ff70c3fcebad04a6849d09682d6886165e81764a18L109-R111) [[3]](diffhunk://#diff-00f523621f516620148576ff70c3fcebad04a6849d09682d6886165e81764a18L235-R237) [[4]](diffhunk://#diff-00f523621f516620148576ff70c3fcebad04a6849d09682d6886165e81764a18L261-R267)
* Modified `ServiceResolutionException` to implement `ContainerExceptionInterface`, aligning it with PSR-11 requirements.

**Dependency Updates:**

* Added `psr/container` as a required dependency in `composer.json` to support PSR-11 compliance.