### PR TITLE
Improve updates integrity checks

### DIFF
--- a/formwork/config/system.yaml
+++ b/formwork/config/system.yaml
@@ -152,6 +152,7 @@ updates:
     time: 900
     force: false
     tempFile: '${%ROOT_PATH%}/.formwork-update.zip'
+    lockTimeout: 300
     preferDistAssets: true
     backupBefore: true
     cleanupAfterInstall: true

--- a/formwork/src/Http/Client.php
+++ b/formwork/src/Http/Client.php
@@ -123,16 +123,27 @@ class Client
         $connection = $this->connect($uri, $options);
 
         try {
-            if (($destination = @fopen($file, 'w')) === false) {
-                throw new RuntimeException(sprintf('Cannot open destination "%s" for writing', $file));
+            $temporaryFile = FileSystem::createTemporaryFile(dirname($file));
+
+            if (($destination = @fopen($temporaryFile, 'w')) === false) {
+                throw new RuntimeException(sprintf('Cannot open temporary file "%s" for writing', $temporaryFile));
             }
 
             try {
-                if (@stream_copy_to_stream($connection['handle'], $destination, $connection['length'] ?? -1) === false) {
-                    throw new RuntimeException(sprintf('Cannot copy stream contents from "%s" to "%s"', $uri, $file));
+                if (($bytesCopied = @stream_copy_to_stream($connection['handle'], $destination, $connection['length'] ?? -1)) === false) {
+                    throw new RuntimeException(sprintf('Cannot copy stream contents from "%s" to temporary file "%s"', $uri, $temporaryFile));
+                }
+
+                if ($connection['length'] !== null && $bytesCopied !== $connection['length']) {
+                    throw new RuntimeException(sprintf('Incomplete download from "%s": expected %d bytes, got %d', $uri, $connection['length'], $bytesCopied));
+                }
+
+                if (!@rename($temporaryFile, $file)) {
+                    throw new RuntimeException(sprintf('Cannot move temporary file "%s" to destination "%s"', $temporaryFile, $file));
                 }
             } finally {
                 @fclose($destination);
+                @unlink($temporaryFile);
             }
         } finally {
             @fclose($connection['handle']);

--- a/formwork/src/Updater/Updater.php
+++ b/formwork/src/Updater/Updater.php
@@ -3,6 +3,7 @@
 namespace Formwork\Updater;
 
 use DateTimeImmutable;
+use Formwork\Backup\Utils\ZipErrors;
 use Formwork\Cms\App;
 use Formwork\Http\Client;
 use Formwork\Log\Registry;
@@ -32,7 +33,7 @@ final class Updater
     /**
      * Updates registry default data
      *
-     * @var array{lastCheck: ?int, lastUpdate: ?int, currentRelease: string, releaseArchiveEtag: ?string, release: ?array{name: string, tag: string, date: int, archive: string}, upToDate: bool, preferDistAssets: bool}
+     * @var array{lastCheck: ?int, lastUpdate: ?int, currentRelease: string, releaseArchiveEtag: ?string, release: ?array{name: string, tag: string, date: int, archive: string, checksum: ?string}, upToDate: bool, preferDistAssets: bool}
      */
     private array $registryDefaults = [
         'lastCheck'          => null,
@@ -52,7 +53,7 @@ final class Updater
     /**
      * Array containing release information
      *
-     * @var array{name: string, tag: string, date: int, archive: string}
+     * @var array{name: string, tag: string, date: int, archive: string, checksum: ?string}
      */
     private array $release;
 
@@ -138,67 +139,35 @@ final class Updater
      */
     public function update(?bool $force = null, ?bool $preferDistAssets = null, ?bool $cleanupAfterInstall = null): ?bool
     {
+        $cleanupAfterInstall ??= $this->options['cleanupAfterInstall'];
+
         $this->checkUpdates($force, $preferDistAssets);
 
         if ($this->registry->get('upToDate')) {
             return null;
         }
 
-        $this->client->download($this->release['archive'], $this->options['tempFile']);
+        $this->acquireLock();
 
-        if (!FileSystem::exists($this->options['tempFile'])) {
-            throw new RuntimeException('Cannot update Formwork, archive not downloaded');
-        }
+        try {
+            $installedFiles = $this->downloadAndExtractRelease();
 
-        $zipArchive = new ZipArchive();
-        $zipArchive->open($this->options['tempFile'], ZipArchive::RDONLY);
-        $installedFiles = [];
-        $counter = count($zipArchive);
-
-        for ($i = 0; $i < $counter; $i++) {
-            $filename = $zipArchive->getNameIndex($i);
-
-            if ($filename === false) {
-                throw new RuntimeException('Cannot get filename from zip archive');
-            }
-
-            $root = ROOT_PATH;
-            $destination = FileSystem::joinPaths($root, $filename);
-            $destinationDirectory = dirname($destination);
-
-            if ($this->isCopiable($filename)) {
-                if (!FileSystem::exists($destinationDirectory)) {
-                    FileSystem::createDirectory($destinationDirectory);
+            if ($cleanupAfterInstall) {
+                $deletableFiles = $this->findDeletableFiles($installedFiles);
+                foreach ($deletableFiles as $deletableFile) {
+                    FileSystem::delete($deletableFile);
                 }
-                if (!Str::endsWith($destination, DIRECTORY_SEPARATOR)) {
-                    if ($zipArchive->extractTo($root, $filename) === false) {
-                        throw new RuntimeException(sprintf('Cannot extract "%s" from zip archive', $filename));
-                    }
-                    if ($zipArchive->getExternalAttributesIndex($i, $opsys, $perms) && $opsys === ZipArchive::OPSYS_UNIX) {
-                        @chmod($destination, ($perms >> 16) & 0o777);
-                    }
-                }
-                $installedFiles[] = $destination;
             }
+
+            $this->registry->set('lastUpdate', time());
+            $this->registry->set('currentRelease', $this->release['tag']);
+            $this->registry->set('releaseArchiveEtag', $this->getReleaseArchiveEtag());
+
+            $this->registry->set('upToDate', true);
+            $this->registry->save();
+        } finally {
+            $this->releaseLock();
         }
-
-        $zipArchive->close();
-
-        FileSystem::delete($this->options['tempFile']);
-
-        if ($cleanupAfterInstall ?? $this->options['cleanupAfterInstall']) {
-            $deletableFiles = $this->findDeletableFiles($installedFiles);
-            foreach ($deletableFiles as $deletableFile) {
-                FileSystem::delete($deletableFile);
-            }
-        }
-
-        $this->registry->set('lastUpdate', time());
-        $this->registry->set('currentRelease', $this->release['tag']);
-        $this->registry->set('releaseArchiveEtag', $this->getReleaseArchiveEtag());
-
-        $this->registry->set('upToDate', true);
-        $this->registry->save();
 
         return true;
     }
@@ -206,11 +175,140 @@ final class Updater
     /**
      * Get latest release data
      *
-     * @return ?array{name: string, tag: string, date: int, archive: string}
+     * @return ?array{name: string, tag: string, date: int, archive: string, checksum: ?string}
      */
     public function latestRelease(): ?array
     {
         return $this->registry->get('release');
+    }
+
+    /**
+     * Download the release archive and extract it into ROOT_PATH, always cleaning up the
+     * temporary archive file, even if the download or the extraction fails
+     *
+     * @return list<string>
+     */
+    private function downloadAndExtractRelease(): array
+    {
+        try {
+            $this->client->download($this->release['archive'], $this->options['tempFile']);
+
+            if (!FileSystem::exists($this->options['tempFile'])) {
+                throw new RuntimeException('Cannot download update archive');
+            }
+
+            $this->verifyArchiveChecksum($this->options['tempFile']);
+
+            return $this->extractRelease($this->options['tempFile']);
+        } finally {
+            if (FileSystem::exists($this->options['tempFile'])) {
+                FileSystem::delete($this->options['tempFile']);
+            }
+        }
+    }
+
+    /**
+     * Verify the downloaded archive matches the sha256 checksum published for the release
+     * asset, if any is available. The auto-generated GitHub source archive has no checksum
+     */
+    private function verifyArchiveChecksum(string $archiveFile): void
+    {
+        if ($this->release['checksum'] === null) {
+            return;
+        }
+
+        $hash = hash_file('sha256', $archiveFile);
+
+        if ($hash === false || !hash_equals($this->release['checksum'], $hash)) {
+            throw new RuntimeException('Downloaded archive does not match the expected checksum');
+        }
+    }
+
+    /**
+     * Extract a release archive into ROOT_PATH and return the list of installed files
+     *
+     * @return list<string>
+     */
+    private function extractRelease(string $archiveFile): array
+    {
+        $zipArchive = new ZipArchive();
+
+        $status = $zipArchive->open($archiveFile, ZipArchive::RDONLY);
+
+        if ($status !== true) {
+            /** @var key-of<ZipErrors::ERROR_MESSAGES> $status */
+            throw new RuntimeException(sprintf('Cannot open update archive: %s', ZipErrors::ERROR_MESSAGES[$status]));
+        }
+
+        try {
+            $installedFiles = [];
+            $counter = count($zipArchive);
+
+            for ($i = 0; $i < $counter; $i++) {
+                $filename = $zipArchive->getNameIndex($i);
+
+                if ($filename === false) {
+                    throw new RuntimeException('Cannot get filename from zip archive');
+                }
+
+                $root = ROOT_PATH;
+                $destination = FileSystem::joinPaths($root, $filename);
+
+                $destinationDirectory = dirname($destination);
+
+                if ($this->isCopiable($filename)) {
+                    if (!FileSystem::exists($destinationDirectory)) {
+                        FileSystem::createDirectory($destinationDirectory);
+                    }
+                    if (!Str::endsWith($destination, DIRECTORY_SEPARATOR)) {
+                        if ($zipArchive->extractTo($root, $filename) === false) {
+                            throw new RuntimeException(sprintf('Cannot extract "%s" from zip archive', $filename));
+                        }
+                        if ($zipArchive->getExternalAttributesIndex($i, $opsys, $perms) && $opsys === ZipArchive::OPSYS_UNIX) {
+                            @chmod($destination, ($perms >> 16) & 0o777);
+                        }
+                    }
+                    $installedFiles[] = $destination;
+                }
+            }
+
+            return $installedFiles;
+        } finally {
+            $zipArchive->close();
+        }
+    }
+
+    /**
+     * Acquire an exclusive lock preventing concurrent update runs. A stale lock
+     * (older than the configured timeout) is considered abandoned and reused
+     */
+    private function acquireLock(): void
+    {
+        $lockFile = $this->getLockFile();
+
+        if (FileSystem::exists($lockFile) && (time() - FileSystem::lastModifiedTime($lockFile)) < $this->options['lockTimeout']) {
+            throw new RuntimeException('An update is already in progress');
+        }
+
+        FileSystem::write($lockFile, (string) time());
+    }
+
+    /**
+     * Release the update lock
+     */
+    private function releaseLock(): void
+    {
+        if (FileSystem::exists($lockFile = $this->getLockFile())) {
+            FileSystem::delete($lockFile);
+        }
+    }
+
+    /**
+     * Get the update lock file path
+     */
+    private function getLockFile(): string
+    {
+        return $this->options['tempFile'] . '.lock';
     }
 
     /**
@@ -231,10 +329,11 @@ final class Updater
         }
 
         $this->release = [
-            'name'    => $data['name'],
-            'tag'     => $data['tag_name'],
-            'date'    => $releaseDate->getTimestamp(),
-            'archive' => $data['zipball_url'],
+            'name'     => $data['name'],
+            'tag'      => $data['tag_name'],
+            'date'     => $releaseDate->getTimestamp(),
+            'archive'  => $data['zipball_url'],
+            'checksum' => null,
         ];
 
         if ($preferDistAssets && !empty($data['assets'])) {
@@ -243,8 +342,21 @@ final class Updater
 
             if ($key !== false) {
                 $this->release['archive'] = $data['assets'][$key]['browser_download_url'];
+                $this->release['checksum'] = $this->parseSha256Checksum($data['assets'][$key]['digest'] ?? null);
             }
         }
+    }
+
+    /**
+     * Parse a GitHub asset "checksum" field (e.g. "sha256:abc123...") into its hex checksum
+     */
+    private function parseSha256Checksum(?string $checksum): ?string
+    {
+        if ($checksum === null || !Str::startsWith($checksum, 'sha256:')) {
+            return null;
+        }
+
+        return Str::removeStart($checksum, 'sha256:');
     }
 
     /**

--- a/formwork/src/Updater/Updater.php
+++ b/formwork/src/Updater/Updater.php
@@ -9,6 +9,7 @@ use Formwork\Http\Client;
 use Formwork\Log\Registry;
 use Formwork\Parsers\Json;
 use Formwork\Utils\FileSystem;
+use Formwork\Utils\Path;
 use Formwork\Utils\Str;
 use RuntimeException;
 use ZipArchive;
@@ -252,7 +253,12 @@ final class Updater
                 }
 
                 $root = ROOT_PATH;
-                $destination = FileSystem::joinPaths($root, $filename);
+                $destination = Path::resolve($filename, $root, DIRECTORY_SEPARATOR);
+
+                if (!Path::isRelativeTo($destination, $root)) {
+                    throw new RuntimeException(sprintf('Cannot extract "%s" from zip archive: invalid destination', $filename));
+                }
+
 
                 $destinationDirectory = dirname($destination);
 

--- a/formwork/src/Updater/Updater.php
+++ b/formwork/src/Updater/Updater.php
@@ -259,7 +259,6 @@ final class Updater
                     throw new RuntimeException(sprintf('Cannot extract "%s" from zip archive: invalid destination', $filename));
                 }
 
-
                 $destinationDirectory = dirname($destination);
 
                 if ($this->isCopiable($filename)) {


### PR DESCRIPTION
This pull request significantly improves the reliability and security of the update process. The most important changes are the addition of checksum verification for downloaded update archives, better handling of temporary files during downloads, and the introduction of a locking mechanism to prevent concurrent updates. These changes help ensure that updates are applied safely and only once, and that downloaded files are not corrupted or tampered with.

**Update Process Security and Integrity:**

* Added SHA256 checksum verification for downloaded release archives to ensure file integrity before extraction. The checksum is parsed from GitHub asset metadata if available, and the update will abort if the checksum does not match. [[1]](diffhunk://#diff-5292dfadba397776d7cf3959eb28fa0666d81eb146d082848821da26601631e6R144-R237) [[2]](diffhunk://#diff-5292dfadba397776d7cf3959eb28fa0666d81eb146d082848821da26601631e6R333) [[3]](diffhunk://#diff-5292dfadba397776d7cf3959eb28fa0666d81eb146d082848821da26601631e6R342-R358)
* Modified the update process to always use a temporary file for downloads and only move it to the target location after a successful and complete download, reducing the risk of partial or corrupted files being used.

**Concurrency and Reliability Improvements:**

* Introduced an exclusive lock file mechanism to prevent concurrent update runs, with a configurable timeout for handling stale locks. This prevents multiple updates from running at the same time, which could corrupt the installation. [[1]](diffhunk://#diff-5292dfadba397776d7cf3959eb28fa0666d81eb146d082848821da26601631e6R144-R237) [[2]](diffhunk://#diff-5292dfadba397776d7cf3959eb28fa0666d81eb146d082848821da26601631e6R268-R304) [[3]](diffhunk://#diff-71266f382c699109f4896d337ad2621d64f601e47db3291fcdcbb2b9f673c49fR152)

**Data Structure and Metadata Enhancements:**

* Extended the release metadata structures to include an optional `checksum` field, updating all relevant type annotations and logic to handle this new field. [[1]](diffhunk://#diff-5292dfadba397776d7cf3959eb28fa0666d81eb146d082848821da26601631e6L35-R36) [[2]](diffhunk://#diff-5292dfadba397776d7cf3959eb28fa0666d81eb146d082848821da26601631e6L54-R55)
* Added a utility import for better error messaging when handling ZIP archive extraction failures.