### PR TITLE
Reduce statistics visits and visitors identifiability

### DIFF
--- a/formwork/src/Statistics/Statistics.php
+++ b/formwork/src/Statistics/Statistics.php
@@ -61,13 +61,15 @@ final class Statistics
             return;
         }
 
+        $timestamp = time();
+        $date = date(self::DATE_FORMAT, $timestamp);
+
         $ip = IpAnonymizer::anonymize($this->request->ip());
         $uri = Str::append(Uri::make(['query' => '', 'fragment' => ''], $this->request->uri()), '/');
+        $userAgent = $this->request->userAgent();
 
         // Prefer speed over security for hashing, as it's not a security-critical operation
-        $hash = hash('xxh3', "{$ip}@{$uri}");
-
-        $timestamp = time();
+        $hash = hash('xxh3', "{$date}{$ip}{$uri}{$userAgent}");
 
         if (
             $this->registries['sessions']->has($hash)
@@ -79,18 +81,27 @@ final class Statistics
 
         $this->registries['sessions']->set($hash, $timestamp);
 
-        $date = date(self::DATE_FORMAT, $timestamp);
-
         $todayVisits = $this->registries['visits']->has($date) ? (int) $this->registries['visits']->get($date) : 0;
         $this->registries['visits']->set($date, $todayVisits + 1);
 
         $todayUniqueVisits = $this->registries['uniqueVisits']->has($date) ? (int) $this->registries['uniqueVisits']->get($date) : 0;
-        if (!$this->registries['visitors']->has($ip) || $this->registries['visitors']->get($ip) !== $date) {
+
+        $visitor = hash('xxh3', "{$date}{$ip}{$userAgent}");
+
+        // Remove legacy trackable visitor key based on IP
+        /** @todo remove this logic in Formwork 3.0.0 */
+        if ($this->registries['visitors']->has($ip)) {
+            $lastVisit = $this->registries['visitors']->get($ip);
+            $this->registries['visitors']->remove($ip);
+            $this->registries['visitors']->set($visitor, $lastVisit);
+        }
+
+        if (!$this->registries['visitors']->has($visitor) || $this->registries['visitors']->get($visitor) !== $date) {
             $this->registries['uniqueVisits']->set($date, $todayUniqueVisits + 1);
             $this->registries['uniqueVisits']->save();
         }
 
-        $this->registries['visitors']->set($ip, $date);
+        $this->registries['visitors']->set($visitor, $date);
 
         $pageViews = $this->registries['pageViews']->has($uri) ? (int) $this->registries['pageViews']->get($uri) : 0;
         $this->registries['pageViews']->set($uri, $pageViews + 1);

--- a/formwork/src/Statistics/Statistics.php
+++ b/formwork/src/Statistics/Statistics.php
@@ -69,7 +69,7 @@ final class Statistics
         $userAgent = $this->request->userAgent();
 
         // Prefer speed over security for hashing, as it's not a security-critical operation
-        $hash = hash('xxh3', "{$date}{$ip}{$uri}{$userAgent}");
+        $hash = hash('xxh3', "{$date}|{$ip}|{$uri}|{$userAgent}");
 
         if (
             $this->registries['sessions']->has($hash)
@@ -86,7 +86,7 @@ final class Statistics
 
         $todayUniqueVisits = $this->registries['uniqueVisits']->has($date) ? (int) $this->registries['uniqueVisits']->get($date) : 0;
 
-        $visitor = hash('xxh3', "{$date}{$ip}{$userAgent}");
+        $visitor = hash('xxh3', "{$date}|{$ip}|{$userAgent}");
 
         // Remove legacy trackable visitor key based on IP
         /** @todo remove this logic in Formwork 3.0.0 */


### PR DESCRIPTION
This pull request updates the visitor tracking logic in the `Statistics` module to improve uniqueness and future-proof the identification of visitors. The main changes focus on replacing the legacy IP-based visitor keys with a new approach that incorporates the date and user agent, and introduces a migration step to handle existing data. In this way, visitors become less identifiable over time, as the anonymized IP address and user agent are hashed together with the current date, producing rotating, non-persistent identifiers instead of stable tracking keys.

**Visitor tracking improvements:**

* Visitor hash generation now includes the date, anonymized IP, URI, and user agent, making visitor identification more robust and less reliant solely on IP address. (`formwork/src/Statistics/Statistics.php`, [formwork/src/Statistics/Statistics.phpR64-R72](diffhunk://#diff-809b866342cde30e81cdae808b1812836a922c640252c81a89c7f07852d291fcR64-R72))
* Visitor registry keys are now based on a hash of the date, IP, and user agent, rather than just the IP, which helps reduce false positives for unique visits. (`formwork/src/Statistics/Statistics.php`, [formwork/src/Statistics/Statistics.phpL82-R104](diffhunk://#diff-809b866342cde30e81cdae808b1812836a922c640252c81a89c7f07852d291fcL82-R104))

**Legacy data migration:**

* Added logic to migrate legacy visitor keys based on IP to the new hash-based format, ensuring backward compatibility and a smooth transition. This migration code is marked for removal in a future major release. (`formwork/src/Statistics/Statistics.php`, [formwork/src/Statistics/Statistics.phpL82-R104](diffhunk://#diff-809b866342cde30e81cdae808b1812836a922c640252c81a89c7f07852d291fcL82-R104))