### PR TITLE
Add the possibility to define navigation item children

### DIFF
--- a/formwork/src/Panel/Controllers/OptionsController.php
+++ b/formwork/src/Panel/Controllers/OptionsController.php
@@ -13,13 +13,6 @@ use UnexpectedValueException;
 final class OptionsController extends AbstractController
 {
     /**
-     * All options tabs
-     *
-     * @var list<string>
-     */
-    private array $tabs = ['site', 'system'];
-
-    /**
      * Options@index action
      */
     public function index(): Response
@@ -71,11 +64,7 @@ final class OptionsController extends AbstractController
         }
 
         return new Response($this->view('@panel.options.system', [
-            'title' => $this->translate('panel.options.options'),
-            'tabs'  => $this->view('@panel.options.tabs', [
-                'tabs'    => $this->tabs,
-                'current' => 'system',
-            ]),
+            'title'  => $this->translate('panel.options.options'),
             'fields' => $form->fields(),
         ]), $form->getResponseStatus());
     }
@@ -119,11 +108,7 @@ final class OptionsController extends AbstractController
         }
 
         return new Response($this->view('@panel.options.site', [
-            'title' => $this->translate('panel.options.options'),
-            'tabs'  => $this->view('@panel.options.tabs', [
-                'tabs'    => $this->tabs,
-                'current' => 'site',
-            ]),
+            'title'  => $this->translate('panel.options.options'),
             'fields' => $form->fields(),
         ]), $form->getResponseStatus());
     }

--- a/formwork/src/Panel/Controllers/ToolsController.php
+++ b/formwork/src/Panel/Controllers/ToolsController.php
@@ -13,13 +13,6 @@ use Formwork\Utils\Str;
 final class ToolsController extends AbstractController
 {
     /**
-     * All options tabs
-     *
-     * @var list<string>
-     */
-    private array $tabs = ['backups', 'updates', 'info'];
-
-    /**
      * Cached composer.json data
      *
      * @var array<string, mixed>
@@ -57,11 +50,7 @@ final class ToolsController extends AbstractController
         ]);
 
         return new Response($this->view('@panel.tools.backups', [
-            'title' => $this->translate('panel.tools.backups'),
-            'tabs'  => $this->view('@panel.tools.tabs', [
-                'tabs'    => $this->tabs,
-                'current' => 'backups',
-            ]),
+            'title'   => $this->translate('panel.tools.backups'),
             'backups' => Collection::from($backups),
         ]));
     }
@@ -76,11 +65,7 @@ final class ToolsController extends AbstractController
         }
 
         return new Response($this->view('@panel.tools.updates', [
-            'title' => $this->translate('panel.tools.updates'),
-            'tabs'  => $this->view('@panel.tools.tabs', [
-                'tabs'    => $this->tabs,
-                'current' => 'updates',
-            ]),
+            'title'          => $this->translate('panel.tools.updates'),
             'currentVersion' => $this->app::VERSION,
         ]));
     }
@@ -220,11 +205,7 @@ final class ToolsController extends AbstractController
         ksort($data['HTTP Response Headers']);
 
         return new Response($this->view('@panel.tools.info', [
-            'title' => $this->translate('panel.tools.info'),
-            'tabs'  => $this->view('@panel.tools.tabs', [
-                'tabs'    => $this->tabs,
-                'current' => 'info',
-            ]),
+            'title'    => $this->translate('panel.tools.info'),
             'formwork' => $formwork,
             'warnings' => $warnings,
             'info'     => $data,

--- a/formwork/src/Panel/Navigation/NavigationItem.php
+++ b/formwork/src/Panel/Navigation/NavigationItem.php
@@ -2,19 +2,26 @@
 
 namespace Formwork\Panel\Navigation;
 
-use Formwork\Data\Contracts\Arrayable;
-use Formwork\Data\Traits\DataArrayable;
+use Formwork\Data\Contracts\ArraySerializable;
 
-class NavigationItem implements Arrayable
+class NavigationItem implements ArraySerializable
 {
-    use DataArrayable;
+    /**
+     * @var array<string,mixed>
+     */
+    protected array $data = [];
 
     /**
      * @param array<string, mixed> $data
      */
     public function __construct(protected string $id, array $data)
     {
-        $this->data = $data;
+        foreach ($data as $key => $value) {
+            if ($key === 'children') {
+                $value = NavigationItemCollection::fromArray($value);
+            }
+            $this->data[$key] = $value;
+        }
     }
 
     /**
@@ -46,7 +53,7 @@ class NavigationItem implements Arrayable
      */
     public function permissions(): ?string
     {
-        return $this->data['permissions'];
+        return $this->data['permissions'] ?? null;
     }
 
     /**
@@ -75,5 +82,27 @@ class NavigationItem implements Arrayable
     public function visible(): bool
     {
         return $this->data['visible'] ?? true;
+    }
+
+    /**
+     * Get navigation item children
+     */
+    public function children(): ?NavigationItemCollection
+    {
+        return $this->data['children'] ?? null;
+    }
+
+    public function toArray(): array
+    {
+        $data = $this->data;
+        if (isset($data['children'])) {
+            $data['children'] = $data['children']->toArray();
+        }
+        return [...$data, 'id' => $this->id];
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['id'], $data);
     }
 }

--- a/formwork/src/Panel/Navigation/NavigationItemCollection.php
+++ b/formwork/src/Panel/Navigation/NavigationItemCollection.php
@@ -3,12 +3,24 @@
 namespace Formwork\Panel\Navigation;
 
 use Formwork\Data\AbstractCollection;
+use Formwork\Data\Contracts\ArraySerializable;
+use Formwork\Utils\Arr;
 
-class NavigationItemCollection extends AbstractCollection
+class NavigationItemCollection extends AbstractCollection implements ArraySerializable
 {
     protected bool $associative = true;
 
     protected ?string $dataType = NavigationItem::class;
 
     protected bool $mutable = true;
+
+    public function toArray(): array
+    {
+        return Arr::map($this->data, fn(NavigationItem $navigationItem) => $navigationItem->toArray());
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(Arr::map($data, fn(array $item, string $id) => NavigationItem::fromArray([...$item, 'id' => $id])));
+    }
 }

--- a/formwork/src/Panel/Panel.php
+++ b/formwork/src/Panel/Panel.php
@@ -11,14 +11,12 @@ use Formwork\Http\Session\MessageType;
 use Formwork\Languages\LanguageCodes;
 use Formwork\Panel\Events\PanelNavigationLoadedEvent;
 use Formwork\Panel\Modals\Modals;
-use Formwork\Panel\Navigation\NavigationItem;
 use Formwork\Panel\Navigation\NavigationItemCollection;
 use Formwork\Services\Container;
 use Formwork\Translations\Translations;
 use Formwork\Users\ColorScheme;
 use Formwork\Users\User;
 use Formwork\Users\Users;
-use Formwork\Utils\Arr;
 use Formwork\Utils\FileSystem;
 use Formwork\Utils\Str;
 use Formwork\Utils\Uri;
@@ -117,15 +115,20 @@ final class Panel
      */
     public function navigation(): NavigationItemCollection
     {
-        $translation = $this->translations->getCurrent();
-        if (!isset($this->navigation)) {
-            $items = $this->container->call(require $this->config->get('system.panel.config.navigation'), [
-                'translation' => $translation,
-            ]);
-            $this->navigation = new NavigationItemCollection();
-            $this->navigation->setMultiple(Arr::map($items, fn(array $data, string $id) => new NavigationItem($id, $data)));
-            $this->events->dispatch(new PanelNavigationLoadedEvent($this->navigation, $translation));
+        if (isset($this->navigation)) {
+            return $this->navigation;
         }
+
+        $translation = $this->translations->getCurrent();
+
+        $this->navigation = NavigationItemCollection::fromArray(
+            $this->container->call(require $this->config->get('system.panel.config.navigation'), [
+                'translation' => $translation,
+            ])
+        );
+
+        $this->events->dispatch(new PanelNavigationLoadedEvent($this->navigation, $translation));
+
         return $this->navigation;
     }
 

--- a/panel/config/navigation.php
+++ b/panel/config/navigation.php
@@ -9,7 +9,6 @@ return fn(App $app, Site $site, Translation $translation) => [
         'label'       => $translation->translate('panel.dashboard.dashboard'),
         'uri'         => '/dashboard/',
         'permissions' => 'panel.dashboard',
-        'badge'       => null,
         'icon'        => 'home',
     ],
     'pages' => [
@@ -23,14 +22,12 @@ return fn(App $app, Site $site, Translation $translation) => [
         'label'       => $translation->translate('panel.files.files'),
         'uri'         => '/files/',
         'permissions' => 'panel.files',
-        'badge'       => null,
         'icon'        => 'files',
     ],
     'statistics' => [
         'label'       => $translation->translate('panel.statistics.statistics'),
         'uri'         => '/statistics/',
         'permissions' => 'panel.statistics',
-        'badge'       => null,
         'icon'        => 'chart-line',
     ],
     'users' => [
@@ -44,15 +41,42 @@ return fn(App $app, Site $site, Translation $translation) => [
         'label'       => $translation->translate('panel.options.options'),
         'uri'         => '/options/',
         'permissions' => 'panel.options',
-        'badge'       => null,
         'icon'        => 'gear',
+        'children'    => [
+            'site' => [
+                'label'       => $translation->translate('panel.options.site'),
+                'uri'         => '/options/site/',
+                'permissions' => 'panel.options.site',
+            ],
+            'system' => [
+                'label'       => $translation->translate('panel.options.system'),
+                'uri'         => '/options/system/',
+                'permissions' => 'panel.options.system',
+            ],
+        ],
     ],
     'tools' => [
         'label'       => $translation->translate('panel.tools.tools'),
         'uri'         => '/tools/',
         'permissions' => 'panel.tools',
-        'badge'       => null,
         'icon'        => 'toolbox',
+        'children'    => [
+            'backups' => [
+                'label'       => $translation->translate('panel.tools.backups'),
+                'uri'         => '/tools/backups/',
+                'permissions' => 'panel.tools.backups',
+            ],
+            'updates' => [
+                'label'       => $translation->translate('panel.tools.updates'),
+                'uri'         => '/tools/updates/',
+                'permissions' => 'panel.tools.updates',
+            ],
+            'info' => [
+                'label'       => $translation->translate('panel.tools.info'),
+                'uri'         => '/tools/info/',
+                'permissions' => 'panel.tools.info',
+            ],
+        ],
     ],
     'plugins' => [
         'label'       => $translation->translate('panel.plugins.plugins'),
@@ -63,9 +87,7 @@ return fn(App $app, Site $site, Translation $translation) => [
         'visible'     => !$app->plugins()->isEmpty(),
     ],
     'logout' => [
-        'label'       => $translation->translate('panel.login.logout'),
-        'uri'         => '/logout/',
-        'permissions' => null,
-        'badge'       => null,
+        'label' => $translation->translate('panel.login.logout'),
+        'uri'   => '/logout/',
     ],
 ];

--- a/panel/src/scss/components/_tabs.scss
+++ b/panel/src/scss/components/_tabs.scss
@@ -60,6 +60,10 @@
     }
 }
 
+.tabs-tab .icon {
+    margin-right: 0.375rem;
+}
+
 .tabs-panel {
     display: none;
 }

--- a/panel/views/options/site.php
+++ b/panel/views/options/site.php
@@ -11,7 +11,7 @@
             <input type="hidden" name="csrf-token" value="<?= $csrfToken ?>">
         </div>
     </div>
-    <?php $this->insert('@panel.partials.navigation.tabs', ['items' => $panel->navigation()->get('options')->children(), 'current' => 'site']) ?>
+    <?php $this->insert('@panel._navigation.tabs', ['items' => $panel->navigation()->get('options')->children(), 'current' => 'site']) ?>
     <div>
         <?php $this->insert('@panel.fields', ['fields' => $fields]) ?>
     </div>

--- a/panel/views/options/site.php
+++ b/panel/views/options/site.php
@@ -11,7 +11,7 @@
             <input type="hidden" name="csrf-token" value="<?= $csrfToken ?>">
         </div>
     </div>
-    <?= $tabs ?>
+    <?php $this->insert('@panel.partials.navigation.tabs', ['items' => $panel->navigation()->get('options')->children(), 'current' => 'site']) ?>
     <div>
         <?php $this->insert('@panel.fields', ['fields' => $fields]) ?>
     </div>

--- a/panel/views/options/system.php
+++ b/panel/views/options/system.php
@@ -11,7 +11,7 @@
             <input type="hidden" name="csrf-token" value="<?= $csrfToken ?>">
         </div>
     </div>
-    <?php $this->insert('@panel.partials.navigation.tabs', ['items' => $panel->navigation()->get('options')->children(), 'current' => 'system']) ?>
+    <?php $this->insert('@panel._navigation.tabs', ['items' => $panel->navigation()->get('options')->children(), 'current' => 'system']) ?>
     <div>
         <?php $this->insert('@panel.fields', ['fields' => $fields]) ?>
     </div>

--- a/panel/views/options/system.php
+++ b/panel/views/options/system.php
@@ -11,7 +11,7 @@
             <input type="hidden" name="csrf-token" value="<?= $csrfToken ?>">
         </div>
     </div>
-    <?= $tabs ?>
+    <?php $this->insert('@panel.partials.navigation.tabs', ['items' => $panel->navigation()->get('options')->children(), 'current' => 'system']) ?>
     <div>
         <?php $this->insert('@panel.fields', ['fields' => $fields]) ?>
     </div>

--- a/panel/views/options/tabs.php
+++ b/panel/views/options/tabs.php
@@ -1,7 +1,0 @@
-<div class="tabs">
-    <?php foreach ($tabs as $tab) : ?>
-        <?php if ($panel->user()->permissions()->has("panel.options.{$tab}")) : ?>
-            <a class="<?= $this->classes(['tabs-tab', 'active' => $tab === $current]) ?>" href="<?= $panel->uri("/options/{$tab}/") ?>"><?= $this->translate("panel.options.{$tab}") ?></a>
-        <?php endif ?>
-    <?php endforeach ?>
-</div>

--- a/panel/views/partials/navigation/sidebar.php
+++ b/panel/views/partials/navigation/sidebar.php
@@ -1,0 +1,15 @@
+<?php foreach ($items as $item) : ?>
+    <?php if ($item->visible() && ($item->permissions() === null || $panel->user()->permissions()->has($item->permissions()))) : ?>
+        <li class="<?= $this->classes(['active' => $location === $item->id()]) ?>">
+            <a href="<?= $panel->uri($item->uri()) ?>">
+                <?php if ($item->icon()) : ?>
+                    <?= $this->icon($item->icon()) ?>
+                <?php endif ?>
+                <?= $this->escape($item->label()) ?>
+                <?php if ($item->badge()) : ?>
+                    <span class="badge"><?= $item->badge() ?></span>
+                <?php endif ?>
+            </a>
+        </li>
+    <?php endif ?>
+<?php endforeach ?>

--- a/panel/views/partials/navigation/tabs.php
+++ b/panel/views/partials/navigation/tabs.php
@@ -1,0 +1,15 @@
+<div class="tabs">
+    <?php foreach ($items as $item) : ?>
+        <?php if ($item->visible() && ($item->permissions() === null || $panel->user()->permissions()->has($item->permissions()))) : ?>
+            <a class="<?= $this->classes(['tabs-tab', 'active' => $item->id() === $current]) ?>" href="<?= $panel->uri($item->uri()) ?>">
+                <?php if ($item->icon()) : ?>
+                    <?= $this->icon($item->icon()) ?>
+                <?php endif ?>
+                <?= $this->escape($item->label()) ?>
+                <?php if ($item->badge()) : ?>
+                    <span class="badge"><?= $item->badge() ?></span>
+                <?php endif ?>
+            </a>
+        <?php endif ?>
+    <?php endforeach ?>
+</div>

--- a/panel/views/partials/sidebar.php
+++ b/panel/views/partials/sidebar.php
@@ -15,21 +15,7 @@
     <nav class="sidebar-wrapper">
         <div class="caption mb-8"><?= $this->translate('panel.manage') ?></div>
         <ul class="sidebar-navigation">
-            <?php foreach ($panel->navigation() as $item) : ?>
-                <?php if ($item->visible() && ($item->permissions() === null || $panel->user()->permissions()->has($item->permissions()))) : ?>
-                    <li class="<?= $this->classes(['active' => $location === $item->id()]) ?>">
-                        <a href="<?= $panel->uri($item->uri()) ?>">
-                            <?php if ($item->icon()) : ?>
-                                <?= $this->icon($item->icon()) ?>
-                            <?php endif ?>
-                            <?= $this->escape($item->label()) ?>
-                            <?php if ($item->badge()) : ?>
-                                <span class="badge"><?= $item->badge() ?></span>
-                            <?php endif ?>
-                        </a>
-                    </li>
-                <?php endif ?>
-            <?php endforeach ?>
+            <?php $this->insert('@panel.partials.navigation.sidebar', ['items' => $panel->navigation()]) ?>
         </ul>
     </nav>
 </div>

--- a/panel/views/partials/sidebar.php
+++ b/panel/views/partials/sidebar.php
@@ -15,7 +15,7 @@
     <nav class="sidebar-wrapper">
         <div class="caption mb-8"><?= $this->translate('panel.manage') ?></div>
         <ul class="sidebar-navigation">
-            <?php $this->insert('@panel.partials.navigation.sidebar', ['items' => $panel->navigation()]) ?>
+            <?php $this->insert('@panel._navigation.sidebar', ['items' => $panel->navigation()]) ?>
         </ul>
     </nav>
 </div>

--- a/panel/views/tools/backups.php
+++ b/panel/views/tools/backups.php
@@ -7,7 +7,8 @@
     <div class="header-title"><?= $this->translate('panel.tools.tools') ?></div>
 </div>
 
-<?= $tabs ?>
+<?php $this->insert('@panel.partials.navigation.tabs', ['items' => $panel->navigation()->get('tools')->children(), 'current' => 'backups']) ?>
+
 <div data-view="backups">
     <section class="section">
         <button type="button" class="button button-secondary mr-6" data-command="make-backup"><?= $this->icon('clock-rotate-left') ?> <?= $this->translate('panel.backup.backup') ?></button>

--- a/panel/views/tools/backups.php
+++ b/panel/views/tools/backups.php
@@ -7,7 +7,7 @@
     <div class="header-title"><?= $this->translate('panel.tools.tools') ?></div>
 </div>
 
-<?php $this->insert('@panel.partials.navigation.tabs', ['items' => $panel->navigation()->get('tools')->children(), 'current' => 'backups']) ?>
+<?php $this->insert('@panel._navigation.tabs', ['items' => $panel->navigation()->get('tools')->children(), 'current' => 'backups']) ?>
 
 <div data-view="backups">
     <section class="section">

--- a/panel/views/tools/info.php
+++ b/panel/views/tools/info.php
@@ -5,7 +5,7 @@
     <div class="header-title"><?= $this->translate('panel.tools.tools') ?></div>
 </div>
 
-<?= $tabs ?>
+<?php $this->insert('@panel.partials.navigation.tabs', ['items' => $panel->navigation()->get('tools')->children(), 'current' => 'info']) ?>
 
 <div>
     <section class="section">

--- a/panel/views/tools/info.php
+++ b/panel/views/tools/info.php
@@ -5,7 +5,7 @@
     <div class="header-title"><?= $this->translate('panel.tools.tools') ?></div>
 </div>
 
-<?php $this->insert('@panel.partials.navigation.tabs', ['items' => $panel->navigation()->get('tools')->children(), 'current' => 'info']) ?>
+<?php $this->insert('@panel._navigation.tabs', ['items' => $panel->navigation()->get('tools')->children(), 'current' => 'info']) ?>
 
 <div>
     <section class="section">

--- a/panel/views/tools/tabs.php
+++ b/panel/views/tools/tabs.php
@@ -1,7 +1,0 @@
-<div class="tabs">
-    <?php foreach ($tabs as $tab) : ?>
-        <?php if ($panel->user()->permissions()->has("panel.tools.{$tab}")) : ?>
-            <a class="<?= $this->classes(['tabs-tab', 'active' => $tab === $current]) ?>" href="<?= $panel->uri("/tools/{$tab}/") ?>"><?= $this->translate("panel.tools.{$tab}") ?></a>
-        <?php endif ?>
-    <?php endforeach ?>
-</div>

--- a/panel/views/tools/updates.php
+++ b/panel/views/tools/updates.php
@@ -5,7 +5,7 @@
     <div class="header-title"><?= $this->translate('panel.tools.tools') ?></div>
 </div>
 
-<?= $tabs ?>
+<?php $this->insert('@panel.partials.navigation.tabs', ['items' => $panel->navigation()->get('tools')->children(), 'current' => 'updates']) ?>
 
 <section id="updater-component" class="section">
     <div class="row">

--- a/panel/views/tools/updates.php
+++ b/panel/views/tools/updates.php
@@ -5,7 +5,7 @@
     <div class="header-title"><?= $this->translate('panel.tools.tools') ?></div>
 </div>
 
-<?php $this->insert('@panel.partials.navigation.tabs', ['items' => $panel->navigation()->get('tools')->children(), 'current' => 'updates']) ?>
+<?php $this->insert('@panel._navigation.tabs', ['items' => $panel->navigation()->get('tools')->children(), 'current' => 'updates']) ?>
 
 <section id="updater-component" class="section">
     <div class="row">


### PR DESCRIPTION
This pull request refactors how navigation tabs are handled in the panel, making the navigation structure more flexible and maintainable. Instead of hardcoding tab arrays and rendering logic in controllers and views, tabs are now defined as navigation children in the configuration and rendered using reusable partials. This change also introduces improved handling for navigation items and collections, including support for nested items.

**Navigation Structure Refactoring**

* Navigation tabs for options and tools are now defined as `children` in the navigation config (`panel/config/navigation.php`), replacing hardcoded arrays in controllers. This enables dynamic tab generation and easier future extension. [[1]](diffhunk://#diff-db9e5fccdd96040f9741f7b8a65db133081c2601f22c439ddbc50da8d3a747bdL47-R79) [[2]](diffhunk://#diff-db9e5fccdd96040f9741f7b8a65db133081c2601f22c439ddbc50da8d3a747bdL68-L69) [[3]](diffhunk://#diff-42b973d64c5b91ea7e7067d79b0b65f863a3a7087cf9251de4ce7d5462405cb7L15-L21) [[4]](diffhunk://#diff-5647a1669fe76f595755623ac18f8737cf99e0a1ec6d1c02342a44d86edb76f6L15-L21)
* Controllers (`OptionsController`, `ToolsController`) no longer maintain their own tab arrays or pass tab views; views now use navigation children for tab rendering. [[1]](diffhunk://#diff-42b973d64c5b91ea7e7067d79b0b65f863a3a7087cf9251de4ce7d5462405cb7L75-L78) [[2]](diffhunk://#diff-42b973d64c5b91ea7e7067d79b0b65f863a3a7087cf9251de4ce7d5462405cb7L123-L126) [[3]](diffhunk://#diff-5647a1669fe76f595755623ac18f8737cf99e0a1ec6d1c02342a44d86edb76f6L61-L64) [[4]](diffhunk://#diff-5647a1669fe76f595755623ac18f8737cf99e0a1ec6d1c02342a44d86edb76f6L80-L83) [[5]](diffhunk://#diff-5647a1669fe76f595755623ac18f8737cf99e0a1ec6d1c02342a44d86edb76f6L224-L227)

**Navigation Item & Collection Improvements**

* `NavigationItem` and `NavigationItemCollection` classes now implement `ArraySerializable` and support nested children, with new methods for serialization and construction from arrays. [[1]](diffhunk://#diff-12c63e0d6e055fb2155317ccd75be75892d2a7b3b9c2061b369b206b018010c1L5-R24) [[2]](diffhunk://#diff-12c63e0d6e055fb2155317ccd75be75892d2a7b3b9c2061b369b206b018010c1R86-R107) [[3]](diffhunk://#diff-ef0e65ad65e4592452495b6e303860e38d698321ad432be6a85d2ed908e321d1R6-R25)
* The panel's navigation loading logic now uses `NavigationItemCollection::fromArray` for building navigation items, supporting nested structures.

**View and Partial Updates**

* Old tab rendering views (`options/tabs.php`, `tools/tabs.php`) are removed and replaced with a new partial (`partials/navigation/tabs.php`) that renders navigation tabs based on navigation children. [[1]](diffhunk://#diff-4049b4ebf97361da8ee129799fd3ebc28763748e2301c170135fd05642fe924aL1-L7) [[2]](diffhunk://#diff-d161cb896317d23ce7bfd72780fb4d9a39ae3abb2c96f759294fc0b82760449bL1-L7) [[3]](diffhunk://#diff-a04d6dfed063b1b5217dbaa9c36b9ea8a536184fece1d63a3d305abdc09743ddR1-R15)
* Options and tools views (`options/site.php`, `options/system.php`, `tools/backups.php`, `tools/info.php`, `tools/updates.php`) now use the new tab partial, passing appropriate navigation children. [[1]](diffhunk://#diff-9933f116db0e6cd8a6db2d002e047bfe44ce9901e348417065f91098832b6556L14-R14) [[2]](diffhunk://#diff-e4bde2ab902fa77fb0c14b3ac7d5073de5ec8b72fc5dd81b67c16fbbc47bdab6L14-R14) [[3]](diffhunk://#diff-4c27c66256d074b84826bccd395be07cd613475461d4e87ae626d62fb10ac254L10-R11) [[4]](diffhunk://#diff-0d628f4864b4e28991046d4dcd918c170eb100c0cd7fe15b7c0925dbe8ff212cL8-R8) [[5]](diffhunk://#diff-011227006bff82bd89d73c5330355f314b3b9724d507dcc4c574d802931ace96L8-R8)
* Sidebar navigation is also refactored to use a new partial for consistent rendering. [[1]](diffhunk://#diff-8b4932969d341638147250cf7b9605d01d6be3e7cc9ffcbd7b276b3cb5eb7daeR1-R15) [[2]](diffhunk://#diff-13e395d2cbc8f92c4323660831e9e6cae8c0f873d30ec2122517cb5ee19ca5deL18-R18)

**Styling**

* Minor CSS update for tab icons to improve spacing.