### PR TITLE
Validate request host in `Request::host()`

### DIFF
--- a/formwork/src/Http/Request.php
+++ b/formwork/src/Http/Request.php
@@ -8,6 +8,7 @@ use Formwork\Utils\Path;
 use Formwork\Utils\Str;
 use Formwork\Utils\Uri;
 use InvalidArgumentException;
+use UnexpectedValueException;
 
 class Request
 {
@@ -192,16 +193,31 @@ class Request
 
     /**
      * Get the request host name
+     *
+     * @throws UnexpectedValueException If the host is invalid
      */
     public function host(): ?string
     {
-        $host = $this->headers->get('Host');
+        $host = $this->headers->get('Host')
+            ?? $this->server->get('SERVER_NAME')
+            ?? $this->server->get('SERVER_ADDR');
 
         if ($this->isFromTrustedProxy()) {
-            return $this->getForwardedDirective('host')[0] ?? $host;
+            $host = $this->getForwardedDirective('host')[0] ?? $host;
         }
 
-        return $host;
+        // Normalize host by converting to lowercase, trimming whitespace, and removing port if present
+        $host = (string) preg_replace('/:\d+$/', '', strtolower(trim((string) $host)));
+
+        if (filter_var($host = trim($host, '[]'), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+            return "[$host]";
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) !== false) {
+            return $host;
+        }
+
+        throw new UnexpectedValueException(sprintf('Invalid host: %s', $host));
     }
 
     /**

--- a/formwork/src/Http/Request.php
+++ b/formwork/src/Http/Request.php
@@ -206,18 +206,29 @@ class Request
             $host = $this->getForwardedDirective('host')[0] ?? $host;
         }
 
-        // Normalize host by converting to lowercase, trimming whitespace, and removing port if present
-        $host = (string) preg_replace('/:\d+$/', '', strtolower(trim((string) $host)));
-
-        if (filter_var($host = trim($host, '[]'), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
-            return "[$host]";
+        if ($host === null) {
+            return null;
         }
+
+        // Normalize host by converting to lowercase and trimming whitespace
+        $host = strtolower(trim($host));
+
+        if (filter_var(
+            $ipv6 = (string) preg_replace('/^\[|\](:\d+)?$/', '', $host),
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_IPV6
+        ) !== false) {
+            return "[$ipv6]";
+        }
+
+        // Remove port number
+        $host = (string) preg_replace('/:\d+$/', '', $host);
 
         if (filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) !== false) {
             return $host;
         }
 
-        throw new UnexpectedValueException(sprintf('Invalid host: %s', $host));
+        throw new UnexpectedValueException(sprintf('Invalid host: "%s"', $host));
     }
 
     /**

--- a/formwork/src/Http/Utils/Visitor.php
+++ b/formwork/src/Http/Utils/Visitor.php
@@ -8,6 +8,7 @@ use Formwork\Traits\StaticClass;
 use Formwork\Utils\Uri;
 use InvalidArgumentException;
 use Jaybizzle\CrawlerDetect\CrawlerDetect;
+use UnexpectedValueException;
 
 final class Visitor
 {
@@ -80,7 +81,12 @@ final class Visitor
             return null;
         }
 
-        $host = $request->host();
+        try {
+            $host = $request->host();
+        } catch (UnexpectedValueException) {
+            return null;
+        }
+
         if (
             $host === null || filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false
             || $source === $host // Source and host are already lowercased by `Uri::host()` and `Request::host()`

--- a/formwork/src/Http/Utils/Visitor.php
+++ b/formwork/src/Http/Utils/Visitor.php
@@ -5,7 +5,6 @@ namespace Formwork\Http\Utils;
 use Detection\MobileDetect;
 use Formwork\Http\Request;
 use Formwork\Traits\StaticClass;
-use Formwork\Utils\Str;
 use Formwork\Utils\Uri;
 use InvalidArgumentException;
 use Jaybizzle\CrawlerDetect\CrawlerDetect;
@@ -81,22 +80,10 @@ final class Visitor
             return null;
         }
 
-        $hostHeader = $request->host();
-        if ($hostHeader === null || Str::contains($hostHeader, '://')) {
-            return null;
-        }
-
-        try {
-            // Host header may contain a port number, so we need to extract the host part only
-            // adding '//' to tell the parser the input is an authority component
-            $host = Uri::host('//' . $hostHeader);
-        } catch (InvalidArgumentException) {
-            return null;
-        }
-
+        $host = $request->host();
         if (
             $host === null || filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false
-            || $source === $host // Source and host are lowercased by `Uri::host()`
+            || $source === $host // Source and host are already lowercased by `Uri::host()` and `Request::host()`
         ) {
             return null;
         }

--- a/formwork/src/Services/Loaders/ConfigServiceLoader.php
+++ b/formwork/src/Services/Loaders/ConfigServiceLoader.php
@@ -8,6 +8,7 @@ use Formwork\Parsers\Php;
 use Formwork\Services\Container;
 use Formwork\Services\ServiceLoaderInterface;
 use Formwork\Utils\FileSystem;
+use UnexpectedValueException;
 
 final class ConfigServiceLoader implements ServiceLoaderInterface
 {
@@ -17,18 +18,9 @@ final class ConfigServiceLoader implements ServiceLoaderInterface
 
     public function load(Container $container): Config
     {
-        $cachePath = ROOT_PATH . '/cache/config/';
-        $cacheFile = FileSystem::joinPaths($cachePath, "config.{$this->request->host()}.php");
+        $cacheFile = $this->getConfigCacheFile();
 
-        if (!FileSystem::isDirectory($cachePath, assertExists: false)) {
-            FileSystem::createDirectory($cachePath, recursive: true);
-        }
-
-        if (
-            FileSystem::exists($cacheFile)
-            && !FileSystem::directoryModifiedSince(ROOT_PATH . '/site/config/', FileSystem::lastModifiedTime($cacheFile))
-            && !FileSystem::directoryModifiedSince(SYSTEM_PATH . '/config/', FileSystem::lastModifiedTime($cacheFile))
-        ) {
+        if ($this->validateConfigCacheFile($cacheFile)) {
             $config = new Config(require $cacheFile, resolved: true);
         } else {
             $config = new Config();
@@ -45,7 +37,7 @@ final class ConfigServiceLoader implements ServiceLoaderInterface
                 '%SYSTEM_PATH%' => SYSTEM_PATH,
             ]);
 
-            if (PHP_SAPI !== 'cli') {
+            if (PHP_SAPI !== 'cli' && $cacheFile !== null) {
                 Php::encodeToFile($config->toArray(), $cacheFile);
             }
         }
@@ -56,5 +48,31 @@ final class ConfigServiceLoader implements ServiceLoaderInterface
         $this->request->session()->setDuration($config->get('system.session.duration'));
 
         return $config;
+    }
+
+    private function getConfigCacheFile(): ?string
+    {
+        try {
+            $host = $this->request->host();
+        } catch (UnexpectedValueException) {
+            return null;
+        }
+
+        $cachePath = ROOT_PATH . '/cache/config/';
+        $cacheFile = FileSystem::joinPaths($cachePath, "config.{$host}.php");
+
+        if (!FileSystem::isDirectory($cachePath, assertExists: false)) {
+            FileSystem::createDirectory($cachePath, recursive: true);
+        }
+
+        return $cacheFile;
+    }
+
+    private function validateConfigCacheFile(?string $cacheFile): bool
+    {
+        return $cacheFile !== null
+            && FileSystem::exists($cacheFile)
+            && !FileSystem::directoryModifiedSince(ROOT_PATH . '/site/config/', FileSystem::lastModifiedTime($cacheFile))
+            && !FileSystem::directoryModifiedSince(SYSTEM_PATH . '/config/', FileSystem::lastModifiedTime($cacheFile));
     }
 }


### PR DESCRIPTION
This pull request improves the handling and validation of HTTP host headers in the `Request` class and simplifies host extraction logic in the `Visitor` utility. The main focus is on strengthening host validation, normalizing host values, and removing redundant code.

**Host header handling and validation:**

* Enhanced the `host()` method in `Request` to:
  - Retrieve the host from multiple sources (`Host` header, `SERVER_NAME`, `SERVER_ADDR`).
  - Normalize the host by lowercasing, trimming, and removing any port number.
  - Validate the host as either a valid IPv6 address or a domain name, throwing an `UnexpectedValueException` if invalid.
* Added `UnexpectedValueException` import to support the new validation logic.

**Code simplification and cleanup:**

* Refactored `Visitor::getSource()` to use the already-normalized and validated host from `Request::host()`, removing redundant parsing and string manipulation.
* Removed unnecessary import of `Str` utility from `Visitor.php` since it is no longer used.