### PR TITLE
Enforce escaping for dynamic content in views and templates

### DIFF
--- a/formwork/views/errors/partials/debug.php
+++ b/formwork/views/errors/partials/debug.php
@@ -1,11 +1,11 @@
 </div>
 <div class="error-debug-details">
-    <h3>Uncaught <code><?= $throwable::class ?></code>: <?= $throwable->getMessage() ?></h3>
+    <h3>Uncaught <code><?= $throwable::class ?></code>: <?= $this->escape($throwable->getMessage()) ?></h3>
     <?php foreach ($stackTrace as $i => $frame) : ?>
         <?php if (isset($frame['file'], $frame['line'])): ?>
             <details <?= $this->attr(['open' => $i === 0]) ?>>
                 <summary><a class="error-debug-editor-uri" href="<?= Formwork\Utils\Str::interpolate($app->config()->get('system.debug.editorUri'), ['filename' => $frame['file'], 'line' => $frame['line']]) ?>"><span class="error-debug-filename"><?= preg_replace('/([^\/]+)$/', '<strong>$1</strong>', $frame['file']) ?></span><span class="error-debug-line">:<?= $frame['line'] ?></span></a></summary>
-                <?= Formwork\Debug\CodeDumper::dumpBacktraceFrame($frame, $app->config()->get('system.debug.contextLines', 5)) ?>
+                <?php Formwork\Debug\CodeDumper::dumpBacktraceFrame($frame, $app->config()->get('system.debug.contextLines', 5)) ?>
             </details>
         <?php endif ?>
     <?php endforeach ?>

--- a/formwork/views/errors/partials/header.php
+++ b/formwork/views/errors/partials/header.php
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-    <title><?= $message ?? 'Internal Server Error' ?> | Formwork</title>
+    <title><?= $this->escape($message ?? 'Internal Server Error') ?> | Formwork</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
@@ -132,5 +132,5 @@
     <div class="container">
         <h1>
             <span class="error-code"><?= $status ?? 500 ?></span>
-            <span class="error-status"><?= $message ?? 'Internal Server Error' ?></span>
+            <span class="error-status"><?= $this->escape($message ?? 'Internal Server Error') ?></span>
         </h1>

--- a/panel/views/errors/error.php
+++ b/panel/views/errors/error.php
@@ -2,7 +2,7 @@
 <html class="color-scheme-<?= $panel->colorScheme()->value ?>">
 
 <head>
-    <title><?php if (!empty($title)) : ?><?= $title ?> | <?php endif ?>Formwork</title>
+    <title><?php if (!empty($title)) : ?><?= $this->escape($title) ?> | <?php endif ?>Formwork</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="noindex, nofollow">
     <link rel="icon" type="image/svg+xml" href="<?= $this->assets()->get('@panel/images/icon.svg')->uri() ?>">
@@ -17,23 +17,23 @@
             <div class="error-container">
                 <h1>
                     <span class="error-code"><?= $code ?></span>
-                    <span class="error-status"><?= $status ?></span>
+                    <span class="error-status"><?= $this->escape($status) ?></span>
                 </h1>
                 <img class="logo" src="<?= $this->assets()->get('@panel/images/icon.svg')->uri() ?>">
-                <h2><?= $heading ?></h2>
-                <p><?= $description ?></p>
-                <?php if (isset($action)) : ?><a class="action" href="<?= $action['href'] ?>"><?= $action['label'] ?></a><?php endif ?>
+                <h2><?= $this->escape($heading) ?></h2>
+                <p><?= $this->escape($description) ?></p>
+                <?php if (isset($action)) : ?><a class="action" href="<?= $action['href'] ?>"><?= $this->escape($action['label']) ?></a><?php endif ?>
             </div>
         </div>
         <?php if (isset($throwable, $stackTrace)) : ?>
             <div class="container-full">
                 <div class="error-debug-details">
-                    <h3>Uncaught <code><?= $throwable::class ?></code>: <?= $throwable->getMessage() ?></h3>
+                    <h3>Uncaught <code><?= $throwable::class ?></code>: <?= $this->escape($throwable->getMessage()) ?></h3>
                     <?php foreach ($stackTrace as $i => $frame) : ?>
                         <?php if (isset($frame['file'], $frame['line'])): ?>
                             <details <?= $this->attr(['open' => $i === 0]) ?>>
                                 <summary><a class="error-debug-editor-uri" href="<?= Formwork\Utils\Str::interpolate($app->config()->get('system.debug.editorUri'), ['filename' => $frame['file'], 'line' => $frame['line']]) ?>"><span class="error-debug-filename"><?= preg_replace('/([^\/]+)$/', '<strong>$1</strong>', $frame['file']) ?></span><span class="error-debug-line">:<?= $frame['line'] ?></span></a></summary>
-                                <?= Formwork\Debug\CodeDumper::dumpBacktraceFrame($frame, $app->config()->get('system.debug.contextLines', 5)) ?>
+                                <?php Formwork\Debug\CodeDumper::dumpBacktraceFrame($frame, $app->config()->get('system.debug.contextLines', 5)) ?>
                             </details>
                         <?php endif ?>
                     <?php endforeach ?>

--- a/panel/views/layouts/login.php
+++ b/panel/views/layouts/login.php
@@ -2,7 +2,7 @@
 <html lang="<?= $app->translations()->getCurrent()->code() ?>" class="color-scheme-<?= $panel->colorScheme()->value ?>">
 
 <head>
-    <title><?php if (!empty($title)) : ?><?= $title ?> | <?php endif ?>Formwork</title>
+    <title><?php if (!empty($title)) : ?><?= $this->escape($title) ?> | <?php endif ?>Formwork</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
     <meta name="robots" content="noindex, nofollow">
     <link rel="icon" type="image/svg+xml" href="<?= $this->assets()->get('@panel/images/icon.svg')->uri() ?>">

--- a/panel/views/layouts/panel.php
+++ b/panel/views/layouts/panel.php
@@ -2,7 +2,7 @@
 <html lang="<?= $app->translations()->getCurrent()->code() ?>" class="color-scheme-<?= $panel->colorScheme()->value ?>">
 
 <head>
-    <title><?php if (!empty($title)) : ?><?= $title ?> | <?php endif ?>Formwork</title>
+    <title><?php if (!empty($title)) : ?><?= $this->escape($title) ?> | <?php endif ?>Formwork</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
     <meta name="robots" content="noindex, nofollow">
     <?php foreach ($panel->notifications() as $notification) : ?>

--- a/panel/views/tools/updates.php
+++ b/panel/views/tools/updates.php
@@ -10,7 +10,7 @@
 <section id="updater-component" class="section">
     <div class="row">
         <div class="col-md-1-1">
-            <div class="checker"><span class="spinner"></span><span class="update-status" data-checking-text="<?= $this->translate('panel.updates.status.checking') ?>" data-installing-text="<?= $this->translate('panel.updates.status.installing') ?>"><?= $this->translate('panel.updates.status.checking') ?></span></div>
+            <div class="checker"><span class="spinner"></span><span class="update-status" data-checking-text="<?= $this->escapeAttr($this->translate('panel.updates.status.checking')) ?>" data-installing-text="<?= $this->escapeAttr($this->translate('panel.updates.status.installing')) ?>"><?= $this->translate('panel.updates.status.checking') ?></span></div>
         </div>
     </div>
     <div class="row new-version mt-9" style="display: none;">

--- a/panel/views/users/profile.php
+++ b/panel/views/users/profile.php
@@ -31,7 +31,7 @@
             <div class="h3 mb-0"><?= $this->escape($user->fullname()) ?></div>
             <div class="text-color-gray-medium mb-4"><?= $this->escape($user->username()) ?></div>
             <div class="mb-2"><a href="mailto:<?= $user->email() ?>"><?= $this->escape($user->email()) ?></a></div>
-            <div class="text-size-sm mb-2"><strong><?= $this->translate('user.role') ?>:</strong> <?= $user->role()->title() ?></div>
+            <div class="text-size-sm mb-2"><strong><?= $this->translate('user.role') ?>:</strong> <?= $this->escape($user->role()->title()) ?></div>
             <div class="text-size-sm"><strong><?= $this->translate('panel.user.lastAccess') ?>:</strong> <?= is_null($user->lastAccess()) ? '&infin;' : $this->datetime($user->lastAccess()) ?></div>
         </div>
     </section>

--- a/site/templates/blog.php
+++ b/site/templates/blog.php
@@ -11,7 +11,7 @@
         <?php foreach ($posts as $post) : ?>
             <article class="article">
                 <?php if ($post->has('coverImage') && ($image = $post->coverImage())) : ?>
-                    <img class="article-cover-image" src="<?= $image->uri() ?>" alt="<?= $this->escape($post->title()) ?>">
+                    <img class="article-cover-image" src="<?= $image->uri() ?>" alt="<?= $this->escapeAttr($post->title()) ?>">
                 <?php endif ?>
                 <?php if (!$post->publishDate()->isEmpty()) : ?><time class="article-time"><?= $post->publishDate()->toTimeDistance() ?></time><?php endif ?>
                 <h1 class="article-title"><a href="<?= $post->uri() ?>"><?= $this->escape($post->title()) ?></a></h1>

--- a/site/templates/layouts/site.php
+++ b/site/templates/layouts/site.php
@@ -2,7 +2,7 @@
 <html lang="<?= $site->languages()->current() ?>">
 
 <head>
-    <title><?= $page->title() ?> | <?= $site->title() ?></title>
+    <title><?= $this->escape($page->title()) ?> | <?= $this->escape($site->title()) ?></title>
     <?= $this->insert('_meta') ?>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚧</text></svg>">


### PR DESCRIPTION
This pull request focuses on improving the security and robustness of the application's views by ensuring that all dynamic content is properly escaped before being rendered. This helps prevent XSS (Cross-Site Scripting) vulnerabilities and ensures that special characters are handled correctly in both HTML and attribute contexts. The main changes are grouped below:

**Security and Output Escaping Improvements:**

* All dynamic page titles and status messages in `panel` and `formwork` error and layout views are now escaped using `$this->escape()` to prevent XSS attacks and ensure correct HTML rendering. (`panel/views/errors/error.php`, `panel/views/layouts/login.php`, `panel/views/layouts/panel.php`, `formwork/views/errors/partials/header.php`, `site/templates/layouts/site.php`) [[1]](diffhunk://#diff-3e34110135d9aabf430ec9d5610267ca3f49f6f1b1e231e4ab0a667d11b99975L5-R5) [[2]](diffhunk://#diff-cf70e2ff1fa808f4f9f63c82993ef36b72aa9d5a86186bfdadcef65824230445L5-R5) [[3]](diffhunk://#diff-7965b9dc99741b60516fde818db5706452b9e1a7f8620606a7a402f23ca4ecadL5-R5) [[4]](diffhunk://#diff-dced6a03a425db3a1e6485cccdd630e92f9925c480a68a90573761121786a637L5-R5) [[5]](diffhunk://#diff-26a14cb571b1e9e53e7f36a3b89cbb3f4c4009d3191d0cf7199d1198e8d135adL5-R5)
* Error details, headings, descriptions, and action labels in error views are now escaped, including throwable messages, headings, and descriptions, to further prevent the injection of malicious content. (`panel/views/errors/error.php`, `formwork/views/errors/partials/debug.php`) [[1]](diffhunk://#diff-3e34110135d9aabf430ec9d5610267ca3f49f6f1b1e231e4ab0a667d11b99975L20-R36) [[2]](diffhunk://#diff-d34c5ff93330aa3174787d5b154b0ba84ed79d05302281864c3b127127599a19L3-R8)
* User role titles in the user profile are now escaped to avoid issues with special characters. (`panel/views/users/profile.php`)

**Attribute Escaping:**

* All dynamic content used in HTML attributes, such as `alt` attributes for images and `data-*` attributes for update status, is now escaped with `$this->escapeAttr()` to ensure valid and safe attribute values. (`site/templates/blog.php`, `panel/views/tools/updates.php`) [[1]](diffhunk://#diff-01bcf1608d55d50b8d837f701bb72ba961b91540743cb4fd3f08708d3a2d77edL14-R14) [[2]](diffhunk://#diff-011227006bff82bd89d73c5330355f314b3b9724d507dcc4c574d802931ace96L13-R13)

**Minor Rendering Fixes:**

* Changed how `CodeDumper::dumpBacktraceFrame` is called in error debug details to use a PHP block rather than outputting the return value directly, aligning with the intended usage. (`panel/views/errors/error.php`, `formwork/views/errors/partials/debug.php`) [[1]](diffhunk://#diff-3e34110135d9aabf430ec9d5610267ca3f49f6f1b1e231e4ab0a667d11b99975L20-R36) [[2]](diffhunk://#diff-d34c5ff93330aa3174787d5b154b0ba84ed79d05302281864c3b127127599a19L3-R8)

These changes collectively harden the application's frontend against XSS and improve the reliability of rendered output.