### PR TITLE
Add the possibility to bind `ServeCommand` to all interfaces

### DIFF
--- a/formwork/src/Commands/ServeCommand.php
+++ b/formwork/src/Commands/ServeCommand.php
@@ -13,9 +13,19 @@ use UnexpectedValueException;
 final class ServeCommand implements CommandInterface
 {
     /**
+     * @var list<string> List of loopback hosts
+     */
+    private const array LOOPBACK_HOSTS = ['localhost', '127.0.0.1', '::1'];
+
+    /**
+     * @var list<string> List of wildcard hosts
+     */
+    private const array WILDCARD_HOSTS = ['0.0.0.0', '::'];
+
+    /**
      * Host to bind the server to
      */
-    private string $host = '127.0.0.1';
+    private string $host = 'localhost';
 
     /**
      * Port to bind the server to
@@ -66,7 +76,7 @@ final class ServeCommand implements CommandInterface
         $this->climate->arguments->add([
             'host' => [
                 'longPrefix'   => 'host',
-                'description'  => 'Host to bind the server to',
+                'description'  => 'Host to bind the server to (if the value is omitted, the server will bind to all interfaces)',
                 'defaultValue' => $this->host,
             ],
             'port' => [
@@ -89,7 +99,8 @@ final class ServeCommand implements CommandInterface
             ],
         ]);
 
-        $this->climate->arguments->parse();
+        // Ignore parsing errors to handle passing `--host` without a value as a flag to bind to all interfaces
+        @$this->climate->arguments->parse();
 
         if ($this->climate->arguments->get('help')) {
             $this->climate->usage($argv);
@@ -97,7 +108,9 @@ final class ServeCommand implements CommandInterface
         }
 
         /** @var string */
-        $host = $this->climate->arguments->get('host');
+        $host = $this->climate->arguments->defined('host')
+            ? ($this->climate->arguments->get('host') ?: '0.0.0.0') // Bind to all interfaces if `--host` is passed without a value
+            : $this->host;
 
         /** @var int */
         $port = $this->climate->arguments->get('port');
@@ -164,6 +177,14 @@ final class ServeCommand implements CommandInterface
                     $this->climate->br();
                     $this->climate->out(sprintf('➜ Listening on <cyan>http://%s:<bold>%s</bold>/</cyan>', $this->formatHost($this->host), $this->port));
                     $this->climate->br();
+
+                    if (in_array($this->host, self::WILDCARD_HOSTS, true)) {
+                        foreach ($this->getLocalNetworkIps() as $localNetworkIp) {
+                            $this->climate->out(sprintf('➜ Remote address: <cyan>http://%s:<bold>%s</bold>/</cyan>', $this->formatHost($localNetworkIp), $this->port));
+                            $this->climate->br();
+                        }
+                    }
+
                     $this->climate->out('<dark_gray>Press <bold>CTRL+C</bold> to stop</dark_gray>');
                     $this->climate->br();
                     break;
@@ -335,5 +356,35 @@ final class ServeCommand implements CommandInterface
             default:
                 throw new UnexpectedValueException(sprintf('Unexpected output type "%s"', $type));
         }
+    }
+
+    /**
+     * Get local network IP addresses, excluding loopback interfaces
+     *
+     * @return list<string>
+     */
+    private function getLocalNetworkIps(): array
+    {
+        if (($interfaces = net_get_interfaces()) === false) {
+            return [];
+        }
+
+        $localNetworkIps = [];
+
+        foreach ($interfaces as $interface) {
+            if (!isset($interface['unicast'])) {
+                continue;
+            }
+            foreach ($interface['unicast'] as $data) {
+                if (
+                    $data['family'] === AF_INET // IPv4 addresses only
+                    && !in_array($data['address'], self::LOOPBACK_HOSTS, true) // Exclude loopback address
+                ) {
+                    $localNetworkIps[] = $data['address'];
+                }
+            }
+        }
+
+        return $localNetworkIps;
     }
 }

--- a/formwork/src/Commands/ServeCommand.php
+++ b/formwork/src/Commands/ServeCommand.php
@@ -99,8 +99,12 @@ final class ServeCommand implements CommandInterface
             ],
         ]);
 
-        // Ignore parsing errors to handle passing `--host` without a value as a flag to bind to all interfaces
-        @$this->climate->arguments->parse();
+        // --host without a value binds to all interfaces
+        foreach (array_keys($argv, '--host', true) as $key) {
+            $argv[$key] = '--host=0.0.0.0';
+        }
+
+        $this->climate->arguments->parse($argv);
 
         if ($this->climate->arguments->get('help')) {
             $this->climate->usage($argv);
@@ -108,9 +112,12 @@ final class ServeCommand implements CommandInterface
         }
 
         /** @var string */
-        $host = $this->climate->arguments->defined('host')
-            ? ($this->climate->arguments->get('host') ?: '0.0.0.0') // Bind to all interfaces if `--host` is passed without a value
-            : $this->host;
+        $host = $this->climate->arguments->get('host');
+
+        if (!$this->isValidHost($host)) {
+            $this->climate->to('error')->out(sprintf('<bold>Formwork <cyan>%s</cyan></bold> Server <red>failed to listen on invalid host <bold>%s</bold></red>', App::VERSION, $host));
+            exit(1);
+        }
 
         /** @var int */
         $port = $this->climate->arguments->get('port');
@@ -305,6 +312,15 @@ final class ServeCommand implements CommandInterface
     }
 
     /**
+     * Check if host is a valid IP address or hostname
+     */
+    private function isValidHost(string $host): bool
+    {
+        return filter_var($host, FILTER_VALIDATE_IP) !== false
+            || filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) !== false;
+    }
+
+    /**
      * Format host for display and binding
      */
     private function formatHost(string $host): string
@@ -365,6 +381,12 @@ final class ServeCommand implements CommandInterface
      */
     private function getLocalNetworkIps(): array
     {
+        if (!function_exists('net_get_interfaces')) {
+            $this->climate->to('error')->out('<yellow>Cannot get local network IP addresses: function net_get_interfaces() is not available</yellow>');
+            $this->climate->br();
+            return [];
+        }
+
         if (($interfaces = net_get_interfaces()) === false) {
             return [];
         }


### PR DESCRIPTION
This pull request improves the usability of the `ServeCommand` by making it easier to bind the server to all network interfaces and providing clearer feedback when running in this mode. The changes also enhance the output by listing accessible remote addresses when the server is bound to a wildcard host.

**Usability improvements:**

* The default host for the server has been changed from `'127.0.0.1'` to `'localhost'`, and new constants `LOOPBACK_HOSTS` and `WILDCARD_HOSTS` have been introduced to clarify host types.
* The host argument description now explains that omitting the value will bind the server to all interfaces.
* Argument parsing allows `--host` to be passed without a value, causing the server to bind to all interfaces (`0.0.0.0`).

**Output enhancements:**

* When the server is bound to a wildcard host, the output now displays remote addresses for all local network IPs, making it easier for users to find the correct address for remote access.
* A new helper method `getLocalNetworkIps()` was added to retrieve local network IP addresses, excluding loopback interfaces.