### PR TITLE
Drop unsafe SMIL `attributeName` values in SVG sanitization

### DIFF
--- a/formwork/src/Sanitizer/DomSanitizer.php
+++ b/formwork/src/Sanitizer/DomSanitizer.php
@@ -231,22 +231,30 @@ class DomSanitizer
                 continue;
             }
 
-            if (!in_array($attribute->nodeName, $this->allowedAttributes, true)) {
-                $domElement->removeAttribute($attribute->nodeName);
+            $this->sanitizeNodeAttribute($domElement, $attribute);
+        }
+    }
+
+    /**
+     * Sanitize a single DOM element attribute
+     */
+    protected function sanitizeNodeAttribute(DOMElement $domElement, DOMAttr $domAttr): void
+    {
+        if (!in_array($domAttr->nodeName, $this->allowedAttributes, true)) {
+            $domElement->removeAttribute($domAttr->nodeName);
+        }
+
+        if (in_array($domAttr->nodeName, $this->uriAttributes, true)) {
+            $uri = $this->sanitizeUri((string) $domAttr->nodeValue);
+
+            $scheme = Uri::scheme($uri);
+
+            if ($scheme === null && !Str::startsWith($uri, '//')) {
+                return;
             }
 
-            if (in_array($attribute->nodeName, $this->uriAttributes, true)) {
-                $uri = $this->sanitizeUri((string) $attribute->nodeValue);
-
-                $scheme = Uri::scheme($uri);
-
-                if ($scheme === null && !Str::startsWith($uri, '//')) {
-                    continue;
-                }
-
-                if (!$this->allowExternalUris || !in_array($scheme, $this->allowedUriSchemes, true)) {
-                    $domElement->removeAttribute($attribute->nodeName);
-                }
+            if (!$this->allowExternalUris || !in_array($scheme, $this->allowedUriSchemes, true)) {
+                $domElement->removeAttribute($domAttr->nodeName);
             }
         }
     }

--- a/formwork/src/Sanitizer/DomSanitizer.php
+++ b/formwork/src/Sanitizer/DomSanitizer.php
@@ -242,6 +242,7 @@ class DomSanitizer
     {
         if (!in_array($domAttr->nodeName, $this->allowedAttributes, true)) {
             $domElement->removeAttribute($domAttr->nodeName);
+            return;
         }
 
         if (in_array($domAttr->nodeName, $this->uriAttributes, true)) {

--- a/formwork/src/Sanitizer/Reference/SvgReference.php
+++ b/formwork/src/Sanitizer/Reference/SvgReference.php
@@ -318,4 +318,17 @@ class SvgReference
         'href',
         'xlink:href',
     ];
+
+    /**
+     * SMIL elements that require handling of the `attributeName` attribute to ensure it is safe
+     *
+     * @var list<string>
+     */
+    public const array SMIL_ELEMENTS = [
+        'animate',
+        'animateMotion',
+        'animateTransform',
+        'discard',
+        'set',
+    ];
 }

--- a/formwork/src/Sanitizer/SvgSanitizer.php
+++ b/formwork/src/Sanitizer/SvgSanitizer.php
@@ -19,6 +19,11 @@ class SvgSanitizer extends DomSanitizer
 
     protected array $uriAttributes = SvgReference::URI_ATTRIBUTES;
 
+    /**
+     * @var list<string>
+     */
+    protected array $smilElements = SvgReference::SMIL_ELEMENTS;
+
     public function __construct(
         protected DomParserInterface $domParser = new PhpDomParser(),
     ) {}
@@ -40,6 +45,19 @@ class SvgSanitizer extends DomSanitizer
     {
         parent::sanitizeDocumentFragment($domDocumentFragment);
         $this->addExplicitSvgNamespace($domDocumentFragment);
+    }
+
+    protected function sanitizeNodeAttribute(DOMElement $domElement, DOMAttr $domAttr): void
+    {
+        parent::sanitizeNodeAttribute($domElement, $domAttr);
+
+        if (
+            in_array($domElement->nodeName, $this->smilElements, true)
+            && $domAttr->name === 'attributeName'
+            && !$this->isSafeSmilAttributeName($domAttr->value)
+        ) {
+            $domElement->removeAttribute($domAttr->name);
+        }
     }
 
     protected function addExplicitSvgNamespace(DOMDocumentFragment $domDocumentFragment): void
@@ -79,5 +97,14 @@ class SvgSanitizer extends DomSanitizer
         $domElement->append(...$svg->childNodes);
 
         $svg->replaceWith($domElement);
+    }
+
+    /**
+     * Return whether the SMIL `attributeName` is allowed and not a URI attribute (which would be unsafe)
+     */
+    private function isSafeSmilAttributeName(string $attributeName): bool
+    {
+        return in_array($attributeName, $this->allowedAttributes, true)
+            && !in_array($attributeName, $this->uriAttributes, true);
     }
 }


### PR DESCRIPTION
This pull request refactors and strengthens the SVG and DOM sanitization logic, with a particular focus on improving the handling of SVG SMIL animation elements. The main changes involve extracting attribute sanitization into its own method, introducing special handling for SMIL `attributeName` attributes, and centralizing SMIL-related reference data.

**Sanitization refactor and SMIL handling:**

* Extracted the logic for sanitizing individual DOM element attributes into a new protected method `sanitizeNodeAttribute`, improving code clarity and reusability. (`formwork/src/Sanitizer/DomSanitizer.php`, [formwork/src/Sanitizer/DomSanitizer.phpL234-R257](diffhunk://#diff-477c2cdea0e619764aade542fb6ec1cd70e85578762616641f295e3cbbeff014L234-R257))
* In `SvgSanitizer`, overridden `sanitizeNodeAttribute` to add special handling for SMIL animation elements: if an element is a SMIL animation type and its `attributeName` is not considered safe, the attribute is removed. (`formwork/src/Sanitizer/SvgSanitizer.php`, [formwork/src/Sanitizer/SvgSanitizer.phpR50-R62](diffhunk://#diff-a3f567e6a23f762d6f7648f14d5687a3e3b9c435e319795e682c4239ee1ceb3aR50-R62))
* Added a private helper method `isSafeSmilAttributeName` to determine if a SMIL `attributeName` is allowed (i.e., not a URI attribute and present in allowed attributes). (`formwork/src/Sanitizer/SvgSanitizer.php`, [formwork/src/Sanitizer/SvgSanitizer.phpR101-R109](diffhunk://#diff-a3f567e6a23f762d6f7648f14d5687a3e3b9c435e319795e682c4239ee1ceb3aR101-R109))

**Centralization of SMIL reference data:**

* Defined a constant `SMIL_ELEMENTS` in `SvgReference` containing the list of SVG SMIL animation element names that require special attribute handling. (`formwork/src/Sanitizer/Reference/SvgReference.php`, [formwork/src/Sanitizer/Reference/SvgReference.phpR321-R333](diffhunk://#diff-5667ab56619af82b3e9393aa71b39ad482c0b148c2e3d9c04d394c0ece57510dR321-R333))
* Added a `protected array $smilElements` property to `SvgSanitizer`, initialized from `SvgReference::SMIL_ELEMENTS`, to make SMIL element checks consistent and maintainable. (`formwork/src/Sanitizer/SvgSanitizer.php`, [formwork/src/Sanitizer/SvgSanitizer.phpR22-R26](diffhunk://#diff-a3f567e6a23f762d6f7648f14d5687a3e3b9c435e319795e682c4239ee1ceb3aR22-R26))