### PR TITLE
Implement generics in data classes

### DIFF
--- a/formwork/phpstan.neon
+++ b/formwork/phpstan.neon
@@ -16,7 +16,7 @@ parameters:
 	scanFiles:
 		- ../index.php
 	ignoreErrors:
-		- '#^Call to an undefined method Formwork\\Data\\CollectionDataProxy\:\:#'
+		- '#^Call to an undefined method Formwork\\Data\\CollectionDataProxy#'
 		- '#^Call to an undefined method Formwork\\Fields\\Field\:\:#'
 		- '#^Call to an undefined method Formwork\\Pages\\Page\:\:#'
 		- '#^Call to an undefined method Formwork\\Cms\\Site\:\:#'

--- a/formwork/src/Assets/AssetCollection.php
+++ b/formwork/src/Assets/AssetCollection.php
@@ -5,6 +5,9 @@ namespace Formwork\Assets;
 use Formwork\Data\AbstractCollection;
 use Formwork\Utils\Str;
 
+/**
+ * @extends AbstractCollection<Asset>
+ */
 class AssetCollection extends AbstractCollection
 {
     protected bool $associative = true;

--- a/formwork/src/Assets/Assets.php
+++ b/formwork/src/Assets/Assets.php
@@ -76,6 +76,7 @@ class Assets
             ['path' => $path, 'uri' => $uri] = $this->resolve($key);
             $this->collection->set($key, new Asset($path, $uri));
         }
+        /** @var Asset */
         return $this->collection->get($key);
     }
 

--- a/formwork/src/Controllers/PageController.php
+++ b/formwork/src/Controllers/PageController.php
@@ -94,8 +94,10 @@ final class PageController extends AbstractController
                 $upperLevel = $this->config->get('system.pages.index');
             }
 
-            if ((($parent = $this->site->findPage($upperLevel)) !== null) && $parent->files()->has($filename)) {
-                $file = $parent->files()->get($filename);
+            if (
+                ($parent = $this->site->findPage($upperLevel)) !== null
+                && ($file = $parent->files()->get($filename)) !== null
+            ) {
                 return new FileResponse($file->path(), autoEtag: true, autoLastModified: true);
             }
         }

--- a/formwork/src/Data/AbstractCollection.php
+++ b/formwork/src/Data/AbstractCollection.php
@@ -20,7 +20,6 @@ use LogicException;
  */
 abstract class AbstractCollection implements Arrayable, Countable, Iterator
 {
-    /** @use DataArrayable<array<int|string, T>> */
     use DataArrayable;
 
     /** @use DataCountableIterator<array<int|string, T>> */

--- a/formwork/src/Data/AbstractCollection.php
+++ b/formwork/src/Data/AbstractCollection.php
@@ -14,23 +14,32 @@ use Iterator;
 use LogicException;
 
 /**
- * @implements Iterator<int|string,mixed>
+ * @implements Iterator<int|string, T>
+ *
+ * @template T
  */
 abstract class AbstractCollection implements Arrayable, Countable, Iterator
 {
+    /** @use DataArrayable<array<int|string, T>> */
     use DataArrayable;
+
+    /** @use DataCountableIterator<array<int|string, T>> */
     use DataCountableIterator;
+
+    /** @use DataMultipleGetter<array<string, T>> */
     use DataMultipleGetter {
         has as protected baseHas;
         get as protected baseGet;
     }
+
+    /** @use DataMultipleSetter<array<string, T>> */
     use DataMultipleSetter {
         set as protected baseSet;
         remove as protected baseRemove;
     }
 
     /**
-     * @var array<int|string, mixed>
+     * @var array<int|string, T>
      */
     protected array $data = [];
 
@@ -50,7 +59,7 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
     protected bool $mutable = false;
 
     /**
-     * @param array<int|string, mixed> $data
+     * @param array<int|string, T> $data
      *
      * @throws LogicException If collection associativeness mismatches data or if typed collection is created from data of different types
      */
@@ -113,6 +122,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
     /**
      * Return the collection item at the specified index
+     *
+     * @return T|null
      */
     public function nth(int $index): mixed
     {
@@ -123,6 +134,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
      * Return the collection item at the specified index
      *
      * A negative index starts from the last item
+     *
+     * @return T|null
      */
     public function at(int $index): mixed
     {
@@ -131,6 +144,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
     /**
      * Return first collection item
+     *
+     * @return T|null
      */
     public function first(): mixed
     {
@@ -139,6 +154,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
     /**
      * Return last collection item
+     *
+     * @return T|null
      */
     public function last(): mixed
     {
@@ -147,6 +164,10 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
     /**
      * Return a random item or a given default value if the collection is empty
+     *
+     * @param T|null $default
+     *
+     * @return T|null
      */
     public function random(mixed $default = null): mixed
     {
@@ -198,7 +219,7 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
     /**
      * Get the values of all items
      *
-     * @return list<mixed>
+     * @return list<T>
      */
     public function values(): array
     {
@@ -231,6 +252,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
     /**
      * Find the first item in the collection for which the given callback returns `true`
+     *
+     * @return T|null
      */
     public function find(callable $callback): mixed
     {
@@ -398,7 +421,7 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
     /**
      * Group collection items using a callback
      *
-     * @return array<mixed>
+     * @return array<string, list<T>>
      */
     public function group(callable $callback): array
     {
@@ -410,7 +433,7 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
      *
      * Typed collections should implement their own version of this method, optimised for their data type
      *
-     * @return array<mixed>
+     * @return array<T>
      */
     public function extract(string $key, mixed $default = null): array
     {
@@ -423,7 +446,7 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
      *
      * This method is similar to `extract()` but does not preserve keys
      *
-     * @return array<mixed>
+     * @return list<T>
      */
     public function pluck(string $key, mixed $default = null): array
     {
@@ -500,7 +523,9 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
     /**
      * Group the collection using the given key from each item
      *
-     * @return array<string, mixed>
+     * @param T|null $default
+     *
+     * @return array<string, list<T|null>>
      */
     public function groupBy(string $key, mixed $default = null): array
     {
@@ -524,6 +549,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
      * Return a copy of the collection with the given values
      *
      * If a value is already in the collection, it will not be added
+     *
+     * @param T ...$values
      */
     public function with(mixed ...$values): static
     {
@@ -540,6 +567,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
     /**
      * Return a copy of the collection without the given values
+     *
+     * @param T ...$values
      */
     public function without(mixed ...$values): static
     {
@@ -556,6 +585,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
      * Return a special object on which property accesses and method calls
      * are redirected to every item of the collection and the results
      * are collected again
+     *
+     * @return CollectionDataProxy<T>
      */
     public function everyItem(): CollectionDataProxy
     {
@@ -564,6 +595,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
     /**
      * Return a copy of the collection with the union of the values of the given collections
+     *
+     * @param self<T> ...$collections
      */
     public function union(self ...$collections): static
     {
@@ -578,6 +611,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
     /**
      * Return a copy of the collection with the intersection of the values of the given collections
+     *
+     * @param self<T> ...$collections
      */
     public function intersection(self ...$collections): static
     {
@@ -592,6 +627,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
     /**
      * Return a copy of the collection with the values of the given collections removed
+     *
+     * @param self<T> ...$collections
      */
     public function difference(self ...$collections): static
     {
@@ -606,6 +643,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
     /**
      * Add the given value to the collection
+     *
+     * @param T $value
      *
      * @throws LogicException If the collection is not mutable, associative, or if value type is invalid
      */
@@ -625,7 +664,7 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
     /**
      * Add multiple values to the collection
      *
-     * @param list<mixed> $values
+     * @param list<T> $values
      */
     public function addMultiple(array $values): void
     {
@@ -636,6 +675,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
     /**
      * Remove all occurrences of the given value from the collection
+     *
+     * @param T $value
      *
      * @throws LogicException If the collection is not mutable or is associative
      */
@@ -651,7 +692,7 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
     /**
      * Remove all occurrences of the given values from the collection
      *
-     * @param list<mixed> $values
+     * @param list<T> $values
      */
     public function pullMultiple(array $values): void
     {
@@ -685,7 +726,15 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
      *
      * A default value is returned if the item is not present
      *
+     * @template TKey of string
+     * @template TDefault
+     *
+     * @param TKey     $key
+     * @param TDefault $default
+     *
      * @throws LogicException If the collection is not associative
+     *
+     * @return T|TDefault
      */
     public function get(string $key, mixed $default = null): mixed
     {
@@ -697,6 +746,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
     /**
      * Set a collection item
+     *
+     * @param T $value
      *
      * @throws LogicException If the collection is not associative, not mutable, or if value type is invalid
      */
@@ -712,6 +763,7 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
         if ($this->dataType() !== 'array') {
             // Avoid dot notation traversal by setting the key before
+            // @phpstan-ignore assign.propertyType
             $this->data[$key] = null;
         }
 
@@ -733,6 +785,8 @@ abstract class AbstractCollection implements Arrayable, Countable, Iterator
 
     /**
      * Merge another collection into the current
+     *
+     * @param self<T> ...$collection
      *
      * @throws LogicException If the collection is not mutable, if associativeness differs, or if data types differ
      */

--- a/formwork/src/Data/Collection.php
+++ b/formwork/src/Data/Collection.php
@@ -5,6 +5,11 @@ namespace Formwork\Data;
 use Formwork\Utils\Arr;
 use LogicException;
 
+/**
+ * @template T
+ *
+ * @extends AbstractCollection<T>
+ */
 final class Collection extends AbstractCollection
 {
     /**

--- a/formwork/src/Data/CollectionDataProxy.php
+++ b/formwork/src/Data/CollectionDataProxy.php
@@ -2,12 +2,21 @@
 
 namespace Formwork\Data;
 
+/**
+ * @template T
+ */
 final class CollectionDataProxy
 {
+    /**
+     * @param AbstractCollection<T> $collection
+     */
     public function __construct(
         private AbstractCollection $collection,
     ) {}
 
+    /**
+     * @return Collection<mixed>
+     */
     public function __get(string $name): Collection
     {
         $result = [];
@@ -28,6 +37,8 @@ final class CollectionDataProxy
 
     /**
      * @param list<mixed> $arguments
+     *
+     * @return Collection<mixed>
      */
     public function __call(string $name, array $arguments): Collection
     {

--- a/formwork/src/Data/Contracts/Paginable.php
+++ b/formwork/src/Data/Contracts/Paginable.php
@@ -5,15 +5,22 @@ namespace Formwork\Data\Contracts;
 use Formwork\Data\AbstractCollection;
 use Formwork\Data\Pagination;
 
+/**
+ * @template T
+ */
 interface Paginable
 {
     /**
      * Return the pagination for the collection
+     *
+     * @return Pagination<T>
      */
     public function pagination(): Pagination;
 
     /**
      * Paginate the collection
+     *
+     * @return AbstractCollection<T>
      */
     public function paginate(int $length, int $currentPage): AbstractCollection;
 }

--- a/formwork/src/Data/Pagination.php
+++ b/formwork/src/Data/Pagination.php
@@ -2,6 +2,9 @@
 
 namespace Formwork\Data;
 
+/**
+ * @template T
+ */
 class Pagination
 {
     /**
@@ -20,7 +23,8 @@ class Pagination
     protected int $currentPage = 1;
 
     /**
-     * @param int $length Number of items in each pagination page
+     * @param AbstractCollection<T> $collection Collection to paginate
+     * @param int                   $length     Number of items in each pagination page
      */
     public function __construct(
         AbstractCollection $collection,

--- a/formwork/src/Data/Traits/DataArrayable.php
+++ b/formwork/src/Data/Traits/DataArrayable.php
@@ -6,14 +6,19 @@ use Formwork\Data\Contracts\Arrayable;
 
 /**
  * @phpstan-require-implements Arrayable
+ *
+ * @template TData of array<int|string, mixed> = array<string, mixed>
  */
 trait DataArrayable
 {
     /**
-     * @var array<mixed>
+     * @var TData
      */
     protected array $data = [];
 
+    /**
+     * @return TData
+     */
     public function toArray(): array
     {
         return $this->data;

--- a/formwork/src/Data/Traits/DataArrayable.php
+++ b/formwork/src/Data/Traits/DataArrayable.php
@@ -6,18 +6,16 @@ use Formwork\Data\Contracts\Arrayable;
 
 /**
  * @phpstan-require-implements Arrayable
- *
- * @template TData of array<int|string, mixed> = array<string, mixed>
  */
 trait DataArrayable
 {
     /**
-     * @var TData
+     * @var array<mixed>
      */
     protected array $data = [];
 
     /**
-     * @return TData
+     * @return array<mixed>
      */
     public function toArray(): array
     {

--- a/formwork/src/Data/Traits/DataCountable.php
+++ b/formwork/src/Data/Traits/DataCountable.php
@@ -6,9 +6,14 @@ use Countable;
 
 /**
  * @phpstan-require-implements Countable
+ *
+ * @template TData of array<int|string, mixed> = array<int|string, mixed>
  */
 trait DataCountable
 {
+    /**
+     * @var TData
+     */
     protected array $data = [];
 
     /**

--- a/formwork/src/Data/Traits/DataCountableIterator.php
+++ b/formwork/src/Data/Traits/DataCountableIterator.php
@@ -2,8 +2,14 @@
 
 namespace Formwork\Data\Traits;
 
+/**
+ * @template TData of array<int|string, mixed> = array<int|string, mixed>
+ */
 trait DataCountableIterator
 {
+    /** @use DataCountable<TData> */
     use DataCountable;
+
+    /** @use DataIterator<TData> */
     use DataIterator;
 }

--- a/formwork/src/Data/Traits/DataGetter.php
+++ b/formwork/src/Data/Traits/DataGetter.php
@@ -4,15 +4,20 @@ namespace Formwork\Data\Traits;
 
 use Formwork\Utils\Arr;
 
+/**
+ * @template TData of array<string, mixed> = array<string, mixed>
+ */
 trait DataGetter
 {
     /**
-     * @var array<string, mixed>
+     * @var TData
      */
     protected array $data = [];
 
     /**
      * Return whether a key is present
+     *
+     * @param key-of<TData> $key
      */
     public function has(string $key): bool
     {
@@ -21,6 +26,14 @@ trait DataGetter
 
     /**
      * Get data by key returning a default value if key is not present
+     *
+     * @template TKey of key-of<TData>
+     * @template TDefault
+     *
+     * @param TKey     $key
+     * @param TDefault $default
+     *
+     * @return TDefault|value-of<TData>
      */
     public function get(string $key, mixed $default = null): mixed
     {

--- a/formwork/src/Data/Traits/DataIterator.php
+++ b/formwork/src/Data/Traits/DataIterator.php
@@ -6,9 +6,14 @@ use Iterator;
 
 /**
  * @phpstan-require-implements Iterator
+ *
+ * @template TData of array<int|string, mixed> = array<int|string, mixed>
  */
 trait DataIterator
 {
+    /**
+     * @var TData
+     */
     protected array $data = [];
 
     /**
@@ -24,6 +29,7 @@ trait DataIterator
      */
     public function current(): mixed
     {
+        /** @var mixed */
         return current($this->data);
     }
 

--- a/formwork/src/Data/Traits/DataMultipleGetter.php
+++ b/formwork/src/Data/Traits/DataMultipleGetter.php
@@ -2,14 +2,18 @@
 
 namespace Formwork\Data\Traits;
 
+/**
+ * @template TData of array<string, mixed> = array<string, mixed>
+ */
 trait DataMultipleGetter
 {
+    /** @use DataGetter<TData> */
     use DataGetter;
 
     /**
      * Return whether multiple keys are present
      *
-     * @param list<string> $keys
+     * @param list<key-of<TData>> $keys
      */
     public function hasMultiple(array $keys): bool
     {
@@ -25,9 +29,13 @@ trait DataMultipleGetter
     /**
      * Get an array containing multiple values
      *
-     * @param list<string> $keys
+     * @template TKey of key-of<TData>
+     * @template TDefault
      *
-     * @return array<string, mixed>
+     * @param list<TKey> $keys
+     * @param TDefault   $default
+     *
+     * @return array<TKey, TDefault|value-of<TData>>
      */
     public function getMultiple(array $keys, mixed $default = null): array
     {

--- a/formwork/src/Data/Traits/DataMultipleSetter.php
+++ b/formwork/src/Data/Traits/DataMultipleSetter.php
@@ -2,14 +2,18 @@
 
 namespace Formwork\Data\Traits;
 
+/**
+ * @template TData of array<string, mixed> = array<string, mixed>
+ */
 trait DataMultipleSetter
 {
+    /** @use DataSetter<TData> */
     use DataSetter;
 
     /**
      * Set multiple values
      *
-     * @param array<string, mixed> $keysAndValues
+     * @param array<key-of<TData>, value-of<TData>> $keysAndValues
      */
     public function setMultiple(array $keysAndValues): void
     {
@@ -21,7 +25,7 @@ trait DataMultipleSetter
     /**
      * Remove multiple values
      *
-     * @param list<string> $keys
+     * @param list<key-of<TData>> $keys
      */
     public function removeMultiple(array $keys): void
     {

--- a/formwork/src/Data/Traits/DataSetter.php
+++ b/formwork/src/Data/Traits/DataSetter.php
@@ -17,6 +17,7 @@ trait DataSetter
     /**
      * Set a data value by key
      *
+     * @param key-of<TData>   $key
      * @param value-of<TData> $value
      */
     public function set(string $key, mixed $value): void

--- a/formwork/src/Data/Traits/DataSetter.php
+++ b/formwork/src/Data/Traits/DataSetter.php
@@ -4,15 +4,20 @@ namespace Formwork\Data\Traits;
 
 use Formwork\Utils\Arr;
 
+/**
+ * @template TData of array<string, mixed> = array<string, mixed>
+ */
 trait DataSetter
 {
     /**
-     * @var array<string, mixed>
+     * @var TData
      */
     protected array $data = [];
 
     /**
      * Set a data value by key
+     *
+     * @param value-of<TData> $value
      */
     public function set(string $key, mixed $value): void
     {
@@ -21,6 +26,8 @@ trait DataSetter
 
     /**
      * Remove a data value by key
+     *
+     * @param key-of<TData> $key
      */
     public function remove(string $key): void
     {

--- a/formwork/src/Fields/FieldCollection.php
+++ b/formwork/src/Fields/FieldCollection.php
@@ -8,6 +8,9 @@ use Formwork\Http\Request;
 use Formwork\Model\Model;
 use Formwork\Utils\Arr;
 
+/**
+ * @extends AbstractCollection<Field>
+ */
 class FieldCollection extends AbstractCollection
 {
     protected bool $associative = true;

--- a/formwork/src/Fields/Layout/SectionCollection.php
+++ b/formwork/src/Fields/Layout/SectionCollection.php
@@ -5,6 +5,9 @@ namespace Formwork\Fields\Layout;
 use Formwork\Data\AbstractCollection;
 use Formwork\Utils\Arr;
 
+/**
+ * @extends AbstractCollection<Section>
+ */
 class SectionCollection extends AbstractCollection
 {
     protected bool $associative = true;

--- a/formwork/src/Fields/Layout/TabCollection.php
+++ b/formwork/src/Fields/Layout/TabCollection.php
@@ -5,6 +5,9 @@ namespace Formwork\Fields\Layout;
 use Formwork\Data\AbstractCollection;
 use Formwork\Utils\Arr;
 
+/**
+ * @extends AbstractCollection<Tab>
+ */
 class TabCollection extends AbstractCollection
 {
     protected bool $associative = true;

--- a/formwork/src/Files/FileCollection.php
+++ b/formwork/src/Files/FileCollection.php
@@ -5,6 +5,9 @@ namespace Formwork\Files;
 use Formwork\Data\AbstractCollection;
 use Formwork\Utils\Arr;
 
+/**
+ * @extends AbstractCollection<File>
+ */
 class FileCollection extends AbstractCollection
 {
     protected bool $associative = true;

--- a/formwork/src/Http/Request.php
+++ b/formwork/src/Http/Request.php
@@ -135,7 +135,7 @@ class Request
      */
     public function root(): string
     {
-        return '/' . ltrim(preg_replace('~[^/]+$~', '', $this->server->get('SCRIPT_NAME', '')), '/');
+        return '/' . ltrim((string) preg_replace('~[^/]+$~', '', $this->server->get('SCRIPT_NAME', '')), '/');
     }
 
     /**

--- a/formwork/src/Http/ResponseHeaders.php
+++ b/formwork/src/Http/ResponseHeaders.php
@@ -53,13 +53,9 @@ class ResponseHeaders implements Arrayable, Countable, Iterator
         return $this->baseHas(Header::fixHeaderName($key));
     }
 
-    /**
-     * @template TKey of string
-     *
-     * @param TKey $key
-     */
     public function get(string $key, mixed $default = null): mixed
     {
+        /** @var string $key */
         return $this->baseGet(Header::fixHeaderName($key), $default);
     }
 

--- a/formwork/src/Http/ResponseHeaders.php
+++ b/formwork/src/Http/ResponseHeaders.php
@@ -15,19 +15,26 @@ use Iterator;
  */
 class ResponseHeaders implements Arrayable, Countable, Iterator
 {
+    /** @use DataArrayable<array<string, string>> */
     use DataArrayable;
+
+    /** @use DataCountableIterator<array<string, string>> */
     use DataCountableIterator;
+
+    /** @use DataMultipleGetter<array<string, string>> */
     use DataMultipleGetter {
         has as protected baseHas;
         get as protected baseGet;
     }
+
+    /** @use DataMultipleSetter<array<string, string>> */
     use DataMultipleSetter {
         set as protected baseSet;
         remove as protected baseRemove;
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param array<string, string> $data
      */
     public function __construct(array $data)
     {
@@ -47,6 +54,11 @@ class ResponseHeaders implements Arrayable, Countable, Iterator
         return $this->baseHas(Header::fixHeaderName($key));
     }
 
+    /**
+     * @template TKey of string
+     *
+     * @param TKey $key
+     */
     public function get(string $key, mixed $default = null): mixed
     {
         return $this->baseGet(Header::fixHeaderName($key), $default);

--- a/formwork/src/Http/ResponseHeaders.php
+++ b/formwork/src/Http/ResponseHeaders.php
@@ -15,7 +15,6 @@ use Iterator;
  */
 class ResponseHeaders implements Arrayable, Countable, Iterator
 {
-    /** @use DataArrayable<array<string, string>> */
     use DataArrayable;
 
     /** @use DataCountableIterator<array<string, string>> */

--- a/formwork/src/Http/Session/Messages.php
+++ b/formwork/src/Http/Session/Messages.php
@@ -7,6 +7,7 @@ use Formwork\Data\Traits\DataArrayable;
 
 class Messages implements Arrayable
 {
+    /** @use DataArrayable<array<string, list<string>>> */
     use DataArrayable;
 
     /**

--- a/formwork/src/Http/Session/Messages.php
+++ b/formwork/src/Http/Session/Messages.php
@@ -7,7 +7,6 @@ use Formwork\Data\Traits\DataArrayable;
 
 class Messages implements Arrayable
 {
-    /** @use DataArrayable<array<string, list<string>>> */
     use DataArrayable;
 
     /**

--- a/formwork/src/Images/Transform/TransformCollection.php
+++ b/formwork/src/Images/Transform/TransformCollection.php
@@ -4,6 +4,9 @@ namespace Formwork\Images\Transform;
 
 use Formwork\Data\AbstractCollection;
 
+/**
+ * @extends AbstractCollection<AbstractTransform>
+ */
 class TransformCollection extends AbstractCollection
 {
     protected ?string $dataType = AbstractTransform::class;

--- a/formwork/src/Languages/LanguageCollection.php
+++ b/formwork/src/Languages/LanguageCollection.php
@@ -5,6 +5,9 @@ namespace Formwork\Languages;
 use Formwork\Data\AbstractCollection;
 use Formwork\Utils\Arr;
 
+/**
+ * @extends AbstractCollection<Language>
+ */
 class LanguageCollection extends AbstractCollection
 {
     protected ?string $dataType = Language::class;

--- a/formwork/src/Metadata/MetadataCollection.php
+++ b/formwork/src/Metadata/MetadataCollection.php
@@ -4,6 +4,9 @@ namespace Formwork\Metadata;
 
 use Formwork\Data\AbstractCollection;
 
+/**
+ * @extends AbstractCollection<Metadata>
+ */
 class MetadataCollection extends AbstractCollection
 {
     protected bool $associative = true;
@@ -22,10 +25,23 @@ class MetadataCollection extends AbstractCollection
     }
 
     /**
+     * Set multiple metadata
+     *
+     * @param array<string, string> $keysAndValues
+     */
+    // @phpstan-ignore method.childParameterType
+    public function setMultiple(array $keysAndValues): void
+    {
+        // @phpstan-ignore argument.type
+        parent::setMultiple($keysAndValues);
+    }
+
+    /**
      * Set a metadata
      *
      * @param string $value
      */
+    // @phpstan-ignore method.childParameterType
     public function set(string $key, $value): void
     {
         $this->data[$key] = new Metadata($key, $value);

--- a/formwork/src/Model/Model.php
+++ b/formwork/src/Model/Model.php
@@ -119,6 +119,7 @@ class Model implements Arrayable
 
         // Get values from fields
         if ($this->fields->has($key)) {
+            /** @var Field */
             $field = $this->fields->get($key);
 
             // If defined use the value returned by `return()`

--- a/formwork/src/Pages/Page.php
+++ b/formwork/src/Pages/Page.php
@@ -822,11 +822,11 @@ class Page extends Model implements Stringable
                 $this->contentFile = null;
             }
 
-            $this->template ??= $site->templates()->get($contentFiles[$key]['template']);
+            $this->template ??= $this->resolveTemplate($contentFiles[$key]['template']);
 
             $this->scheme ??= $site->schemes()->get("pages.{$this->template}");
         } else {
-            $this->template ??= $site->templates()->get('default');
+            $this->template ??= $this->resolveTemplate('default');
 
             $this->scheme ??= $site->schemes()->get("pages.{$this->template}");
         }
@@ -1092,14 +1092,7 @@ class Page extends Model implements Stringable
      */
     protected function setTemplate(Template|string $template): void
     {
-        if ($template instanceof Template) {
-            $this->template = $template;
-        } else {
-            if (!$this->site()->templates()->has($template)) {
-                throw new InvalidValueException('Invalid page template', 'invalidTemplate');
-            }
-            $this->template = $this->site()->templates()->get($template);
-        }
+        $this->template = $this->resolveTemplate($template);
         $this->scheme = $this->site()->schemes()->get("pages.{$template}");
     }
 
@@ -1207,5 +1200,21 @@ class Page extends Model implements Stringable
     protected function validateSlug(string $slug): bool
     {
         return (bool) preg_match(self::SLUG_REGEX, $slug);
+    }
+
+    /**
+     * Resolve a template from a string or Template instance
+     */
+    protected function resolveTemplate(string|Template $template): Template
+    {
+        if (is_string($template)) {
+            $template = $this->site()->templates()->get($template);
+        }
+
+        if ($template === null) {
+            throw new InvalidValueException('Invalid page template', 'invalidTemplate');
+        }
+
+        return $template;
     }
 }

--- a/formwork/src/Pages/PageCollection.php
+++ b/formwork/src/Pages/PageCollection.php
@@ -9,6 +9,11 @@ use Formwork\Utils\Arr;
 use Formwork\Utils\Str;
 use RuntimeException;
 
+/**
+ * @extends AbstractCollection<Page|Site>
+ *
+ * @implements Paginable<Page|Site>
+ */
 class PageCollection extends AbstractCollection implements Paginable
 {
     protected ?string $dataType = Page::class . '|' . Site::class;
@@ -244,7 +249,10 @@ class PageCollection extends AbstractCollection implements Paginable
      */
     public function withoutParent(Page $page): static
     {
-        return $this->without($page->parent());
+        if (($parent = $page->parent()) !== null) {
+            return $this->without($parent);
+        }
+        return $this->clone();
     }
 
     /**
@@ -252,7 +260,10 @@ class PageCollection extends AbstractCollection implements Paginable
      */
     public function withoutPageAndParent(Page $page): static
     {
-        return $this->without($page)->without($page->parent());
+        if (($parent = $page->parent()) !== null) {
+            return $this->without($page, $parent);
+        }
+        return $this->without($page);
     }
 
     /**

--- a/formwork/src/Pages/PageCollectionFactory.php
+++ b/formwork/src/Pages/PageCollectionFactory.php
@@ -2,6 +2,8 @@
 
 namespace Formwork\Pages;
 
+use Formwork\Cms\Site;
+
 final class PageCollectionFactory
 {
     public function __construct(
@@ -11,7 +13,7 @@ final class PageCollectionFactory
     /**
      * Create a new PageCollection instance
      *
-     * @param array<int|string, mixed> $data
+     * @param array<int|string, Page|Site> $data
      */
     public function make(array $data): PageCollection
     {

--- a/formwork/src/Pages/Pagination.php
+++ b/formwork/src/Pages/Pagination.php
@@ -7,6 +7,9 @@ use Formwork\Data\Pagination as BasePagination;
 use Formwork\Pages\Traits\PaginationUri;
 use Formwork\Router\Router;
 
+/**
+ * @extends BasePagination<Page|Site>
+ */
 class Pagination extends BasePagination
 {
     use PaginationUri;

--- a/formwork/src/Pages/Traits/PageTraversal.php
+++ b/formwork/src/Pages/Traits/PageTraversal.php
@@ -246,6 +246,7 @@ trait PageTraversal
      */
     public function previousSibling(): ?Page
     {
+        /** @var ?Page */
         return $this->inclusiveSiblings()->nth($this->index() - 1);
     }
 
@@ -254,6 +255,7 @@ trait PageTraversal
      */
     public function nextSibling(): ?Page
     {
+        /** @var ?Page */
         return $this->inclusiveSiblings()->nth($this->index() + 1);
     }
 

--- a/formwork/src/Pages/Traits/PaginationUri.php
+++ b/formwork/src/Pages/Traits/PaginationUri.php
@@ -146,11 +146,11 @@ trait PaginationUri
 
         $routeName = Str::removeEnd($this->router->current()->getName(), static::$routeSuffix);
 
-        if (!$this->router->routes()->has($routeName)) {
+        if (($baseRoute = $this->router->routes()->get($routeName)) === null) {
             throw new RuntimeException(sprintf('Cannot generate pagination routes, base route "%s" is not defined', $routeName));
         }
 
-        return $this->baseRoute = $this->router->routes()->get($routeName);
+        return $this->baseRoute = $baseRoute;
     }
 
     /**
@@ -164,10 +164,10 @@ trait PaginationUri
 
         $routeName = $this->baseRoute()->getName() . static::$routeSuffix;
 
-        if (!$this->router->routes()->has($routeName)) {
+        if (($paginationRoute = $this->router->routes()->get($routeName)) === null) {
             throw new RuntimeException(sprintf('Cannot generate pagination for route "%s", route "%s" is not defined', $this->baseRoute()->getName(), $routeName));
         }
 
-        return $this->paginationRoute = $this->router->routes()->get($routeName);
+        return $this->paginationRoute = $paginationRoute;
     }
 }

--- a/formwork/src/Panel/ContentHistory/ContentHistoryItemCollection.php
+++ b/formwork/src/Panel/ContentHistory/ContentHistoryItemCollection.php
@@ -4,6 +4,9 @@ namespace Formwork\Panel\ContentHistory;
 
 use Formwork\Data\AbstractCollection;
 
+/**
+ * @extends AbstractCollection<ContentHistoryItem>
+ */
 class ContentHistoryItemCollection extends AbstractCollection
 {
     protected bool $associative = false;

--- a/formwork/src/Panel/Controllers/AbstractController.php
+++ b/formwork/src/Panel/Controllers/AbstractController.php
@@ -45,6 +45,8 @@ abstract class AbstractController extends BaseAbstractController
     protected function modal(string $name): Modal
     {
         $this->panel->modals()->add($name);
+
+        /** @var Modal */
         return $this->panel->modals()->get($name);
     }
 

--- a/formwork/src/Panel/Controllers/FilesController.php
+++ b/formwork/src/Panel/Controllers/FilesController.php
@@ -22,6 +22,7 @@ use Formwork\Utils\Path;
 use Formwork\Utils\Str;
 use Formwork\Utils\Uri;
 use InvalidArgumentException;
+use UnexpectedValueException;
 
 final class FilesController extends AbstractController
 {
@@ -88,7 +89,9 @@ final class FilesController extends AbstractController
         $form = $this->form('upload-file', $this->modal('uploadFile')->fields())
             ->processRequest($this->request, uploadFiles: false);
 
-        $filesField = $form->fields()->get('files');
+        if (($filesField = $form->fields()->get('files')) === null) {
+            throw new UnexpectedValueException('Missing "files" field in upload file form');
+        }
 
         if (!$form->isSubmitted() || !$form->isValid() || $filesField->isEmpty()) {
             $this->panel->notify($this->translate('panel.files.cannotUpload.invalidFields'), 'error');
@@ -97,8 +100,11 @@ final class FilesController extends AbstractController
 
         $files = $filesField->isMultiple() ? $filesField->value() : [$filesField->value()];
 
-        /** @var Page|Site */
-        $parent = $form->fields()->get('parent')->return();
+        $parent = $form->fields()->get('parent')?->return();
+
+        if ($parent === null) {
+            throw new UnexpectedValueException('Missing "parent" field in upload file form');
+        }
 
         $destination = $parent instanceof Site
             ? $this->config->get('system.files.paths.site')
@@ -351,7 +357,7 @@ final class FilesController extends AbstractController
     }
 
     /**
-     * @return array<array{FileCollection, Page|Site}>
+     * @return array<array{File, Page|Site}>
      */
     private function getFiles(): array
     {

--- a/formwork/src/Panel/Controllers/PagesController.php
+++ b/formwork/src/Panel/Controllers/PagesController.php
@@ -360,6 +360,7 @@ final class PagesController extends AbstractController
 
         $pageCollection->moveItem($from, $to);
 
+        /** @var Page $page */
         foreach ($pageCollection->filterBy('orderable')->values() as $i => $page) {
             $num = $i + 1;
             if ($num !== $page->num()) {
@@ -581,7 +582,7 @@ final class PagesController extends AbstractController
     /**
      * Get previous and next page helper
      *
-     * @return array{previousPage: ?Page, nextPage: ?Page}
+     * @return array{previousPage: Page|Site|null, nextPage: Page|Site|null}
      */
     private function getPreviousAndNextPage(Page $page): array
     {

--- a/formwork/src/Panel/Controllers/PluginsController.php
+++ b/formwork/src/Panel/Controllers/PluginsController.php
@@ -51,11 +51,9 @@ final class PluginsController extends AbstractController
 
         $name = Str::toCamelCase($routeParams->get('id'));
 
-        if (!$plugins->has($name)) {
+        if (($plugin = $plugins->get($name)) === null) {
             return $this->forward(ErrorsController::class, 'notFound');
         }
-
-        $plugin = $plugins->get($name);
 
         $scheme = $this->getPluginScheme($plugin);
 
@@ -105,11 +103,11 @@ final class PluginsController extends AbstractController
 
         $name = Str::toCamelCase($routeParams->get('id'));
 
-        if (!$plugins->has($name)) {
+        if (($plugin = $plugins->get($name)) === null) {
             return JsonResponse::error($this->translate('panel.plugins.plugin.notFound'), ResponseStatus::NotFound);
         }
 
-        $this->togglePluginStatus($plugins->get($name), true);
+        $this->togglePluginStatus($plugin, true);
 
         $this->panel->notify($this->translate('panel.plugins.plugin.enabled'), 'success');
         return JsonResponse::success($this->translate('panel.plugins.plugin.enabled'));
@@ -126,11 +124,11 @@ final class PluginsController extends AbstractController
 
         $name = Str::toCamelCase($routeParams->get('id'));
 
-        if (!$plugins->has($name)) {
+        if (($plugin = $plugins->get($name)) === null) {
             return JsonResponse::error($this->translate('panel.plugins.plugin.notFound'), ResponseStatus::NotFound);
         }
 
-        $this->togglePluginStatus($plugins->get($name), false);
+        $this->togglePluginStatus($plugin, false);
 
         $this->panel->notify($this->translate('panel.plugins.plugin.disabled'), 'success');
         return JsonResponse::success($this->translate('panel.plugins.plugin.disabled'));

--- a/formwork/src/Panel/Controllers/UsersController.php
+++ b/formwork/src/Panel/Controllers/UsersController.php
@@ -169,10 +169,10 @@ final class UsersController extends AbstractController
         $fields->setModel($user);
 
         // Hide password field if the user cannot change it
-        $fields->get('password')->set('visible', $this->panel->user()->canChangePasswordOf($user));
+        $fields->get('password')?->set('visible', $this->panel->user()->canChangePasswordOf($user));
 
         // Disable role field if it cannot be changed
-        $fields->get('role')->set('disabled', !$this->panel->user()->canChangeRoleOf($user));
+        $fields->get('role')?->set('disabled', !$this->panel->user()->canChangeRoleOf($user));
 
         $fields->setValues($user);
 

--- a/formwork/src/Panel/Modals/Modal.php
+++ b/formwork/src/Panel/Modals/Modal.php
@@ -32,7 +32,17 @@ class Modal implements Arrayable
     protected ModalButtonCollection $buttons;
 
     /**
-     * @param array<string, mixed> $data
+     * @param array{
+     *     title?: ?string,
+     *     message?: ?string,
+     *     action?: ?string,
+     *     target?: ?string,
+     *     size?: string,
+     *     open?: bool,
+     *     form?: bool,
+     *     fields?: array<string, array<string, mixed>>,
+     *     buttons?: array<array<string, mixed>>,
+     * } $data
      */
     public function __construct(
         string $id,

--- a/formwork/src/Panel/Modals/ModalButtonCollection.php
+++ b/formwork/src/Panel/Modals/ModalButtonCollection.php
@@ -4,6 +4,9 @@ namespace Formwork\Panel\Modals;
 
 use Formwork\Data\AbstractCollection;
 
+/**
+ * @extends AbstractCollection<ModalButton>
+ */
 class ModalButtonCollection extends AbstractCollection
 {
     protected bool $associative = true;

--- a/formwork/src/Panel/Modals/ModalCollection.php
+++ b/formwork/src/Panel/Modals/ModalCollection.php
@@ -4,6 +4,9 @@ namespace Formwork\Panel\Modals;
 
 use Formwork\Data\AbstractCollection;
 
+/**
+ * @extends AbstractCollection<Modal>
+ */
 class ModalCollection extends AbstractCollection
 {
     protected bool $associative = true;

--- a/formwork/src/Panel/Modals/Modals.php
+++ b/formwork/src/Panel/Modals/Modals.php
@@ -13,6 +13,7 @@ class Modals extends ModalCollection
      *
      * @param string $name
      */
+    // @phpstan-ignore method.childParameterType
     public function add(mixed $name): void
     {
         if (!$this->has($name)) {

--- a/formwork/src/Panel/Navigation/NavigationItemCollection.php
+++ b/formwork/src/Panel/Navigation/NavigationItemCollection.php
@@ -6,6 +6,9 @@ use Formwork\Data\AbstractCollection;
 use Formwork\Data\Contracts\ArraySerializable;
 use Formwork\Utils\Arr;
 
+/**
+ * @extends AbstractCollection<NavigationItem>
+ */
 class NavigationItemCollection extends AbstractCollection implements ArraySerializable
 {
     protected bool $associative = true;
@@ -16,6 +19,7 @@ class NavigationItemCollection extends AbstractCollection implements ArraySerial
 
     public function toArray(): array
     {
+        /** @var array<string, NavigationItem> */
         return Arr::map($this->data, fn(NavigationItem $navigationItem) => $navigationItem->toArray());
     }
 

--- a/formwork/src/Panel/Navigation/NavigationItemCollection.php
+++ b/formwork/src/Panel/Navigation/NavigationItemCollection.php
@@ -19,7 +19,6 @@ class NavigationItemCollection extends AbstractCollection implements ArraySerial
 
     public function toArray(): array
     {
-        /** @var array<string, NavigationItem> */
         return Arr::map($this->data, fn(NavigationItem $navigationItem) => $navigationItem->toArray());
     }
 

--- a/formwork/src/Plugins/PluginCollection.php
+++ b/formwork/src/Plugins/PluginCollection.php
@@ -5,6 +5,8 @@ namespace Formwork\Plugins;
 use Formwork\Data\AbstractCollection;
 
 /**
+ * @extends AbstractCollection<Plugin>
+ *
  * @since 2.3.0
  */
 class PluginCollection extends AbstractCollection

--- a/formwork/src/Plugins/Plugins.php
+++ b/formwork/src/Plugins/Plugins.php
@@ -48,11 +48,9 @@ class Plugins extends PluginCollection
      */
     public function initialize(string $name): void
     {
-        if (!$this->has($name)) {
+        if (($plugin = $this->get($name)) === null) {
             throw new InvalidArgumentException(sprintf('Invalid plugin "%s"', $name));
         }
-
-        $plugin = $this->get($name);
 
         $plugin->autoload()?->register();
 

--- a/formwork/src/Router/RouteCollection.php
+++ b/formwork/src/Router/RouteCollection.php
@@ -4,6 +4,9 @@ namespace Formwork\Router;
 
 use Formwork\Data\AbstractCollection;
 
+/**
+ * @extends AbstractCollection<Route>
+ */
 class RouteCollection extends AbstractCollection
 {
     protected bool $associative = true;

--- a/formwork/src/Router/RouteFilterCollection.php
+++ b/formwork/src/Router/RouteFilterCollection.php
@@ -4,6 +4,9 @@ namespace Formwork\Router;
 
 use Formwork\Data\AbstractCollection;
 
+/**
+ * @extends AbstractCollection<RouteFilter>
+ */
 class RouteFilterCollection extends AbstractCollection
 {
     protected bool $associative = true;

--- a/formwork/src/Router/Router.php
+++ b/formwork/src/Router/Router.php
@@ -244,7 +244,10 @@ class Router
      */
     public function generate(string $name, array $params): string
     {
-        return $this->generateRoute($this->routes->get($name), $params);
+        if (($route = $this->routes->get($name)) === null) {
+            throw new InvalidArgumentException(sprintf('Route "%s" does not exist', $name));
+        }
+        return $this->generateRoute($route, $params);
     }
 
     /**
@@ -254,7 +257,10 @@ class Router
      */
     public function generateWith(string $name, array $params): string
     {
-        return $this->generateRoute($this->routes->get($name), $params + $this->params->toArray());
+        if (($route = $this->routes->get($name)) === null) {
+            throw new InvalidArgumentException(sprintf('Route "%s" does not exist', $name));
+        }
+        return $this->generateRoute($route, $params + $this->params->toArray());
     }
 
     /**

--- a/formwork/src/Schemes/Scheme.php
+++ b/formwork/src/Schemes/Scheme.php
@@ -13,12 +13,20 @@ use Formwork\Utils\Arr;
 use Formwork\Utils\Str;
 use InvalidArgumentException;
 
-/**
- * @property array{title?: array<string, string>|string, extend?: string, options?: array<string, mixed>, layout?: array<string, mixed>, fields?: array<string, mixed>} $data
- */
 class Scheme implements Arrayable
 {
     use DataArrayable;
+
+    /**
+     * @var array{
+     *     title?: array<string, string>|string,
+     *     extend?: string,
+     *     options?: array<string, mixed>,
+     *     layout?: array<string, mixed>,
+     *     fields?: array<string, mixed>
+     * }
+     */
+    protected array $data = [];
 
     /**
      * Scheme path
@@ -36,7 +44,13 @@ class Scheme implements Arrayable
     protected SchemeOptions $options;
 
     /**
-     * @param array<string, mixed> $data
+     * @param array{
+     *     title?: array<string, string>|string,
+     *     extend?: string,
+     *     options?: array<string, mixed>,
+     *     layout?: array<string, mixed>,
+     *     fields?: array<string, mixed>
+     * } $data
      *
      * @throws InvalidArgumentException If the extended scheme ID is invalid
      * @throws InvalidArgumentException If a scheme tries to extend itself
@@ -101,7 +115,6 @@ class Scheme implements Arrayable
     {
         $fieldCollection = new FieldCollection();
 
-        // @phpstan-ignore argument.templateType
         $fieldCollection->setMultiple(Arr::map(
             $this->data['fields'] ?? [],
             fn($data, $name) => $this->fieldFactory->make($name, $data, $fieldCollection)
@@ -130,18 +143,25 @@ class Scheme implements Arrayable
             throw new InvalidArgumentException(sprintf('Scheme "%s" cannot be extended by itself', $this->id));
         }
 
-        $this->data = Arr::extend($scheme->data, $this->data);
+        $this->extendWith($scheme->data);
     }
 
     /**
      * Extend the scheme with an array of data
      *
-     * @param array<string, mixed> $data
+     * @param array{
+     *     title?: array<string, string>|string,
+     *     extend?: string,
+     *     options?: array<string, mixed>,
+     *     layout?: array<string, mixed>,
+     *     fields?: array<string, mixed>
+     * } $data
      *
      * @since 2.3.0
      */
     public function extendWith(array $data): void
     {
+        // @phpstan-ignore assign.propertyType
         $this->data = Arr::extend($data, $this->data);
     }
 

--- a/formwork/src/Templates/TemplateCollection.php
+++ b/formwork/src/Templates/TemplateCollection.php
@@ -4,6 +4,9 @@ namespace Formwork\Templates;
 
 use Formwork\Data\AbstractCollection;
 
+/**
+ * @extends AbstractCollection<Template>
+ */
 class TemplateCollection extends AbstractCollection
 {
     protected bool $associative = true;

--- a/formwork/src/Users/RoleCollection.php
+++ b/formwork/src/Users/RoleCollection.php
@@ -4,6 +4,9 @@ namespace Formwork\Users;
 
 use Formwork\Data\AbstractCollection;
 
+/**
+ * @extends AbstractCollection<Role>
+ */
 class RoleCollection extends AbstractCollection
 {
     protected bool $associative = true;

--- a/formwork/src/Users/User.php
+++ b/formwork/src/Users/User.php
@@ -116,6 +116,7 @@ class User extends Model
             throw new LogicException(sprintf('User "%s" has an invalid role assigned: "%s"', $this->username(), $role));
         }
 
+        /** @var Role */
         return $this->users->roles()->get($role);
     }
 

--- a/formwork/src/Users/UserCollection.php
+++ b/formwork/src/Users/UserCollection.php
@@ -4,6 +4,9 @@ namespace Formwork\Users;
 
 use Formwork\Data\AbstractCollection;
 
+/**
+ * @extends AbstractCollection<User>
+ */
 class UserCollection extends AbstractCollection
 {
     protected bool $associative = true;

--- a/formwork/src/Utils/Arr.php
+++ b/formwork/src/Utils/Arr.php
@@ -16,12 +16,12 @@ final class Arr
      * Get data by key returning a default value if key is not present in a given array,
      * using dot notation to traverse if literal key is not found
      *
+     * @template TValue
+     *
      * @param array<string, TValue> $array
      * @param TValue|null           $default
      *
      * @return TValue|null
-     *
-     * @template TValue
      */
     public static function get(array $array, string $key, mixed $default = null): mixed
     {
@@ -41,9 +41,9 @@ final class Arr
      * Return whether a key is present in a given array, using dot notation to traverse
      * if literal key is not found
      *
-     * @param array<string, TValue> $array
-     *
      * @template TValue
+     *
+     * @param array<string, TValue> $array
      */
     public static function has(array $array, string $key): bool
     {
@@ -62,10 +62,10 @@ final class Arr
     /**
      * Set data by key using dot notation to traverse if literal key is not found
      *
+     * @template TValue
+     *
      * @param array<string, TValue> $array
      * @param TValue                $value
-     *
-     * @template TValue
      */
     public static function set(array &$array, string $key, mixed $value): void
     {
@@ -109,11 +109,11 @@ final class Arr
     /**
      * Convert a multidimensional array to a dot notation array, skipping non-associative arrays
      *
+     * @template TValue
+     *
      * @param array<array-key, TValue> $array
      *
      * @return array<string, TValue>
-     *
-     * @template TValue
      */
     public static function dot(array $array): array
     {
@@ -135,11 +135,11 @@ final class Arr
     /**
      * Convert a dot notation array to a multidimensional array
      *
+     * @template TValue
+     *
      * @param array<string, TValue> $array
      *
      * @return array<array-key, TValue>
-     *
-     * @template TValue
      */
     public static function undot(array $array): array
     {
@@ -155,9 +155,9 @@ final class Arr
     /**
      * Remove from an array all the occurrences of the given value
      *
-     * @param array<array-key, TValue> $array
-     *
      * @template TValue
+     *
+     * @param array<array-key, TValue> $array
      */
     public static function pull(array &$array, mixed $value): void
     {
@@ -171,17 +171,17 @@ final class Arr
     /**
      * Remove a portion of the array and replace it with something else like `array_splice` but also preserve string keys from the replacement array
      *
+     * @template TKey of array-key
+     * @template TValue
+     * @template TReplacementKey of array-key
+     * @template TReplacementValue
+     *
      * @param array<TKey|TReplacementKey, TReplacementValue|TValue> $array
      * @param array<TReplacementKey, TReplacementValue>             $replacement
      *
      * @throws UnexpectedValueException If some keys in the replacement array are the same of the resulting array
      *
      * @return array<TKey, TValue>
-     *
-     * @template TKey of array-key
-     * @template TValue
-     * @template TReplacementKey of array-key
-     * @template TReplacementValue
      */
     public static function splice(array &$array, int $offset, ?int $length = null, array $replacement = []): array
     {
@@ -217,12 +217,12 @@ final class Arr
     /**
      * Move an item from the given index to another
      *
+     * @template TKey of array-key
+     * @template TValue
+     *
      * @param array<TKey,TValue> $array
      * @param int                $fromIndex The source index to move from
      * @param int                $toIndex   The destination index to move to
-     *
-     * @template TKey of array-key
-     * @template TValue
      */
     public static function moveItem(array &$array, int $fromIndex, int $toIndex): void
     {
@@ -234,12 +234,12 @@ final class Arr
     /**
      * Return an array of `[$key, $value]` pairs from the given array
      *
+     * @template TKey of array-key
+     * @template TValue
+     *
      * @param array<TKey, TValue> $array
      *
      * @return array<array{TKey, TValue}>
-     *
-     * @template TKey of array-key
-     * @template TValue
      */
     public static function entries(array $array): array
     {
@@ -256,11 +256,11 @@ final class Arr
      * Get the array value at the given index,
      * negative indices are not allowed, use `Arr:at()` instead
      *
+     * @template TValue
+     *
      * @param array<array-key, TValue> $array
      *
      * @return TValue|null
-     *
-     * @template TValue
      */
     public static function nth(array $array, int $index): mixed
     {
@@ -271,11 +271,11 @@ final class Arr
      * Get the array value at the given index,
      * negative indices are allowed and start from the end
      *
+     * @template TValue
+     *
      * @param array<array-key, TValue> $array
      *
      * @return TValue|null
-     *
-     * @template TValue
      */
     public static function at(array $array, int $index): mixed
     {
@@ -296,12 +296,12 @@ final class Arr
     /**
      * Get the key of the given value or null if not found
      *
+     * @template TKey of array-key
+     * @template TValue
+     *
      * @param array<TKey, TValue> $array
      *
      * @return TKey
-     *
-     * @template TKey of array-key
-     * @template TValue
      */
     public static function keyOf(array $array, mixed $value): int|string|null
     {
@@ -312,12 +312,12 @@ final class Arr
     /**
      * Return the duplicate items of the array
      *
+     * @template TKey of array-key
+     * @template TValue
+     *
      * @param array<TKey, TValue> $array
      *
      * @return array<TKey, TValue>
-     *
-     * @template TKey of array-key
-     * @template TValue
      */
     public static function duplicates(array $array): array
     {
@@ -327,13 +327,13 @@ final class Arr
     /**
      * Recursively append items from the second array that are missing in the first
      *
+     * @template TKey of array-key
+     * @template TValue
+     *
      * @param array<TKey, TValue> $array1
      * @param array<TKey, TValue> $array2
      *
      * @return array<TKey, array<TValue>|TValue>
-     *
-     * @template TKey of array-key
-     * @template TValue
      */
     public static function appendMissing(array $array1, array $array2): array
     {
@@ -468,12 +468,12 @@ final class Arr
     /**
      * Return a random value from a given array
      *
+     * @template TValue
+     *
      * @param array<array-key, TValue> $array
      * @param TValue|null              $default
      *
      * @return TValue|null
-     *
-     * @template TValue
      */
     public static function random(array $array, mixed $default = null): mixed
     {
@@ -483,13 +483,13 @@ final class Arr
     /**
      * Return a given array with its values shuffled optionally preserving the key/value pairs
      *
+     * @template TKey of array-key
+     * @template TValue
+     *
      * @param array<TKey, TValue> $array
      * @param bool                $preserveKeys Whether to preserve the original keys
      *
      * @return ($preserveKeys is true ? array<TKey, TValue> : list<TValue>)
-     *
-     * @template TKey of array-key
-     * @template TValue
      */
     public static function shuffle(array $array, bool $preserveKeys = false): array
     {
@@ -524,14 +524,14 @@ final class Arr
      *
      * The key of each element is passed to the callback as second argument
      *
+     * @template TKey of array-key
+     * @template TValue
+     * @template TReturn
+     *
      * @param array<TKey, TValue>             $array
      * @param callable(TValue, TKey): TReturn $callback
      *
      * @return array<TKey, TReturn>
-     *
-     * @template TKey of array-key
-     * @template TValue
-     * @template TReturn
      */
     public static function map(array $array, callable $callback): array
     {
@@ -544,14 +544,14 @@ final class Arr
      *
      * The value of each element is passed to the callback as second argument
      *
+     * @template TKey of array-key
+     * @template TValue
+     * @template TReturn of array-key
+     *
      * @param array<TKey, TValue>             $array
      * @param callable(TKey, TValue): TReturn $callback
      *
      * @return array<TReturn, TValue>
-     *
-     * @template TKey of array-key
-     * @template TValue
-     * @template TReturn of array-key
      */
     public static function mapKeys(array $array, callable $callback): array
     {
@@ -564,13 +564,13 @@ final class Arr
      *
      * The key of each element is passed to the callback as second argument
      *
+     * @template TKey of array-key
+     * @template TValue
+     *
      * @param array<TKey, TValue>          $array
      * @param callable(TValue, TKey): bool $callback
      *
      * @return array<TKey, TValue>
-     *
-     * @template TKey of array-key
-     * @template TValue
      */
     public static function filter(array $array, callable $callback): array
     {
@@ -582,13 +582,13 @@ final class Arr
      *
      * The key of each element is passed to the callback as second argument
      *
+     * @template TKey of array-key
+     * @template TValue
+     *
      * @param array<TKey, TValue>          $array
      * @param callable(TValue, TKey): bool $callback
      *
      * @return array<TKey, TValue>
-     *
-     * @template TKey of array-key
-     * @template TValue
      */
     public static function reject(array $array, callable $callback): array
     {
@@ -655,13 +655,13 @@ final class Arr
      *
      * The original array keys are preserved
      *
-     * @param array<TKey, array<K, V>> $array
-     *
-     * @return array<TKey, V>
-     *
      * @template TKey of array-key
      * @template K of array-key
      * @template V
+     *
+     * @param array<TKey, array<K, V>> $array
+     *
+     * @return array<TKey, V>
      */
     public static function extract(array $array, string $key, mixed $default = null): array
     {
@@ -671,14 +671,14 @@ final class Arr
     /**
      * Group array items using the return value of the given callback
      *
+     * @template TKey of array-key
+     * @template TReturn of string|Stringable
+     * @template TValue
+     *
      * @param array<TKey, TValue>             $array
      * @param callable(TValue, TKey): TReturn $callback
      *
      * @return array<string, list<TValue>>
-     *
-     * @template TKey of array-key
-     * @template TReturn of string|Stringable
-     * @template TValue
      */
     public static function group(array $array, callable $callback): array
     {
@@ -701,15 +701,15 @@ final class Arr
     /**
      * Flatten array items up to the specified depth
      *
+     * @template TKey of array-key
+     * @template TValue
+     *
      * @param array<TKey, TValue> $array
      * @param int                 $depth Maximum depth to flatten
      *
      * @throws UnexpectedValueException If the depth parameter is negative
      *
      * @return array<TKey, TValue>
-     *
-     * @template TKey of array-key
-     * @template TValue
      */
     public static function flatten(array $array, int $depth = PHP_INT_MAX): array
     {
@@ -750,6 +750,9 @@ final class Arr
     /**
      * Sort an array with the given options
      *
+     * @template TKey of array-key
+     * @template TValue
+     *
      * @param array<TKey, TValue>                                    $array
      * @param \SORT_ASC|\SORT_DESC                                   $direction     Direction of sorting. Possible values are `SORT_ASC` and `SORT_DESC`.
      * @param \SORT_NATURAL|\SORT_NUMERIC|\SORT_REGULAR|\SORT_STRING $type          Type of sorting. Possible values are `SORT_NATURAL`, `SORT_NUMERIC`, `SORT_REGULAR` and `SORT_STRING`.
@@ -761,9 +764,6 @@ final class Arr
      * @throws UnexpectedValueException If the type parameter is not one of the supported sorting types
      *
      * @return array<TKey, TValue>
-     *
-     * @template TKey of array-key
-     * @template TValue
      */
     public static function sort(
         array $array,
@@ -830,12 +830,12 @@ final class Arr
     /**
      * Try to convert the given object to array
      *
+     * @template TKey of array-key
+     * @template TValue
+     *
      * @throws UnexpectedValueException If the object cannot be converted to an array
      *
      * @return ($object is array<TKey, TValue>|Traversable<TKey, TValue> ? array<TKey, TValue> : array<mixed>)
-     *
-     * @template TKey of array-key
-     * @template TValue
      */
     public static function from(mixed $object): array
     {
@@ -854,12 +854,12 @@ final class Arr
     /**
      * Create an array from `[$key, $value]` pairs
      *
+     * @template TKey of array-key
+     * @template TValue
+     *
      * @param array<array{TKey, TValue}> $entries
      *
      * @return array<TKey, TValue>
-     *
-     * @template TKey of array-key
-     * @template TValue
      */
     public static function fromEntries(array $entries): array
     {


### PR DESCRIPTION
This pull request introduces comprehensive improvements to type safety and documentation for collections and related classes in the codebase. The main focus is on adding and refining PHP generics annotations (using `@template` and `@extends`), improving docblocks for better static analysis, and clarifying type expectations throughout the collection, pagination, and proxy classes. Additionally, some minor logic improvements and code style adjustments are included.

**Type Safety and Generics Enhancements:**

* Added generic type annotations (`@template T`) and extended docblocks to `AbstractCollection`, `Collection`, `AssetCollection`, `CollectionDataProxy`, `Pagination`, and the `Paginable` interface, ensuring better static analysis and clearer expectations for collection item types. [[1]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbL17-R42) [[2]](diffhunk://#diff-328666d1575c4723e463a1e8c13054994c7ab1ebe794433ba58a95e5a7642682R8-R12) [[3]](diffhunk://#diff-744fbee3cdf887ffe510dbad844553a881968854be1f7b0ce2682ee288afccdeR8-R10) [[4]](diffhunk://#diff-8be5150860d6c6535ebf3f07fb3611218d2ac4b376bef4e3265a1e94bb4609c9R5-R19) [[5]](diffhunk://#diff-8910dfd71e1fc7e17df369049dc06b19893873deb933780355c16c1e38f49bb0R8-R23) [[6]](diffhunk://#diff-dad7a1881aaab3dfd250838da302897b2fe6dfb67af2c054eb9436af667f345eR5-R7)
* Updated method docblocks throughout `AbstractCollection` and related classes to specify parameter and return types using generics, including methods like `get`, `set`, `with`, `without`, `union`, `intersection`, `difference`, `add`, `addMultiple`, `pull`, `pullMultiple`, and others. [[1]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbL53-R62) [[2]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR125-R126) [[3]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR137-R138) [[4]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR147-R148) [[5]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR157-R158) [[6]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR167-R170) [[7]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbL201-R222) [[8]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR255-R256) [[9]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbL401-R424) [[10]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbL413-R436) [[11]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbL426-R449) [[12]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbL503-R528) [[13]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR552-R553) [[14]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR570-R571) [[15]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR588-R589) [[16]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR598-R599) [[17]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR614-R615) [[18]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR630-R631) [[19]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR647-R648) [[20]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbL628-R667) [[21]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR679-R680) [[22]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbL654-R695) [[23]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR729-R737) [[24]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR750-R751) [[25]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR789-R790)

**Static Analysis and Code Quality:**

* Added or improved PHPStan ignore rules and type assertions to accommodate stricter static analysis, including a fix in `phpstan.neon` and inline ignore comments. [[1]](diffhunk://#diff-35e4fe6b77f187e2885ba3c76f709d65f40bfdf332137935c8d99040071209a9L19-R19) [[2]](diffhunk://#diff-3c7a7287ff55f34cfa6c348791e6cb1e9a1acec2c726159c9c3927d8de1a57feR79) [[3]](diffhunk://#diff-754e615fdb005a64d33b13c1bf2799ebf870e82425b7d9c90aa62b8e49b37abbR766)
* Improved docblocks for magic methods in `CollectionDataProxy` for clarity in property and method forwarding.

**Pagination Improvements:**

* Annotated the `Pagination` class and its constructor with generics to ensure paginated collections retain type information. Updated the `Paginable` interface to reflect these changes. [[1]](diffhunk://#diff-dad7a1881aaab3dfd250838da302897b2fe6dfb67af2c054eb9436af667f345eR26) [[2]](diffhunk://#diff-8910dfd71e1fc7e17df369049dc06b19893873deb933780355c16c1e38f49bb0R8-R23)

**Logic and Code Style Adjustments:**

* Improved logic in `PageController` to avoid unnecessary double lookups when fetching files from parent pages.

These changes collectively enhance code reliability, maintainability, and developer experience by making type expectations explicit and improving documentation throughout the collection handling subsystem.