### PR TITLE
Validate statistics visitor source

### DIFF
--- a/formwork/src/Http/Utils/Visitor.php
+++ b/formwork/src/Http/Utils/Visitor.php
@@ -5,7 +5,9 @@ namespace Formwork\Http\Utils;
 use Detection\MobileDetect;
 use Formwork\Http\Request;
 use Formwork\Traits\StaticClass;
+use Formwork\Utils\Str;
 use Formwork\Utils\Uri;
+use InvalidArgumentException;
 use Jaybizzle\CrawlerDetect\CrawlerDetect;
 
 final class Visitor
@@ -56,20 +58,44 @@ final class Visitor
     }
 
     /**
-     * Return the source of the visitor, if any
-     * If the visitor has no source ("direct" visit), an empty string is returned
-     * If the source is invalid or the same as the current host, null is returned
+     * Get the source of the visitor based on the referer and host headers
+     *
+     * @return string|null The source of the visitor, an empty string if it is a direct visit, or null if it cannot be determined or is invalid
      */
     public static function getSource(Request $request): ?string
     {
         $referer = $request->referer();
-        if ($referer === null) {
+        if ($referer === null || $referer === '') {
             return '';
         }
 
-        $source = Uri::host($referer);
+        try {
+            $source = Uri::host($referer);
+        } catch (InvalidArgumentException) {
+            return null;
+        }
 
-        if (filter_var($source, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false || $source === $request->host()) {
+        if ($source === null || filter_var($source, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false) {
+            return null;
+        }
+
+        $hostHeader = $request->host();
+        if ($hostHeader === null || Str::contains($hostHeader, '://')) {
+            return null;
+        }
+
+        try {
+            // Host header may contain a port number, so we need to extract the host part only
+            // adding '//' to tell the parser the input is an authority component
+            $host = Uri::host('//' . $hostHeader);
+        } catch (InvalidArgumentException) {
+            return null;
+        }
+
+        if (
+            $host === null || filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false
+            || $source === $host // Source and host are lowercased by `Uri::host()`
+        ) {
             return null;
         }
 

--- a/formwork/src/Http/Utils/Visitor.php
+++ b/formwork/src/Http/Utils/Visitor.php
@@ -5,6 +5,7 @@ namespace Formwork\Http\Utils;
 use Detection\MobileDetect;
 use Formwork\Http\Request;
 use Formwork\Traits\StaticClass;
+use Formwork\Utils\Uri;
 use Jaybizzle\CrawlerDetect\CrawlerDetect;
 
 final class Visitor
@@ -52,5 +53,26 @@ final class Visitor
     public static function isDesktop(Request $request): bool
     {
         return self::getDeviceType($request) === DeviceType::Desktop;
+    }
+
+    /**
+     * Return the source of the visitor, if any
+     * If the visitor has no source ("direct" visit), an empty string is returned
+     * If the source is invalid or the same as the current host, null is returned
+     */
+    public static function getSource(Request $request): ?string
+    {
+        $referer = $request->referer();
+        if ($referer === null) {
+            return '';
+        }
+
+        $source = Uri::host($referer);
+
+        if (filter_var($source, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false || $source === $request->host()) {
+            return null;
+        }
+
+        return $source;
     }
 }

--- a/formwork/src/Statistics/Statistics.php
+++ b/formwork/src/Statistics/Statistics.php
@@ -106,8 +106,7 @@ final class Statistics
         $pageViews = $this->registries['pageViews']->has($uri) ? (int) $this->registries['pageViews']->get($uri) : 0;
         $this->registries['pageViews']->set($uri, $pageViews + 1);
 
-        if (($referer = $this->request->referer()) === null || ($source = Uri::host($referer)) !== $this->request->host()) {
-            $source ??= '';
+        if ($source = Visitor::getSource($this->request)) {
             $sourceVisits = $this->registries['sources']->has($source) ? (int) $this->registries['sources']->get($source) : 0;
             $this->registries['sources']->set($source, $sourceVisits + 1);
         }

--- a/formwork/src/Statistics/Statistics.php
+++ b/formwork/src/Statistics/Statistics.php
@@ -106,7 +106,7 @@ final class Statistics
         $pageViews = $this->registries['pageViews']->has($uri) ? (int) $this->registries['pageViews']->get($uri) : 0;
         $this->registries['pageViews']->set($uri, $pageViews + 1);
 
-        if ($source = Visitor::getSource($this->request)) {
+        if (($source = Visitor::getSource($this->request)) !== null) {
             $sourceVisits = $this->registries['sources']->has($source) ? (int) $this->registries['sources']->get($source) : 0;
             $this->registries['sources']->set($source, $sourceVisits + 1);
         }

--- a/panel/views/statistics/index.php
+++ b/panel/views/statistics/index.php
@@ -83,7 +83,7 @@
                     <?php foreach ($sources as $source => $views) : ?>
                         <tr>
                             <td class="table-cell statistics-histogram-cell" style="--percentage: <?= round($views / $totalSources * 100, 2) ?>%">
-                                <div class="truncate"><?= $this->icon('globe') ?> <?= $source ?: $this->translate('panel.statistics.sources.direct') ?></div>
+                                <div class="truncate"><?= $this->icon('globe') ?> <?= $this->escape($source) ?: $this->translate('panel.statistics.sources.direct') ?></div>
                             </td>
                             <td class="table-cell text-align-right"><?= $views ?></td>
                         </tr>


### PR DESCRIPTION
This pull request refactors how visitor source detection is handled and improves the accuracy and security of source tracking in statistics. The main changes include introducing a new `Visitor::getSource()` method for determining the source of a visit, updating statistics tracking to use this method, and enhancing output escaping for source display in the statistics panel.

**Visitor source detection and tracking:**

* Added a new static method `Visitor::getSource(Request $request)` in `Visitor.php` to centralize and improve logic for determining the visitor's source, returning an empty string for direct visits, `null` for invalid or same-host sources, and the source host otherwise.
* Updated `Statistics::trackVisit()` to use `Visitor::getSource()` for source tracking, ensuring consistent and accurate detection of external referrers.

**Security and display improvements:**

* Escaped the `$source` value in the statistics panel (`statistics/index.php`) before outputting, preventing potential XSS vulnerabilities and ensuring safe display of source names.

**Dependency updates:**

* Added `use Formwork\Utils\Uri` to `Visitor.php` to support host extraction from referer URLs.