### PR TITLE
Add the possibility to specify services to be resolved with `#[Service]` attributes

### DIFF
--- a/formwork/src/Services/Attributes/Service.php
+++ b/formwork/src/Services/Attributes/Service.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Formwork\Services\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Service
+{
+    public function __construct(
+        public readonly string $name,
+    ) {}
+}

--- a/formwork/src/Services/Container.php
+++ b/formwork/src/Services/Container.php
@@ -3,6 +3,7 @@
 namespace Formwork\Services;
 
 use Closure;
+use Formwork\Services\Attributes\Service;
 use Formwork\Services\Exceptions\ContainerException;
 use Formwork\Services\Exceptions\ServiceNotFoundException;
 use Formwork\Services\Exceptions\ServiceResolutionException;
@@ -250,6 +251,15 @@ class Container implements ContainerInterface
                 }
 
                 $arguments[] = $parameters[$name];
+                continue;
+            }
+
+            // Resolve specific service if defined with the #[Service] attribute
+            if (($serviceAttributes = $reflectionParameter->getAttributes(Service::class)) !== []) {
+                if (count($serviceAttributes) > 1) {
+                    throw new ContainerException(sprintf('Multiple #[Service] attributes found for argument $%s', $name));
+                }
+                $arguments[] = $this->get($serviceAttributes[0]->newInstance()->name);
                 continue;
             }
 


### PR DESCRIPTION
This pull request introduces support for resolving specific services in the dependency injection container using a new `#[Service]` attribute. This allows developers to explicitly specify which service should be injected into a parameter, improving flexibility and control over dependency resolution.

**Attribute-based service resolution:**

* Added a new `Service` attribute in `formwork/src/Services/Attributes/Service.php` to allow explicit service name injection via parameter attributes.
* Updated `formwork/src/Services/Container.php` to detect and resolve parameters marked with the `#[Service]` attribute in the `buildArguments` method, including error handling for multiple attribute usage. [[1]](diffhunk://#diff-00f523621f516620148576ff70c3fcebad04a6849d09682d6886165e81764a18R6) [[2]](diffhunk://#diff-00f523621f516620148576ff70c3fcebad04a6849d09682d6886165e81764a18R257-R265)