### PR TITLE
Add the possibility to pass view blocks to layouts

### DIFF
--- a/formwork/src/View/View.php
+++ b/formwork/src/View/View.php
@@ -186,6 +186,20 @@ class View
     }
 
     /**
+     * Return whether the specified block is defined
+     *
+     * @throws RenderingException If called outside of rendering context
+     */
+    public function defined(string $block): bool
+    {
+        if (!$this->rendering) {
+            throw new RenderingException(sprintf('%s() is allowed only in rendering context', __METHOD__));
+        }
+
+        return isset($this->blocks[$block]);
+    }
+
+    /**
      * End the capturing of last block
      *
      * @throws RenderingException If called outside of rendering context
@@ -296,6 +310,8 @@ class View
 
         if (isset($this->layout)) {
             $this->layout->vars = $this->vars;
+            $this->layout->blocks = $this->blocks;
+
             $contents = ob_get_contents();
 
             if ($contents === false) {


### PR DESCRIPTION
This pull request adds a new method to the `View` class and improves the handling of template blocks when rendering layouts. The main focus is on enhancing template rendering flexibility and ensuring block definitions are properly managed during layout rendering.

Enhancements to template rendering:

* Added a `defined(string $block): bool` method to the `View` class, allowing templates to check if a specific block is defined during rendering. This method throws a `RenderingException` if called outside of the rendering context.

Improvements to layout rendering:

* Updated the `output()` method to copy the current view's `blocks` to the layout before rendering, ensuring that block definitions are available in the layout template.