### PR TITLE
Implement PSR-3 compatible `Logger`

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -13,7 +13,7 @@ AddDefaultCharset utf-8
     RewriteRule ^.* index.php [L]
 
     ## Prevent direct access to Formwork folders
-    RewriteRule ^(panel|backup|bin|cache|formwork|site|vendor)/.* index.php [L,NC]
+    RewriteRule ^(panel|backup|bin|cache|formwork|logs|site|vendor)/.* index.php [L,NC]
 
     ## Prevent access to specific files
     RewriteRule ^(.*)\.(md|yml|yaml|json|neon)/?$ index.php [L,NC]

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "symfony/process": "^7.3",
         "symfony/yaml": "^7.0.3",
         "psr/container": "^2.0",
-        "psr/event-dispatcher": "^1.0"
+        "psr/event-dispatcher": "^1.0",
+        "psr/log": "^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dfc7c8b615b392d0a73f9ec583f64855",
+    "content-hash": "d295952ccef1bd7c89e5e1ecef5c909f",
     "packages": [
         {
             "name": "dflydev/dot-access-data",

--- a/formwork/config/system.yaml
+++ b/formwork/config/system.yaml
@@ -65,6 +65,13 @@ images:
     preserveExifData: true
     clearCacheByDefault: false
 
+logs:
+    handlers:
+        default:
+            type: file
+            path: '${%ROOT_PATH%}/logs/formwork.log'
+            level: info
+
 metadata:
     setGenerator: true
 

--- a/formwork/server.php
+++ b/formwork/server.php
@@ -6,7 +6,7 @@ $path = $_SERVER['SCRIPT_NAME'];
 // Emulate the `mod_rewrite` rules defined in .htaccess
 if ($path !== '/index.php' && is_file($root . $path)) {
     switch (true) {
-        case preg_match('~^/(panel|backup|bin|cache|formwork|site|vendor)/.*~i', $path):
+        case preg_match('~^/(panel|backup|bin|cache|formwork|logs|site|vendor)/.*~i', $path):
         case preg_match('~^/(.*)\.(md|yml|yaml|json|neon)/?$~i', $path):
         case preg_match('~^/(LICENSE|composer\.lock)/?$~i', $path):
         case preg_match('~(^|/)\.(?!well-known)/?~i', $path):

--- a/formwork/src/Cms/App.php
+++ b/formwork/src/Cms/App.php
@@ -22,6 +22,7 @@ use Formwork\Http\Request;
 use Formwork\Http\Response;
 use Formwork\Images\ImageFactory;
 use Formwork\Languages\LanguagesFactory;
+use Formwork\Log\Logger;
 use Formwork\Pages\PageCollectionFactory;
 use Formwork\Pages\PageFactory;
 use Formwork\Pages\PaginationFactory;
@@ -33,6 +34,7 @@ use Formwork\Security\CsrfToken;
 use Formwork\Services\Container;
 use Formwork\Services\Loaders\AssetsServiceLoader;
 use Formwork\Services\Loaders\ConfigServiceLoader;
+use Formwork\Services\Loaders\LoggerServiceLoader;
 use Formwork\Services\Loaders\PanelServiceLoader;
 use Formwork\Services\Loaders\PluginsServiceLoader;
 use Formwork\Services\Loaders\SchemesServiceLoader;
@@ -49,6 +51,7 @@ use Formwork\Users\UserFactory;
 use Formwork\Users\Users;
 use Formwork\Utils\Str;
 use Formwork\View\ViewFactory;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 final class App
@@ -243,6 +246,10 @@ final class App
         $container->define(Container::class, $container);
 
         $container->define(self::class, $this);
+
+        $container->define(Logger::class)
+            ->loader(LoggerServiceLoader::class)
+            ->alias(LoggerInterface::class);
 
         $container->define(EventDispatcher::class)
             ->alias('events');

--- a/formwork/src/Log/Formatter/AbstractFormatter.php
+++ b/formwork/src/Log/Formatter/AbstractFormatter.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Formwork\Log\Formatter;
+
+use BackedEnum;
+use DateTimeInterface;
+use Formwork\Data\Contracts\ArraySerializable;
+use Formwork\Utils\Arr;
+use Formwork\Utils\Constraint;
+use JsonSerializable;
+use Stringable;
+use Throwable;
+use UnitEnum;
+
+abstract class AbstractFormatter implements FormatterInterface
+{
+    abstract public function format(DateTimeInterface $datetime, string $level, string $message, array $context): string;
+
+    /**
+     * Interpolate context values into the message placeholders
+     *
+     * @param array<mixed> $context
+     */
+    protected function interpolate(string $message, array $context = [], string $dateFormat = DateTimeInterface::RFC3339): string
+    {
+        $replacements = [];
+
+        foreach ($context as $key => $value) {
+            if (is_string($key) && !Constraint::matchesRegex($key, '/^[A-Za-z0-9_.]+$/')) {
+                continue;
+            }
+
+            $placeholder = '{' . $key . '}';
+
+            if ($value === null || is_scalar($value) || $value instanceof Stringable) {
+                $replacements[$placeholder] = (string) $value;
+            } elseif ($value instanceof DateTimeInterface) {
+                $replacements[$placeholder] = $value->format($dateFormat);
+            } elseif ($value instanceof UnitEnum) {
+                $replacements[$placeholder] = $value instanceof BackedEnum ? $value->value : $value->name;
+            } else {
+                $type = get_debug_type($value);
+
+                if (is_object($value)) {
+                    $type = "object {$type}";
+                }
+
+                $replacements[$placeholder] = "[$type]";
+            }
+        }
+
+        return strtr($message, $replacements);
+    }
+
+    /**
+     * Normalize data for logging
+     */
+    protected function normalize(mixed $data, string $dateFormat = DateTimeInterface::RFC3339, int $depth = 4): mixed
+    {
+        if ($data === null || is_scalar($data)) {
+            return $data;
+        }
+
+        if ($depth === 0) {
+            if (is_array($data)) {
+                return '[array]';
+            }
+
+            if (is_object($data)) {
+                $type = get_debug_type($data);
+                return "[object {$type}]";
+            }
+        }
+
+        if (is_array($data)) {
+            return Arr::map($data, fn($value) => $this->normalize($value, $dateFormat, $depth - 1));
+        }
+
+        $type = get_debug_type($data);
+
+        if (is_object($data)) {
+            if ($data instanceof DateTimeInterface) {
+                return $data->format($dateFormat);
+            }
+
+            if ($data instanceof Throwable) {
+                $trace = $data->getTrace();
+                $previous = $data->getPrevious();
+
+                $data = [
+                    'class'   => $type,
+                    'message' => $data->getMessage(),
+                    'code'    => (int) $data->getCode(),
+                    'file'    => "{$data->getFile()}:{$data->getLine()}",
+                    'trace'   => [],
+                ];
+
+                foreach ($trace as $frame) {
+                    if (isset($frame['file'], $frame['line'])) {
+                        $data['trace'][] = "{$frame['file']}:{$frame['line']}";
+                    }
+                }
+
+                if ($previous !== null) {
+                    $data['previous'] = $this->normalize($previous, $dateFormat, $depth - 1);
+                }
+
+                return $data;
+            }
+
+            if ($data instanceof Stringable) {
+                $data = (string) $data;
+            }
+
+            if ($data instanceof JsonSerializable) {
+                $data = $data->jsonSerialize();
+            }
+
+            if ($data instanceof ArraySerializable) {
+                $data = $data->toArray();
+            }
+
+            return [$type => $data];
+        }
+
+        if (is_resource($data)) {
+            return "[$type]";
+        }
+
+        return "[unknown {$type}]";
+    }
+}

--- a/formwork/src/Log/Formatter/FormatterInterface.php
+++ b/formwork/src/Log/Formatter/FormatterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Formwork\Log\Formatter;
+
+use DateTimeInterface;
+use Psr\Log\LogLevel;
+
+interface FormatterInterface
+{
+    /**
+     * Format a log entry
+     *
+     * @param LogLevel::*  $level
+     * @param array<mixed> $context
+     */
+    public function format(DateTimeInterface $datetime, string $level, string $message, array $context): string;
+}

--- a/formwork/src/Log/Formatter/JsonFormatter.php
+++ b/formwork/src/Log/Formatter/JsonFormatter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Formwork\Log\Formatter;
+
+use DateTimeInterface;
+use Formwork\Parsers\Json;
+
+class JsonFormatter extends AbstractFormatter
+{
+    public const DATE_FORMAT = 'Y-m-d\TH:i:s.uP';
+
+    /**
+     * @inheritDoc
+     */
+    public function format(DateTimeInterface $datetime, string $level, string $message, array $context): string
+    {
+        return Json::encode([
+            'datetime' => $datetime->format(self::DATE_FORMAT),
+            'level'    => $level,
+            'message'  => $this->interpolate($message, $context, self::DATE_FORMAT),
+            'context'  => $this->normalize($context, self::DATE_FORMAT),
+        ]);
+    }
+}

--- a/formwork/src/Log/Formatter/TextFormatter.php
+++ b/formwork/src/Log/Formatter/TextFormatter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Formwork\Log\Formatter;
+
+use DateTimeInterface;
+use Formwork\Parsers\Json;
+
+class TextFormatter extends AbstractFormatter
+{
+    public const DATE_FORMAT = 'Y-m-d H:i:s.u';
+
+    public function __construct(
+        private bool $withContext = true
+    ) {}
+
+    /**
+     * @inheritDoc
+     */
+    public function format(DateTimeInterface $datetime, string $level, string $message, array $context): string
+    {
+        return sprintf(
+            '[%s] %s: %s%s',
+            $datetime->format(self::DATE_FORMAT),
+            strtoupper($level),
+            $this->interpolate($message, $context, self::DATE_FORMAT),
+            ($this->withContext && $context !== []) ? ' ' . Json::encode($this->normalize($context, self::DATE_FORMAT)) : ''
+        );
+    }
+}

--- a/formwork/src/Log/Handler/AbstractHandler.php
+++ b/formwork/src/Log/Handler/AbstractHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Formwork\Log\Handler;
+
+use DateTimeInterface;
+use Formwork\Log\Formatter\FormatterInterface;
+use Formwork\Log\Logger;
+use InvalidArgumentException;
+use Psr\Log\LogLevel;
+
+abstract class AbstractHandler implements HandlerInterface
+{
+    /**
+     * @param LogLevel::* $level
+     */
+    public function __construct(
+        protected FormatterInterface $formatter,
+        protected string $level = LogLevel::DEBUG,
+    ) {
+        // @phpstan-ignore isset.offset
+        if (!isset(Logger::LOG_LEVELS[$level])) {
+            throw new InvalidArgumentException(sprintf('Invalid log level: "%s"', $level));
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    abstract public function handle(DateTimeInterface $datetime, string $level, string $message, array $context): void;
+
+    /**
+     * Determine if the handler should handle a log record with the given level
+     *
+     * @param LogLevel::* $level
+     */
+    protected function shouldHandle(string $level): bool
+    {
+        // @phpstan-ignore isset.offset
+        if (!isset(Logger::LOG_LEVELS[$level])) {
+            throw new InvalidArgumentException(sprintf('Invalid log level: "%s"', $level));
+        }
+        return Logger::LOG_LEVELS[$level] <= Logger::LOG_LEVELS[$this->level];
+    }
+}

--- a/formwork/src/Log/Handler/FileHandler.php
+++ b/formwork/src/Log/Handler/FileHandler.php
@@ -13,6 +13,11 @@ use RuntimeException;
 class FileHandler extends AbstractHandler
 {
     /**
+     * @var resource
+     */
+    protected $handle;
+
+    /**
      * @inheritDoc
      */
     public function __construct(
@@ -21,6 +26,11 @@ class FileHandler extends AbstractHandler
         string $level = LogLevel::DEBUG,
     ) {
         parent::__construct($formatter, $level);
+    }
+
+    public function __destruct()
+    {
+        $this->close();
     }
 
     /**
@@ -36,8 +46,16 @@ class FileHandler extends AbstractHandler
 
         $line = $this->formatter->format($datetime, $level, $message, $context);
 
+        $this->write($line);
+    }
+
+    /**
+     * Open the log stream for writing
+     */
+    protected function open(): void
+    {
         if (
-            !Str::startsWith($this->path, 'php://')
+            !Str::contains($this->path, '://')
             && !FileSystem::isDirectory($directory = dirname($this->path), assertExists: false)
         ) {
             FileSystem::createDirectory($directory, recursive: true);
@@ -47,14 +65,41 @@ class FileHandler extends AbstractHandler
             throw new RuntimeException(sprintf('Unable to open the stream "%s" for writing in append mode', $this->path));
         }
 
-        $locked = flock($handle, LOCK_EX);
+        $this->handle = $handle;
+    }
 
-        fwrite($handle, $line . PHP_EOL);
+    /**
+     * Write a line to the log stream
+     */
+    protected function write(string $line): void
+    {
+        $data = $line . PHP_EOL;
 
-        if ($locked) {
-            flock($handle, LOCK_UN);
+        if (!is_resource($this->handle)) {
+            $this->open();
         }
 
-        fclose($handle);
+        $locked = flock($this->handle, LOCK_EX);
+
+        $bytesWritten = fwrite($this->handle, $data);
+
+        if ($locked) {
+            flock($this->handle, LOCK_UN);
+        }
+
+        if ($bytesWritten === false || $bytesWritten < strlen($data)) {
+            $this->close();
+            throw new RuntimeException(sprintf('Unable to write log data to stream "%s"', $this->path));
+        }
+    }
+
+    /**
+     * Close the log stream
+     */
+    protected function close(): void
+    {
+        if (is_resource($this->handle)) {
+            fclose($this->handle);
+        }
     }
 }

--- a/formwork/src/Log/Handler/FileHandler.php
+++ b/formwork/src/Log/Handler/FileHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Formwork\Log\Handler;
+
+use DateTimeInterface;
+use Formwork\Log\Formatter\FormatterInterface;
+use Formwork\Log\Formatter\JsonFormatter;
+use Formwork\Utils\FileSystem;
+use Formwork\Utils\Str;
+use Psr\Log\LogLevel;
+use RuntimeException;
+
+class FileHandler extends AbstractHandler
+{
+    /**
+     * @inheritDoc
+     */
+    public function __construct(
+        protected string $path,
+        FormatterInterface $formatter = new JsonFormatter(),
+        string $level = LogLevel::DEBUG,
+    ) {
+        parent::__construct($formatter, $level);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws RuntimeException If the log stream cannot be opened for writing
+     */
+    public function handle(DateTimeInterface $datetime, string $level, string $message, array $context): void
+    {
+        if (!$this->shouldHandle($level)) {
+            return;
+        }
+
+        $line = $this->formatter->format($datetime, $level, $message, $context);
+
+        if (
+            !Str::startsWith($this->path, 'php://')
+            && !FileSystem::isDirectory($directory = dirname($this->path), assertExists: false)
+        ) {
+            FileSystem::createDirectory($directory, recursive: true);
+        }
+
+        if (($handle = fopen($this->path, 'a')) === false) {
+            throw new RuntimeException(sprintf('Unable to open the stream "%s" for writing in append mode', $this->path));
+        }
+
+        $locked = flock($handle, LOCK_EX);
+
+        fwrite($handle, $line . PHP_EOL);
+
+        if ($locked) {
+            flock($handle, LOCK_UN);
+        }
+
+        fclose($handle);
+    }
+}

--- a/formwork/src/Log/Handler/HandlerInterface.php
+++ b/formwork/src/Log/Handler/HandlerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Formwork\Log\Handler;
+
+use DateTimeInterface;
+use Psr\Log\LogLevel;
+
+interface HandlerInterface
+{
+    /**
+     * Handle a log entry
+     *
+     * @param LogLevel::*  $level
+     * @param array<mixed> $context
+     */
+    public function handle(DateTimeInterface $datetime, string $level, string $message, array $context): void;
+}

--- a/formwork/src/Log/Handler/StderrHandler.php
+++ b/formwork/src/Log/Handler/StderrHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Formwork\Log\Handler;
+
+use Formwork\Log\Formatter\FormatterInterface;
+use Formwork\Log\Formatter\TextFormatter;
+use Psr\Log\LogLevel;
+
+/**
+ * @inheritDoc
+ */
+class StderrHandler extends FileHandler
+{
+    public function __construct(
+        FormatterInterface $formatter = new TextFormatter(),
+        string $level = LogLevel::DEBUG,
+    ) {
+        parent::__construct('php://stderr', $formatter, $level);
+    }
+}

--- a/formwork/src/Log/Logger.php
+++ b/formwork/src/Log/Logger.php
@@ -48,11 +48,13 @@ class Logger extends AbstractLogger implements LoggerInterface
             throw new InvalidArgumentException(sprintf('Invalid log level: "%s"', (string) $level));
         }
 
+        $datetime = new DateTimeImmutable(sprintf('@%.6F', microtime(true)));
+
         foreach ($this->handlers as $handler) {
             $handler->handle(
-                new DateTimeImmutable(sprintf('@%F', microtime(true))),
+                $datetime,
                 (string) $level,
-                $message,
+                (string) $message,
                 $context
             );
         }

--- a/formwork/src/Log/Logger.php
+++ b/formwork/src/Log/Logger.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Formwork\Log;
+
+use DateTimeImmutable;
+use Formwork\Log\Handler\HandlerInterface;
+use Psr\Log\AbstractLogger;
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Stringable;
+
+class Logger extends AbstractLogger implements LoggerInterface
+{
+    public const LOG_LEVELS = [
+        LogLevel::EMERGENCY => 0,
+        LogLevel::ALERT     => 1,
+        LogLevel::CRITICAL  => 2,
+        LogLevel::ERROR     => 3,
+        LogLevel::WARNING   => 4,
+        LogLevel::NOTICE    => 5,
+        LogLevel::INFO      => 6,
+        LogLevel::DEBUG     => 7,
+    ];
+
+    /**
+     * @var array<HandlerInterface>
+     */
+    private $handlers = [];
+
+    /**
+     * Add a log handler
+     */
+    public function addHandler(HandlerInterface $handler): void
+    {
+        $this->handlers[] = $handler;
+    }
+
+    /**
+     * Log with an arbitrary level
+     *
+     * @param LogLevel::* $level
+     */
+    public function log(mixed $level, string|Stringable $message, array $context = []): void
+    {
+        // @phpstan-ignore isset.offset
+        if (!isset(self::LOG_LEVELS[$level])) {
+            throw new InvalidArgumentException(sprintf('Invalid log level: "%s"', (string) $level));
+        }
+
+        foreach ($this->handlers as $handler) {
+            $handler->handle(
+                new DateTimeImmutable(sprintf('@%F', microtime(true))),
+                (string) $level,
+                $message,
+                $context
+            );
+        }
+    }
+}

--- a/formwork/src/Services/Loaders/LoggerServiceLoader.php
+++ b/formwork/src/Services/Loaders/LoggerServiceLoader.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Formwork\Services\Loaders;
+
+use Formwork\Config\Config;
+use Formwork\Log\Formatter\FormatterInterface;
+use Formwork\Log\Formatter\JsonFormatter;
+use Formwork\Log\Formatter\TextFormatter;
+use Formwork\Log\Handler\FileHandler;
+use Formwork\Log\Handler\HandlerInterface;
+use Formwork\Log\Handler\StderrHandler;
+use Formwork\Log\Logger;
+use Formwork\Services\Container;
+use Formwork\Services\ServiceLoaderInterface;
+use InvalidArgumentException;
+
+final class LoggerServiceLoader implements ServiceLoaderInterface
+{
+    public function __construct(
+        private Container $container,
+        private Config $config
+    ) {}
+
+    public function load(Container $container): Logger
+    {
+        $logger = $container->build(Logger::class);
+        foreach ($this->config->get('system.logs.handlers', []) as $handlerConfig) {
+            $logger->addHandler($this->buildHandler($handlerConfig));
+        }
+
+        return $logger;
+    }
+
+    /**
+     * @param array{type?: string, path?: string, level?: string, formatter?: string} $config
+     */
+    private function buildHandler(array $config): HandlerInterface
+    {
+        $config['type'] ??= null;
+
+        if (isset($config['formatter'])) {
+            $config['formatter'] = $this->getFormatter($config['formatter']);
+        }
+
+        return match ($config['type']) {
+            'file'   => $this->container->build(FileHandler::class, $config),
+            'stderr' => $this->container->build(StderrHandler::class, $config),
+            default  => throw new InvalidArgumentException(sprintf('Unknown log handler type: %s', $config['type']))
+        };
+    }
+
+    private function getFormatter(string $formatter): FormatterInterface
+    {
+        return match ($formatter) {
+            'json'  => new JsonFormatter(),
+            'text'  => new TextFormatter(),
+            default => throw new InvalidArgumentException(sprintf('Unknown log formatter: %s', $formatter))
+        };
+    }
+}


### PR DESCRIPTION
This pull request introduces a new logging system into the codebase, providing a flexible and extensible way to handle logs with support for multiple handlers and formatters. The changes include the addition of a PSR-3 compliant logger, various log handlers (such as file and stderr), log formatters (JSON and text), and the necessary configuration and service loader to wire everything together.

**Logging System Implementation**

* Added a new `Logger` class implementing PSR-3 `LoggerInterface`, supporting multiple handlers and log levels. (`formwork/src/Log/Logger.php`)
* Introduced handler interfaces and implementations, including `FileHandler` for writing logs to files and `StderrHandler` for stderr output. (`formwork/src/Log/Handler/HandlerInterface.php`, `formwork/src/Log/Handler/AbstractHandler.php`, `formwork/src/Log/Handler/FileHandler.php`, `formwork/src/Log/Handler/StderrHandler.php`) [[1]](diffhunk://#diff-6b890183481f7aa26ebdb75706b074e5a6b1a4400d0d11d5c48a3bd8b729437fR1-R17) [[2]](diffhunk://#diff-b3eb978ea6a6000b06f9398058f1df9891b4b983ac538c253add0287fa94697bR1-R44) [[3]](diffhunk://#diff-e40eb68dcea615cadf7296e1b024fa3d30353130636feab0440c7a7d14a6bb7bR1-R60) [[4]](diffhunk://#diff-ebf4829388cec379a1a23367aba15e1d3ab09d95a1f0ed23bf9ba2d378af2747R1-R20)
* Added formatter interfaces and implementations for JSON and plain text log formatting. (`formwork/src/Log/Formatter/FormatterInterface.php`, `formwork/src/Log/Formatter/AbstractFormatter.php`, `formwork/src/Log/Formatter/JsonFormatter.php`, `formwork/src/Log/Formatter/TextFormatter.php`) [[1]](diffhunk://#diff-491b24455ecf7ea21873c76b3d43efdd9064307afa37f61dbafaa277474476e6R1-R17) [[2]](diffhunk://#diff-0917351d4fe6b7213f5f205506d9851e13a98fc40877c9b3b301cb2d157130d0R1-R132) [[3]](diffhunk://#diff-a6f7698577147aec399796abebd07b1d397a4a1fa0a79cef2d73c1e00ca65c88R1-R24) [[4]](diffhunk://#diff-242e7fd508a113775727850f544a75166bb3ef066ce10d699895218be9e75635R1-R29)

**Configuration and Service Integration**

* Updated `composer.json` to require `psr/log` for PSR-3 logging compatibility.
* Added logging configuration to `system.yaml`, allowing for handler and log level customization.
* Registered the logger in the application service container and created a `LoggerServiceLoader` to instantiate and configure the logger and its handlers based on configuration. (`formwork/src/Cms/App.php`, `formwork/src/Services/Loaders/LoggerServiceLoader.php`) [[1]](diffhunk://#diff-46157155d4e57fd657fd917e7ccbee85651c2ff8d498dbeb4c479c09d08a5966R25) [[2]](diffhunk://#diff-46157155d4e57fd657fd917e7ccbee85651c2ff8d498dbeb4c479c09d08a5966R37) [[3]](diffhunk://#diff-46157155d4e57fd657fd917e7ccbee85651c2ff8d498dbeb4c479c09d08a5966R54) [[4]](diffhunk://#diff-46157155d4e57fd657fd917e7ccbee85651c2ff8d498dbeb4c479c09d08a5966R250-R253) [[5]](diffhunk://#diff-780d85d51b8f24f0328b5b45f7b6d503c46a51dad83b4432606ba41013eb48b8R1-R60)

These changes lay the foundation for a robust and configurable logging infrastructure throughout the application.