### PR TITLE
Implement PSR-14 `EventDispatcherInterface`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "symfony/polyfill-ctype": "^1.23",
         "symfony/process": "^7.3",
         "symfony/yaml": "^7.0.3",
-        "psr/container": "^2.0"
+        "psr/container": "^2.0",
+        "psr/event-dispatcher": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e556167506a02a0028ec1dd05d04dce4",
+    "content-hash": "dfc7c8b615b392d0a73f9ec583f64855",
     "packages": [
         {
             "name": "dflydev/dot-access-data",

--- a/formwork/src/Events/Event.php
+++ b/formwork/src/Events/Event.php
@@ -4,8 +4,9 @@ namespace Formwork\Events;
 
 use Formwork\Data\Traits\DataMultipleGetter;
 use Formwork\Data\Traits\DataMultipleSetter;
+use Psr\EventDispatcher\StoppableEventInterface;
 
-class Event
+class Event implements StoppableEventInterface
 {
     use DataMultipleGetter;
     use DataMultipleSetter;

--- a/formwork/src/Events/EventDispatcher.php
+++ b/formwork/src/Events/EventDispatcher.php
@@ -3,41 +3,42 @@
 namespace Formwork\Events;
 
 use Closure;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\StoppableEventInterface;
 
-class EventDispatcher
+class EventDispatcher implements EventDispatcherInterface
 {
-    /**
-     * @var array<string, list<Closure>>
-     */
-    protected array $listeners = [];
+    public function __construct(
+        private ListenerProvider $listenerProvider = new ListenerProvider()
+    ) {}
 
     /**
      * Register an event listener
      *
-     * @param Closure(Event): void $listener
+     * @template TEvent of Event|object
+     *
+     * @param Closure(TEvent): void $listener
      */
     public function on(string $eventName, Closure $listener): void
     {
-        $this->listeners[$eventName][] = $listener;
+        $this->listenerProvider->addListener($eventName, $listener);
     }
 
     /**
      * Dispatch an event
+     *
+     * @inheritDoc
      */
-    public function dispatch(Event $event): void
+    public function dispatch(object $event): object
     {
-        $eventName = $event->name();
-
-        if (!isset($this->listeners[$eventName])) {
-            return;
-        }
-
-        foreach ($this->listeners[$eventName] as $listener) {
-            $listener($event);
-
-            if ($event->isPropagationStopped()) {
+        foreach ($this->listenerProvider->getListenersForEvent($event) as $listener) {
+            if ($event instanceof StoppableEventInterface && $event->isPropagationStopped()) {
                 break;
             }
+
+            $listener($event);
         }
+
+        return $event;
     }
 }

--- a/formwork/src/Events/ListenerProvider.php
+++ b/formwork/src/Events/ListenerProvider.php
@@ -15,6 +15,9 @@ class ListenerProvider implements ListenerProviderInterface
     /**
      * Register a listener for an event class
      *
+     * The event name can be either a custom name from an `Event` instance
+     * (as returned by `Event::name()`) or the class name of a generic event object.
+     *
      * @template TEvent of Event|object
      *
      * @param Closure(TEvent): void $listener

--- a/formwork/src/Events/ListenerProvider.php
+++ b/formwork/src/Events/ListenerProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Formwork\Events;
+
+use Closure;
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+class ListenerProvider implements ListenerProviderInterface
+{
+    /**
+     * @var array<string, list<Closure>>
+     */
+    private array $listeners = [];
+
+    /**
+     * Register a listener for an event class
+     *
+     * @template TEvent of Event|object
+     *
+     * @param Closure(TEvent): void $listener
+     */
+    public function addListener(string $name, Closure $listener): void
+    {
+        $this->listeners[$name][] = $listener;
+    }
+
+    /**
+     * Get the listeners for a given event object
+     *
+     * @return iterable<Closure>
+     */
+    public function getListenersForEvent(object $event): iterable
+    {
+        // Get the event name from the Event instance or use the class name
+        $name = $event instanceof Event
+            ? $event->name()
+            : $event::class;
+
+        yield from $this->listeners[$name] ?? [];
+    }
+}


### PR DESCRIPTION
This pull request updates the event system to use the PSR-14 standard for event dispatching. It introduces a new `ListenerProvider` class, updates the `EventDispatcher` and `Event` classes to implement the appropriate PSR interfaces, and adds the required dependency to `composer.json`. These changes improve interoperability and standardize event handling in the codebase.

**PSR-14 Event System Integration:**

* Added `psr/event-dispatcher` as a dependency in `composer.json` to support PSR-14 event dispatching.
* Created a new `ListenerProvider` class implementing `ListenerProviderInterface`, responsible for managing and providing event listeners.
* Updated `EventDispatcher` to implement `EventDispatcherInterface`, delegate listener management to `ListenerProvider`, and return the event from `dispatch` as per PSR-14.

**Event Propagation Control:**

* Modified `Event` to implement `StoppableEventInterface`, allowing events to stop their own propagation in compliance with the PSR-14 standard.