### PR TITLE
Enforce explicit actor-target checks for profile/password updates

### DIFF
--- a/formwork/src/Users/User.php
+++ b/formwork/src/Users/User.php
@@ -191,7 +191,7 @@ class User extends Model
      */
     public function canDeleteUser(User $user): bool
     {
-        return $this->isAdmin() && !$user->isLoggedIn();
+        return $this->isAdmin() && $this->username() !== $user->username();
     }
 
     /**
@@ -199,10 +199,7 @@ class User extends Model
      */
     public function canChangeOptionsOf(User $user): bool
     {
-        if ($this->isAdmin()) {
-            return true;
-        }
-        return $user->isLoggedIn();
+        return $this->isAdmin() || $this->username() === $user->username();
     }
 
     /**
@@ -210,7 +207,7 @@ class User extends Model
      */
     public function canChangePasswordOf(User $user): bool
     {
-        return $user->isLoggedIn();
+        return $this->username() === $user->username();
     }
 
     /**
@@ -218,7 +215,7 @@ class User extends Model
      */
     public function canChangeRoleOf(User $user): bool
     {
-        return $this->isAdmin() && !$user->isLoggedIn();
+        return $this->isAdmin() && $this->username() !== $user->username();
     }
 
     /**


### PR DESCRIPTION
This pull request updates user permission logic in the `User` class to improve security and ensure users can only perform sensitive actions on their own accounts or, for admins, on other users. The changes focus on refining checks for deleting users, changing options, passwords, and roles.

**Permission logic updates:**

* Changed `canDeleteUser` and `canChangeRoleOf` to allow admins to act only on other users, not themselves.
* Updated `canChangeOptionsOf` and `canChangePasswordOf` to allow users to modify only their own options or password, unless they are admins (who can modify any user’s options).