### PR TITLE
Use assets folder to store cached assets and serve them directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .php-cs-fixer.cache
 
+/assets/*
 /backup/*
 /cache/*
 /logs/*

--- a/formwork/config/routes/routes.php
+++ b/formwork/config/routes/routes.php
@@ -24,7 +24,11 @@ return [
             'action' => 'Formwork\Controllers\PageController@load',
         ],
         'assets' => [
-            'path'   => '/assets/{id}/{name}/',
+            /** @todo require the type param in Formwork >= 3.0.0 */
+            'path'  => '/assets/{type}?/{id}/{name}/',
+            'where' => [
+                'type' => ['images', null],
+            ],
             'action' => 'Formwork\Controllers\AssetsController@asset',
         ],
         'assets.template' => [

--- a/formwork/config/system.yaml
+++ b/formwork/config/system.yaml
@@ -67,7 +67,7 @@ images:
     webpQuality: 85
     avifQuality: 70
     gifColors: 256
-    processPath: ${%ROOT_PATH%}/cache/images
+    processPath: ${%ROOT_PATH%}/assets/images
     preserveColorProfile: true
     preserveExifData: true
     clearCacheByDefault: false

--- a/formwork/src/Controllers/AssetsController.php
+++ b/formwork/src/Controllers/AssetsController.php
@@ -4,6 +4,7 @@ namespace Formwork\Controllers;
 
 use Formwork\Http\FileResponse;
 use Formwork\Http\Response;
+use Formwork\Http\ResponseStatus;
 use Formwork\Router\RouteParams;
 use Formwork\Utils\FileSystem;
 use Formwork\Utils\Path;
@@ -15,6 +16,11 @@ final class AssetsController extends AbstractController
      */
     public function asset(RouteParams $routeParams): Response
     {
+        if (!$routeParams->has('type')) {
+            trigger_error('The "assets" route without a "type" parameter is deprecated and will be removed in a future version', E_USER_DEPRECATED);
+            return $this->redirect($this->router->rewrite(['type' => 'images']), ResponseStatus::MovedPermanently);
+        }
+
         $path = FileSystem::joinPaths($this->config->get('system.images.processPath'), $routeParams->get('id'), $routeParams->get('name'));
 
         if (FileSystem::isFile($path, assertExists: false)) {

--- a/formwork/src/Files/FileUriGenerator.php
+++ b/formwork/src/Files/FileUriGenerator.php
@@ -38,7 +38,7 @@ class FileUriGenerator
         if (Str::startsWith($path, FileSystem::normalizePath($this->config->get('system.images.processPath')))) {
             $id = basename(dirname($path));
             $name = basename($path);
-            $uriPath = $this->router->generate('assets', compact('id', 'name'));
+            $uriPath = $this->router->generate('assets', ['type' => 'images', 'id' => $id, 'name' => $name]);
             return $this->site->uri($uriPath, includeLanguage: false);
         }
 


### PR DESCRIPTION
This pull request closes #859 by introducing changes to improve asset routing and handling, particularly for image assets. Now the generated image assets are stored in the /assets folder, allowing direct serving without php processing.

The main focus is on making the asset type explicit in routes, updating image processing paths, and preparing for future deprecations. Below are the most important changes grouped by theme:

Routing and asset handling improvements:

* Updated the `assets` route in `routes.php` to include an optional `type` parameter, defaulting to `images`, and added a `where` clause to restrict valid types. This makes asset type explicit and prepares for future versions where the parameter will be required.
* Added logic to `AssetsController::asset` to trigger a deprecation warning if the `type` parameter is missing and redirect requests to include `type=images`. This ensures backward compatibility while encouraging use of the new route format.
* Modified `FileUriGenerator::generate` to always include the `type=images` parameter when generating asset URIs, ensuring consistency with the updated route structure.

Configuration updates:

* Changed the `processPath` for images in `system.yaml` from `cache/images` to `assets/images`, aligning the configuration with the new asset management approach.