### PR TITLE
Update image picker on modal open

### DIFF
--- a/formwork/src/Panel/Controllers/FilesController.php
+++ b/formwork/src/Panel/Controllers/FilesController.php
@@ -42,6 +42,42 @@ final class FilesController extends AbstractController
     }
 
     /**
+     * FilesController@list action
+     */
+    public function list(RouteParams $routeParams): JsonResponse|Response
+    {
+        if (!$this->hasPermission('panel.files.list')) {
+            return $this->forward(ErrorsController::class, 'forbidden');
+        }
+
+        $model = $this->getModel($routeParams);
+
+        if ($model === null) {
+            return $this->forward(ErrorsController::class, 'notFound');
+        }
+
+        $data = [];
+
+        foreach ($model->files() as $file) {
+            $data[] = [
+                'filename'         => $file->name(),
+                'uri'              => $file->uri(),
+                'size'             => $file->size(),
+                'lastModifiedTime' => Date::formatTimestamp(
+                    $file->lastModifiedTime(),
+                    $this->config->get('system.date.datetimeFormat'),
+                    $this->translations->getCurrent()
+                ),
+                'type'      => $file->type(),
+                'thumbnail' => $this->getThumbnailUri($file),
+                'actions'   => $this->getActionsUri($file, $model),
+            ];
+        }
+
+        return JsonResponse::success('', data: $data);
+    }
+
+    /**
      * FilesController@upload action
      */
     public function upload(): Response

--- a/panel/config/routes/routes.php
+++ b/panel/config/routes/routes.php
@@ -115,6 +115,13 @@ return [
             'action' => 'Formwork\Panel\Controllers\FilesController@index',
         ],
 
+        'panel.files.list' => [
+            'path'    => '/files/list/{model:page|site}/{id:all}?/',
+            'action'  => 'Formwork\Panel\Controllers\FilesController@list',
+            'methods' => ['POST'],
+            'types'   => ['XHR'],
+        ],
+
         'panel.files.upload' => [
             'path'    => '/files/upload/',
             'action'  => 'Formwork\Panel\Controllers\FilesController@upload',

--- a/panel/src/scss/components/forms/_forms-image.scss
+++ b/panel/src/scss/components/forms/_forms-image.scss
@@ -39,8 +39,8 @@
     bottom: 0.5rem;
     left: 50%;
     display: block;
-    max-width: calc(100% - 0.5rem);
-    padding: 0 0.375rem;
+    max-width: calc(100% - 1rem);
+    padding: 0 0.25rem;
     border-radius: var(--border-radius);
     background-color: var(--color-tooltip);
     content: attr(data-filename);

--- a/panel/src/ts/components/form.ts
+++ b/panel/src/ts/components/form.ts
@@ -58,7 +58,7 @@ export class Form {
 
         ".form-togglegroup": (element: HTMLFieldSetElement) => this.formInputs.push(new TogglegroupInput(element)),
 
-        ".image-picker": (element: HTMLSelectElement) => this.formInputs.push(new ImagePicker(element)),
+        ".image-picker": (element: HTMLInputElement) => this.formInputs.push(new ImagePicker(element)),
 
         "input[type=file]": (element: HTMLInputElement) => this.formInputs.push(new UploadInput(element, this)),
 

--- a/panel/src/ts/components/inputs/editor/markdown/commands.ts
+++ b/panel/src/ts/components/inputs/editor/markdown/commands.ts
@@ -6,6 +6,7 @@ export { sinkListItem, wrapInList } from "prosemirror-schema-list";
 import { redo as historyRedo, undo as historyUndo, redoDepth, undoDepth } from "prosemirror-history";
 import { $ } from "../../../../utils/selectors";
 import { app } from "../../../../app";
+import type { ImagePicker } from "../../image-picker";
 import { schema } from "prosemirror-markdown";
 
 export const insertLink: Command = (state, dispatch, view) => {
@@ -107,6 +108,11 @@ export const insertImage: Command = (state, dispatch, view) => {
     }
     if (view) {
         const { imagesModal } = app.modals;
+
+        imagesModal.onBeforeOpen((modal) => {
+            const imagePicker = modal.form?.inputs[`${imagesModal.element.id}[imagepicker]`] as ImagePicker;
+            imagePicker.update();
+        });
 
         imagesModal.open();
 

--- a/panel/src/ts/components/inputs/image-picker.ts
+++ b/panel/src/ts/components/inputs/image-picker.ts
@@ -1,11 +1,12 @@
 import { $, $$ } from "../../utils/selectors";
+import { app } from "../../app";
+import { Request } from "../../utils/request";
+
 export class ImagePicker {
-    readonly element: HTMLSelectElement;
+    readonly element: HTMLInputElement;
 
-    constructor(element: HTMLSelectElement) {
+    constructor(element: HTMLInputElement) {
         this.element = element;
-
-        this.initInput();
     }
 
     get name() {
@@ -24,38 +25,60 @@ export class ImagePicker {
         this.element.value = value;
     }
 
-    private initInput() {
-        this.element.hidden = true;
-        this.element.ariaHidden = "true";
-        this.element.tabIndex = -1;
+    update() {
+        const parentElement = this.element.parentElement as HTMLElement;
 
-        const pickImage = (thumbnail: HTMLElement) => {
-            $$(".image-picker-thumbnail").forEach((element) => {
+        $(".image-picker-thumbnails", parentElement)?.remove();
+
+        const emptyState = $(".image-picker-empty-state", parentElement) as HTMLElement;
+
+        const selectImage = (thumbnail: HTMLElement) => {
+            $$(".image-picker-thumbnail", parentElement).forEach((element) => {
                 element.classList.remove("selected");
             });
             thumbnail.classList.add("selected");
             this.element.value = thumbnail.dataset.uri ?? "";
         };
 
-        const options = $$("option", this.element);
-
-        if (options.length > 0) {
-            const container = document.createElement("div");
-            container.className = "image-picker-thumbnails";
-
-            for (const option of Array.from(options) as HTMLOptionElement[]) {
-                const thumbnail = document.createElement("div");
-                thumbnail.className = "image-picker-thumbnail";
-                thumbnail.style.backgroundImage = `url(${option.dataset.thumbnail ?? option.value})`;
-                thumbnail.dataset.uri = option.value;
-                thumbnail.dataset.filename = option.text;
-                thumbnail.addEventListener("click", () => pickImage(thumbnail));
-                thumbnail.addEventListener("dblclick", () => pickImage(thumbnail));
-                container.appendChild(thumbnail);
+        const pickImage = (thumbnail: HTMLElement) => {
+            selectImage(thumbnail);
+            const modal = this.element.closest(".modal") as HTMLElement;
+            if (modal) {
+                app.modals[modal.id].triggerCommand("pick-image");
             }
+        };
 
-            (this.element.parentNode as ParentNode).insertBefore(container, this.element);
-            ($(".image-picker-empty-state") as HTMLElement).style.display = "none";
-        }
+        new Request(
+            {
+                method: "POST",
+                url: this.element.dataset.src as string,
+                data: { "csrf-token": app.config.csrfToken as string },
+            },
+            ({ data }: { data: Record<string, any> }) => {
+                const images = Object.values(data).filter((file) => file.type === "image");
+
+                if (images.length > 0) {
+                    const container = document.createElement("div");
+                    container.className = "image-picker-thumbnails";
+
+                    for (const image of images) {
+                        const thumbnail = document.createElement("div");
+                        thumbnail.className = "image-picker-thumbnail";
+                        thumbnail.style.backgroundImage = `url(${image.thumbnail})`;
+                        thumbnail.dataset.uri = image.uri;
+                        thumbnail.dataset.filename = image.filename;
+                        thumbnail.addEventListener("click", () => selectImage(thumbnail));
+                        thumbnail.addEventListener("dblclick", () => pickImage(thumbnail));
+                        container.appendChild(thumbnail);
+                    }
+
+                    parentElement.appendChild(container);
+
+                    emptyState.style.display = "none";
+                } else {
+                    emptyState.style.display = "block";
+                }
+            },
+        );
     }
 }

--- a/panel/src/ts/components/inputs/image-picker.ts
+++ b/panel/src/ts/components/inputs/image-picker.ts
@@ -27,10 +27,10 @@ export class ImagePicker {
 
     update() {
         const parentElement = this.element.parentElement as HTMLElement;
+        const emptyState = $(".image-picker-empty-state", parentElement) as HTMLElement;
 
         $(".image-picker-thumbnails", parentElement)?.remove();
-
-        const emptyState = $(".image-picker-empty-state", parentElement) as HTMLElement;
+        emptyState.style.display = "";
 
         const selectImage = (thumbnail: HTMLElement) => {
             $$(".image-picker-thumbnail", parentElement).forEach((element) => {
@@ -75,8 +75,6 @@ export class ImagePicker {
                     parentElement.appendChild(container);
 
                     emptyState.style.display = "none";
-                } else {
-                    emptyState.style.display = "block";
                 }
             },
         );

--- a/panel/src/ts/components/modal.ts
+++ b/panel/src/ts/components/modal.ts
@@ -51,6 +51,8 @@ export class Modal {
     }
 
     open(options: ModalShowOptions = {}) {
+        this.dispatchCallback("before-open", options.triggerElement);
+
         this.element.role = "dialog";
         this.element.ariaModal = "true";
         this.element.classList.add("open");
@@ -75,11 +77,11 @@ export class Modal {
     }
 
     close(options: ModalHideOptions = {}) {
-        const modal = this.element;
+        this.dispatchCallback("before-close", options.triggerElement);
 
-        modal.classList.remove("open");
-        modal.role = null;
-        modal.ariaModal = null;
+        this.element.classList.remove("open");
+        this.element.role = null;
+        this.element.ariaModal = null;
 
         this.removeBackdrop();
 
@@ -88,8 +90,16 @@ export class Modal {
         this.dispatchCallback("close", options.triggerElement);
     }
 
+    onBeforeOpen(callback: ModalCallback) {
+        this.callbacks["before-open"] = callback;
+    }
+
     onOpen(callback: ModalCallback) {
         this.callbacks["open"] = callback;
+    }
+
+    onBeforeClose(callback: ModalCallback) {
+        this.callbacks["before-close"] = callback;
     }
 
     onClose(callback: ModalCallback) {

--- a/panel/views/fields/page/imagepicker.php
+++ b/panel/views/fields/page/imagepicker.php
@@ -1,15 +1,9 @@
 <?php $this->layout('@panel.fields.field') ?>
-<div class="image-picker-empty-state">
-    <span class="image-picker-empty-state-icon"><?= $this->icon('images') ?></span>
-    <h4 class="h5"><?= $this->translate('panel.modal.images.noImages') ?></h4>
-</div>
-<?php if (($model = $field->parent()->model())?->has('files')): ?>
-    <select class="form-input image-picker" id="<?= $field->name() ?>">
-        <?php foreach ($model->files()->filterBy('type', 'image') as $image) : ?>
-            <option <?= $this->attr([
-                        'value'          => $page->uri($image, includeLanguage: false),
-                        'data-thumbnail' => $image->square(300, 'contain')->uri(),
-                    ]) ?>><?= $image ?></option>
-        <?php endforeach ?>
-    </select>
+<?php if ($model = $field->parent()->model()): ?>
+    <div class="image-picker-empty-state">
+        <span class="image-picker-empty-state-icon"><?= $this->icon('images') ?></span>
+        <h4 class="h5"><?= $this->translate('panel.modal.images.noImages') ?></h4>
+    </div>
+
+    <input type="hidden" class="form-input image-picker" name="<?= $field->formName() ?>" data-src="<?= $this->uri($app->router()->generate('panel.files.list', ['model' => $model->getModelIdentifier(), 'id' => $model->route()])) ?>">
 <?php endif ?>

--- a/panel/views/fields/page/imagepicker.php
+++ b/panel/views/fields/page/imagepicker.php
@@ -5,5 +5,5 @@
         <h4 class="h5"><?= $this->translate('panel.modal.images.noImages') ?></h4>
     </div>
 
-    <input type="hidden" class="form-input image-picker" name="<?= $field->formName() ?>" data-src="<?= $this->uri($app->router()->generate('panel.files.list', ['model' => $model->getModelIdentifier(), 'id' => $model->route()])) ?>">
+    <input type="hidden" class="form-input image-picker" id="<?= $field->name() ?>" name="<?= $field->formName() ?>" data-src="<?= $this->uri($app->router()->generate('panel.files.list', ['model' => $model->getModelIdentifier(), 'id' => $model->route()])) ?>">
 <?php endif ?>


### PR DESCRIPTION
This pull request introduces a significant refactor and enhancement to the image picker functionality in the panel, shifting from a static `<select>`-based approach to a dynamic, AJAX-powered image selection UI. It also adds a new backend endpoint to serve file lists as JSON, and improves modal event handling for better UI responsiveness.

**Key changes include:**

### Image Picker Refactor & Enhancements
* Refactored the `ImagePicker` component to use a hidden `<input>` instead of a `<select>`, and now dynamically loads available images via an AJAX request to a new backend endpoint, displaying image thumbnails for selection. This provides a more user-friendly and interactive image selection experience. [[1]](diffhunk://#diff-845084f48049270ed8560e10f3a0dfe395bd5a9de9498cdc81f85aa98ec886dcR2-L8) [[2]](diffhunk://#diff-845084f48049270ed8560e10f3a0dfe395bd5a9de9498cdc81f85aa98ec886dcL27-R82) [[3]](diffhunk://#diff-f9441fb0406447d5276d63b305b77571b2b224eedc5d0ddb16b269bef25a2a80L61-R61) [[4]](diffhunk://#diff-bb4165903e26b182fffb8cf1c90401085dd9833bee81cc6fe241caaeb48ed6a6R2-R8)
* Updated the `insertImage` command in the markdown editor to trigger an update of the image picker UI every time the images modal is opened, ensuring the latest images are always displayed.
* Added a type import for `ImagePicker` in the relevant commands file for better type safety.

### Backend API & Routing
* Added a new `FilesController@list` action that returns a JSON list of files (with metadata such as filename, URI, size, type, thumbnail, etc.), with proper permission and error handling.
* Registered a new route `panel.files.list` to expose the above action as a POST XHR endpoint for use by the frontend.

### Modal Event Handling Improvements
* Added `onBeforeOpen` and `onBeforeClose` hooks to the `Modal` class, and ensured these callbacks are dispatched at the appropriate times, allowing components to react before a modal is shown or hidden (e.g., to refresh content). [[1]](diffhunk://#diff-09fa65bc677a666bb9f71264542218242b9ccb34e78643a056b589a9138b02a8R54-R55) [[2]](diffhunk://#diff-09fa65bc677a666bb9f71264542218242b9ccb34e78643a056b589a9138b02a8L78-R84) [[3]](diffhunk://#diff-09fa65bc677a666bb9f71264542218242b9ccb34e78643a056b589a9138b02a8R93-R104)