### PR TITLE
Add typed getters to `Config`

### DIFF
--- a/formwork/config/routes/routes.php
+++ b/formwork/config/routes/routes.php
@@ -67,7 +67,7 @@ return [
     'filters' => [
         'request.validateSize' => [
             'action' => static function (Config $config, Request $request, Router $router, ErrorsControllerInterface $errorsController) {
-                if ($config->get('system.panel.enabled') && $router->requestHasPrefix($config->get('system.panel.root'))) {
+                if ($config->getBool('system.panel.enabled') && $router->requestHasPrefix($config->getString('system.panel.root'))) {
                     return;
                 }
 
@@ -86,7 +86,7 @@ return [
 
         'request.validateCsrf' => [
             'action' => static function (Config $config, Request $request, Router $router, CsrfToken $csrfToken, ErrorsControllerInterface $errorsController) {
-                if ($config->get('system.panel.enabled') && $router->requestHasPrefix($config->get('system.panel.root'))) {
+                if ($config->getBool('system.panel.enabled') && $router->requestHasPrefix($config->getString('system.panel.root'))) {
                     // CSRF validation is handled by a separate filter in the panel routes
                     return;
                 }
@@ -113,7 +113,7 @@ return [
                     $router->setRequest(Str::removeStart($router->request(), '/' . $requested));
                 } elseif (($preferred = $site->languages()->preferred()) !== null) {
                     // Don't redirect if we are in Panel
-                    if ($config->get('system.panel.enabled') && $router->requestHasPrefix($config->get('system.panel.root'))) {
+                    if ($config->getBool('system.panel.enabled') && $router->requestHasPrefix($config->getString('system.panel.root'))) {
                         return;
                     }
                     return new RedirectResponse($request->root() . $preferred . $router->request());

--- a/formwork/config/views/methods.php
+++ b/formwork/config/views/methods.php
@@ -57,9 +57,9 @@ return function (App $app) {
                 [
                     'site'                 => $app->site(),
                     'baseRoute'            => $currentPage !== null ? $currentPage->route() : '/',
-                    'allowHtml'            => $app->config()->get('system.pages.content.allowHtml'),
-                    'addHeadingIds'        => $app->config()->get('system.pages.content.addHeadingIds'),
-                    'commonmarkExtensions' => $app->config()->get('system.pages.content.commonmarkExtensions', []),
+                    'allowHtml'            => $app->config()->getBool('system.pages.content.allowHtml'),
+                    'addHeadingIds'        => $app->config()->getBool('system.pages.content.addHeadingIds'),
+                    'commonmarkExtensions' => $app->config()->getArray('system.pages.content.commonmarkExtensions', []),
                 ]
             );
         },
@@ -70,7 +70,7 @@ return function (App $app) {
         'date' => static function (int $timestamp, ?string $format = null) use ($app): string {
             return Date::formatTimestamp(
                 $timestamp,
-                $format ?? $app->config()->get('system.date.dateFormat'),
+                $format ?? $app->config()->getString('system.date.dateFormat'),
                 $app->translations()->getCurrent()
             );
         },
@@ -79,7 +79,7 @@ return function (App $app) {
          * Formats a timestamp as a datetime string
          */
         'datetime' => static function (int $timestamp) use ($app): string {
-            return Date::formatTimestamp($timestamp, $app->config()->get('system.date.datetimeFormat'), $app->translations()->getCurrent());
+            return Date::formatTimestamp($timestamp, $app->config()->getString('system.date.datetimeFormat'), $app->translations()->getCurrent());
         },
 
         /**

--- a/formwork/fields/date.php
+++ b/formwork/fields/date.php
@@ -35,7 +35,10 @@ return function (App $app): array {
              * Return the field value as a timestamp
              */
             'toTimestamp' => function (Field $field) use ($app): ?int {
-                $formats = $app->config()->getMultiple(['system.date.dateFormat', 'system.date.datetimeFormat']);
+                $formats = [
+                    $app->config()->getString('system.date.dateFormat'),
+                    $app->config()->getString('system.date.datetimeFormat'),
+                ];
                 return $field->isEmpty() ? null : Date::toTimestamp($field->value(), $formats);
             },
 
@@ -100,8 +103,8 @@ return function (App $app): array {
                 }
 
                 $inputFormats = [
-                    $app->config()->get('system.date.dateFormat'),
-                    $app->config()->get('system.date.datetimeFormat'),
+                    $app->config()->getString('system.date.dateFormat'),
+                    $app->config()->getString('system.date.datetimeFormat'),
                 ];
 
                 $format = $field->hasTime()

--- a/formwork/fields/markdown.php
+++ b/formwork/fields/markdown.php
@@ -29,9 +29,9 @@ return function (App $app, Site $site) {
                     [
                         'site'                 => $site,
                         'baseRoute'            => $currentPage !== null ? $currentPage->route() : '/',
-                        'allowHtml'            => $app->config()->get('system.pages.content.allowHtml'),
-                        'addHeadingIds'        => $app->config()->get('system.pages.content.addHeadingIds'),
-                        'commonmarkExtensions' => $app->config()->get('system.pages.content.commonmarkExtensions', []),
+                        'allowHtml'            => $app->config()->getBool('system.pages.content.allowHtml'),
+                        'addHeadingIds'        => $app->config()->getBool('system.pages.content.addHeadingIds'),
+                        'commonmarkExtensions' => $app->config()->getArray('system.pages.content.commonmarkExtensions', []),
                     ]
                 );
             },

--- a/formwork/fields/upload.php
+++ b/formwork/fields/upload.php
@@ -16,7 +16,7 @@ return function (App $app) {
              * Return the accepted MIME types for the field
              */
             'acceptMimeTypes' => function (Field $field) use ($app) {
-                $allowedExtensions = $app->config()->get('system.files.allowedExtensions', '');
+                $allowedExtensions = $app->config()->getArray('system.files.allowedExtensions', []);
 
                 $accept = is_string($field->get('accept'))
                     ? preg_split('/\s*,\s*/', $field->get('accept'), flags: PREG_SPLIT_NO_EMPTY)
@@ -89,7 +89,7 @@ return function (App $app) {
                     return null;
                 }
 
-                $allowedExtensions = $app->config()->get('system.files.allowedExtensions', '');
+                $allowedExtensions = $app->config()->getArray('system.files.allowedExtensions', []);
                 $allowedMimeTypes = Arr::map($allowedExtensions, MimeType::fromExtension(...));
                 $acceptMimeTypes = $field->acceptMimeTypes();
 

--- a/formwork/src/Cms/App.php
+++ b/formwork/src/Cms/App.php
@@ -284,8 +284,8 @@ final class App
             ->alias('config');
 
         $container->define(ViewFactory::class)
-            ->parameter('resolutionPaths', fn(Config $config) => ['system' => $config->get('system.views.paths.system')])
-            ->parameter('methods', fn(Container $container, Config $config) => $container->call(require $config->get('system.views.methods.system')));
+            ->parameter('resolutionPaths', fn(Config $config) => ['system' => $config->getString('system.views.paths.system')])
+            ->parameter('methods', fn(Container $container, Config $config) => $container->call(require $config->getString('system.views.methods.system')));
 
         $container->define(ErrorsController::class)
             ->alias(ErrorsControllerInterface::class);
@@ -323,13 +323,13 @@ final class App
             ->alias('templates');
 
         $container->define(Statistics::class)
-            ->parameter('options', fn(Config $config) => $config->get('site.statistics'))
+            ->parameter('options', fn(Config $config) => $config->getArray('site.statistics'))
             ->parameter('translation', fn(Translations $translations) => $translations->getCurrent())
             ->alias('statistics');
 
         $container->define(FilesCache::class)
-            ->parameter('path', fn(Config $config) => $config->get('system.cache.path'))
-            ->parameter('defaultTtl', fn(Config $config) => $config->get('system.cache.time'))
+            ->parameter('path', fn(Config $config) => $config->getString('system.cache.path'))
+            ->parameter('defaultTtl', fn(Config $config) => $config->getInt('system.cache.time'))
             ->alias(AbstractCache::class)
             ->alias('cache');
 
@@ -376,14 +376,14 @@ final class App
     {
         $this->events()->dispatch(new RoutesBeforeLoadEvent($this->router()));
 
-        if ($this->config()->get('system.panel.enabled')) {
+        if ($this->config()->getBool('system.panel.enabled')) {
             $this->router()->loadFromFile(
-                $this->config()->get('system.routes.files.panel'),
-                Str::wrap($this->config()->get('system.panel.root'), '/')
+                $this->config()->getString('system.routes.files.panel'),
+                Str::wrap($this->config()->getString('system.panel.root'), '/')
             );
         }
 
-        $this->router()->loadFromFile($this->config()->get('system.routes.files.system'));
+        $this->router()->loadFromFile($this->config()->getString('system.routes.files.system'));
 
         $this->events()->dispatch(new RoutesAfterLoadEvent($this->router()));
     }

--- a/formwork/src/Cms/Site.php
+++ b/formwork/src/Cms/Site.php
@@ -270,8 +270,8 @@ class Site extends Model implements Stringable
         }
 
         $defaults = [
-            'charset'   => $this->config->get('system.charset'),
-            'generator' => $this->config->get('system.metadata.setGenerator') ? 'Formwork' : null,
+            'charset'   => $this->config->getString('system.charset'),
+            'generator' => $this->config->getBool('system.metadata.setGenerator') ? 'Formwork' : null,
         ];
 
         $data = array_filter([...$defaults, ...$this->data['metadata']]);
@@ -436,7 +436,7 @@ class Site extends Model implements Stringable
      */
     public function indexPage(): Page
     {
-        return $this->findPage($this->config->get('system.pages.index'))
+        return $this->findPage($this->config->getString('system.pages.index'))
             ?? throw new PageNotFoundException('Site index page not found');
     }
 
@@ -447,7 +447,7 @@ class Site extends Model implements Stringable
      */
     public function errorPage(): Page
     {
-        return $this->findPage($this->config->get('system.pages.error'))
+        return $this->findPage($this->config->getString('system.pages.error'))
             ?? throw new PageNotFoundException('Site error page not found');
     }
 
@@ -478,15 +478,15 @@ class Site extends Model implements Stringable
 
         $files = [];
 
-        $path = $this->config->get('system.files.paths.site');
+        $path = $this->config->getString('system.files.paths.site');
 
         if (FileSystem::isDirectory($path, assertExists: false)) {
             foreach (FileSystem::listFiles($path) as $file) {
                 $extension = '.' . FileSystem::extension($file);
-                if (Str::endsWith($file, $this->config->get('system.files.metadataExtension'))) {
+                if (Str::endsWith($file, $this->config->getString('system.files.metadataExtension'))) {
                     continue;
                 }
-                if (in_array($extension, $this->config->get('system.files.allowedExtensions'), true)) {
+                if (in_array($extension, $this->config->getArray('system.files.allowedExtensions', []), true)) {
                     $files[] = $this->app()->getService(FileFactory::class)->make(FileSystem::joinPaths($path, $file));
                 }
             }

--- a/formwork/src/Commands/BackupCommand.php
+++ b/formwork/src/Commands/BackupCommand.php
@@ -136,7 +136,7 @@ final class BackupCommand implements CommandInterface
      */
     private function getBackupper(?string $hostname = null): Backupper
     {
-        return new Backupper([...$this->app->config()->get('system.backup'), 'hostname' => $hostname ?? (gethostname() ?: 'local-cli')]);
+        return new Backupper([...$this->app->config()->getArray('system.backup'), 'hostname' => $hostname ?? (gethostname() ?: 'local-cli')]);
     }
 
     /**

--- a/formwork/src/Commands/CacheCommand.php
+++ b/formwork/src/Commands/CacheCommand.php
@@ -219,7 +219,7 @@ final class CacheCommand implements CommandInterface
      */
     private function imagesCacheStats(): void
     {
-        $path = $this->app->config()->get('system.images.processPath');
+        $path = $this->app->config()->getString('system.images.processPath');
         $items = iterator_to_array(FileSystem::listContents($path));
         $size = FileSystem::directorySize($path);
 
@@ -233,7 +233,7 @@ final class CacheCommand implements CommandInterface
      */
     private function pagesCacheStats(): void
     {
-        $path = $this->app->config()->get('system.cache.path');
+        $path = $this->app->config()->getString('system.cache.path');
         $items = iterator_to_array(FileSystem::listContents($path));
         $size = FileSystem::directorySize($path);
 
@@ -273,7 +273,7 @@ final class CacheCommand implements CommandInterface
      */
     private function clearImagesCache(): void
     {
-        $path = $this->app->config()->get('system.images.processPath');
+        $path = $this->app->config()->getString('system.images.processPath');
         FileSystem::delete($path, recursive: true);
         FileSystem::createDirectory($path, recursive: true);
     }

--- a/formwork/src/Commands/UpdatesCommand.php
+++ b/formwork/src/Commands/UpdatesCommand.php
@@ -203,7 +203,7 @@ final class UpdatesCommand implements CommandInterface
         }
         $this->climate->br();
 
-        if ($this->app->config()->get('system.cache.enabled')) {
+        if ($this->app->config()->getBool('system.cache.enabled')) {
             $this->climate->out('Clearing cache...');
             $this->app->getService(AbstractCache::class)->clear();
             $this->climate->br();
@@ -219,7 +219,7 @@ final class UpdatesCommand implements CommandInterface
      */
     private function getUpdater(array $config): Updater
     {
-        return new Updater([...$this->app->config()->get('system.updates'), ...$config], App::instance());
+        return new Updater([...$this->app->config()->getArray('system.updates'), ...$config], App::instance());
     }
 
     /**
@@ -227,7 +227,7 @@ final class UpdatesCommand implements CommandInterface
      */
     private function getBackupper(): Backupper
     {
-        return new Backupper([...$this->app->config()->get('system.backup'), 'hostname' => gethostname() ?: 'local-cli']);
+        return new Backupper([...$this->app->config()->getArray('system.backup'), 'hostname' => gethostname() ?: 'local-cli']);
     }
 
     /**

--- a/formwork/src/Config/Config.php
+++ b/formwork/src/Config/Config.php
@@ -10,6 +10,7 @@ use Formwork\Parsers\Yaml;
 use Formwork\Utils\Arr;
 use Formwork\Utils\FileSystem;
 use Formwork\Utils\Str;
+use UnexpectedValueException;
 
 class Config implements ArraySerializable
 {
@@ -62,6 +63,80 @@ class Config implements ArraySerializable
             throw new UnresolvedConfigException('Unresolved config');
         }
         return Arr::get($this->config, $key, $default);
+    }
+
+    /**
+     * Get a string value from the config
+     *
+     * @throws UnexpectedValueException If the config value is not a string
+     */
+    public function getString(string $key, ?string $default = null): string
+    {
+        $value = $this->get($key, $default);
+        if (!is_string($value)) {
+            throw new UnexpectedValueException(sprintf('Config value for key "%s" is not a string, got %s', $key, get_debug_type($value)));
+        }
+        return $value;
+    }
+
+    /**
+     * Get a boolean value from the config
+     *
+     * @throws UnexpectedValueException If the config value is not a boolean
+     */
+    public function getBool(string $key, ?bool $default = null): bool
+    {
+        $value = $this->get($key, $default);
+        if (!is_bool($value)) {
+            throw new UnexpectedValueException(sprintf('Config value for key "%s" is not a boolean, got %s', $key, get_debug_type($value)));
+        }
+        return $value;
+    }
+
+    /**
+     * Get an integer value from the config
+     *
+     * @throws UnexpectedValueException If the config value is not an integer
+     */
+    public function getInt(string $key, ?int $default = null): int
+    {
+        $value = $this->get($key, $default);
+        if (!is_int($value)) {
+            throw new UnexpectedValueException(sprintf('Config value for key "%s" is not an integer, got %s', $key, get_debug_type($value)));
+        }
+        return $value;
+    }
+
+    /**
+     * Get a float value from the config
+     *
+     * @throws UnexpectedValueException If the config value is not a float
+     */
+    public function getFloat(string $key, ?float $default = null): float
+    {
+        $value = $this->get($key, $default);
+        if (!is_float($value)) {
+            throw new UnexpectedValueException(sprintf('Config value for key "%s" is not a float, got %s', $key, get_debug_type($value)));
+        }
+        return $value;
+    }
+
+    /**
+     * Get an array value from the config
+     *
+     * @param ?array<mixed> $default
+     *
+     * @throws UnexpectedValueException If the config value is not an array
+     *
+     * @return array<mixed>
+     */
+    public function getArray(string $key, ?array $default = null): array
+    {
+        $value = $this->get($key, $default);
+        if (!is_array($value)) {
+            throw new UnexpectedValueException(sprintf('Config value for key "%s" is not an array, got %s', $key, get_debug_type($value)));
+        }
+        return $value;
     }
 
     /**

--- a/formwork/src/Controllers/AssetsController.php
+++ b/formwork/src/Controllers/AssetsController.php
@@ -21,7 +21,7 @@ final class AssetsController extends AbstractController
             return $this->redirect($this->router->rewrite(['type' => 'images']), ResponseStatus::MovedPermanently);
         }
 
-        $path = FileSystem::joinPaths($this->config->get('system.images.processPath'), $routeParams->get('id'), $routeParams->get('name'));
+        $path = FileSystem::joinPaths($this->config->getString('system.images.processPath'), $routeParams->get('id'), $routeParams->get('name'));
 
         if (FileSystem::isFile($path, assertExists: false)) {
             return new FileResponse($path, headers: ['Cache-Control' => 'private, max-age=31536000, immutable'], autoEtag: true, autoLastModified: true);
@@ -35,7 +35,7 @@ final class AssetsController extends AbstractController
      */
     public function template(RouteParams $routeParams): Response
     {
-        $path = FileSystem::joinPaths($this->config->get('system.templates.path'), 'assets', Path::resolve($routeParams->get('file'), '/', DIRECTORY_SEPARATOR));
+        $path = FileSystem::joinPaths($this->config->getString('system.templates.path'), 'assets', Path::resolve($routeParams->get('file'), '/', DIRECTORY_SEPARATOR));
 
         if (FileSystem::isFile($path, assertExists: false)) {
             $headers = $this->request->query()->has('v')

--- a/formwork/src/Controllers/ErrorsController.php
+++ b/formwork/src/Controllers/ErrorsController.php
@@ -22,7 +22,7 @@ final class ErrorsController extends AbstractController implements ErrorsControl
     {
         Response::cleanOutputBuffers();
 
-        if ($this->config->get('system.debug.enabled') || $this->request->isLocalhost()) {
+        if ($this->config->getBool('system.debug.enabled') || $this->request->isLocalhost()) {
             $data['throwable'] = $throwable;
             $data['stackTrace'] = $throwable !== null ? $this->getTrace($throwable) : [];
         }

--- a/formwork/src/Controllers/FilesController.php
+++ b/formwork/src/Controllers/FilesController.php
@@ -14,7 +14,7 @@ final class FilesController extends AbstractController
      */
     public function file(RouteParams $routeParams): Response
     {
-        $path = FileSystem::joinPaths($this->config->get('system.files.paths.site'), $routeParams->get('name'));
+        $path = FileSystem::joinPaths($this->config->getString('system.files.paths.site'), $routeParams->get('name'));
 
         if (FileSystem::isFile($path, assertExists: false)) {
             return new FileResponse($path);

--- a/formwork/src/Controllers/PageController.php
+++ b/formwork/src/Controllers/PageController.php
@@ -30,7 +30,7 @@ final class PageController extends AbstractController
      */
     public function load(RouteParams $routeParams, Statistics $statistics): Response
     {
-        $trackable = $this->config->get('site.statistics.enabled');
+        $trackable = $this->config->getBool('site.statistics.enabled');
 
         if ($this->site->get('maintenance.enabled') && !$this->app->panel()->isLoggedIn()) {
             $trackable = false;
@@ -44,7 +44,7 @@ final class PageController extends AbstractController
         }
 
         if (!isset($route)) {
-            $route = $routeParams->get('page', $this->config->get('system.pages.index'));
+            $route = $routeParams->get('page', $this->config->getString('system.pages.index'));
 
             if ($resolvedAlias = $this->site->resolveRouteAlias($route)) {
                 $route = $resolvedAlias;
@@ -69,7 +69,7 @@ final class PageController extends AbstractController
                 return $this->getPageResponse($this->site->errorPage());
             }
 
-            if ($this->config->get('system.cache.enabled') && ($page->fields()->has('publishDate') || $page->fields()->has('unpublishDate')) && (
+            if ($this->config->getBool('system.cache.enabled') && ($page->fields()->has('publishDate') || $page->fields()->has('unpublishDate')) && (
                 ($page->isPublished() && !$page->publishDate()->isEmpty() && !$this->site->modifiedSince($page->publishDate()->toTimestamp()))
                 || (!$page->isPublished() && !$page->unpublishDate()->isEmpty() && !$this->site->modifiedSince($page->unpublishDate()->toTimestamp()))
             )) {
@@ -91,7 +91,7 @@ final class PageController extends AbstractController
             $upperLevel = dirname((string) $route);
 
             if ($upperLevel === '.') {
-                $upperLevel = $this->config->get('system.pages.index');
+                $upperLevel = $this->config->getString('system.pages.index');
             }
 
             if (
@@ -130,7 +130,7 @@ final class PageController extends AbstractController
         // Use requested route as cache key to include parameters like pagination and tags
         $cacheKey = $this->router->request();
 
-        $cacheable = $this->config->get('system.cache.enabled')
+        $cacheable = $this->config->getBool('system.cache.enabled')
             && $this->isRequestCacheable()
             && $page->cacheable()
             && !$page->isErrorPage();

--- a/formwork/src/Fields/FieldFactory.php
+++ b/formwork/src/Fields/FieldFactory.php
@@ -63,7 +63,7 @@ final class FieldFactory
      */
     private function getFieldConfig(string $type, ?array $default = null): array
     {
-        $configPath = FileSystem::joinPaths($this->config->get('system.fields.path'), $type . '.php');
+        $configPath = FileSystem::joinPaths($this->config->getString('system.fields.path'), $type . '.php');
 
         if (!FileSystem::exists($configPath)) {
             if ($default !== null) {

--- a/formwork/src/Files/FileFactory.php
+++ b/formwork/src/Files/FileFactory.php
@@ -47,7 +47,7 @@ final class FileFactory
 
         $instance->setScheme($this->schemes->get($instance::SCHEME_IDENTIFIER));
 
-        $metadataFile = $path . $this->config->get('system.files.metadataExtension');
+        $metadataFile = $path . $this->config->getString('system.files.metadataExtension');
 
         $metadata = FileSystem::exists($metadataFile) ? Yaml::parseFile($metadataFile) : [];
 

--- a/formwork/src/Files/FileUriGenerator.php
+++ b/formwork/src/Files/FileUriGenerator.php
@@ -29,32 +29,32 @@ class FileUriGenerator
     {
         $path = $file->path();
 
-        if (Str::startsWith($path, FileSystem::normalizePath($this->config->get('system.files.paths.site')))) {
+        if (Str::startsWith($path, FileSystem::normalizePath($this->config->getString('system.files.paths.site')))) {
             $name = basename($path);
             $uriPath = $this->router->generate('files', compact('name'));
             return $this->site->uri($uriPath, includeLanguage: false);
         }
 
-        if (Str::startsWith($path, FileSystem::normalizePath($this->config->get('system.images.processPath')))) {
+        if (Str::startsWith($path, FileSystem::normalizePath($this->config->getString('system.images.processPath')))) {
             $id = basename(dirname($path));
             $name = basename($path);
             $uriPath = $this->router->generate('assets', ['type' => 'images', 'id' => $id, 'name' => $name]);
             return $this->site->uri($uriPath, includeLanguage: false);
         }
 
-        if (Str::startsWith($path, $contentPath = FileSystem::normalizePath($this->config->get('system.pages.path')))) {
+        if (Str::startsWith($path, $contentPath = FileSystem::normalizePath($this->config->getString('system.pages.path')))) {
             $uriPath = preg_replace('~[/\\\](\d+-)~', '/', Str::after(dirname($path), $contentPath))
                 ?? throw new RuntimeException(sprintf('Replacement failed with error: %s', preg_last_error_msg()));
             return $this->site->uri(Path::join([$uriPath, basename($path)]), includeLanguage: false);
         }
 
-        if (Str::startsWith($path, FileSystem::normalizePath($this->config->get('system.users.paths.images')))) {
+        if (Str::startsWith($path, FileSystem::normalizePath($this->config->getString('system.users.paths.images')))) {
             $image = basename($path);
             $uriPath = $this->router->generate('panel.users.images', compact('image'));
             return $this->site->uri($uriPath, includeLanguage: false);
         }
 
-        if (Str::startsWith($path, $panelAssetsPath = FileSystem::normalizePath($this->config->get('system.panel.paths.assets')))) {
+        if (Str::startsWith($path, $panelAssetsPath = FileSystem::normalizePath($this->config->getString('system.panel.paths.assets')))) {
             $uriPath = Str::after($path, $panelAssetsPath);
             return $this->site->uri(Path::join(['panel/assets/', $uriPath]), includeLanguage: false);
         }

--- a/formwork/src/Files/Services/FileUploader.php
+++ b/formwork/src/Files/Services/FileUploader.php
@@ -31,8 +31,8 @@ class FileUploader
         protected Config $config,
         protected FileFactory $fileFactory,
     ) {
-        $this->allowedMimeTypes = Arr::map($this->config->get('system.files.allowedExtensions'), fn(string $ext) => MimeType::fromExtension($ext));
-        $this->baseDestinations = $this->config->get('system.files.uploads.baseDestinations');
+        $this->allowedMimeTypes = Arr::map($this->config->getArray('system.files.allowedExtensions', []), fn(string $ext) => MimeType::fromExtension($ext));
+        $this->baseDestinations = $this->config->getArray('system.files.uploads.baseDestinations', []);
     }
 
     /**
@@ -89,7 +89,7 @@ class FileUploader
                 case 'image/webp':
                 case 'image/avif':
                     // Process JPEG, PNG, WebP and AVIF images according to system options (e.g. quality)
-                    if ($this->config->get('system.uploads.processImages') && !$file->info()->isAnimation()) {
+                    if ($this->config->getBool('system.uploads.processImages') && !$file->info()->isAnimation()) {
                         $file->save();
                     }
                     break;

--- a/formwork/src/Images/ImageFactory.php
+++ b/formwork/src/Images/ImageFactory.php
@@ -20,7 +20,7 @@ final class ImageFactory
         /**
          * @var array<string, mixed>
          */
-        $defaults = $this->config->get('system.images', []);
+        $defaults = $this->config->getArray('system.images', []);
 
         return new Image($path, [...$defaults, ...$options]);
     }

--- a/formwork/src/Pages/Page.php
+++ b/formwork/src/Pages/Page.php
@@ -770,7 +770,7 @@ class Page extends Model implements Stringable
 
                 $extension = '.' . FileSystem::extension($file);
 
-                if ($extension === $config->get('system.pages.content.extension')) {
+                if ($extension === $config->getString('system.pages.content.extension')) {
                     $language = '';
 
                     if (preg_match('/([a-z0-9]+)\.([a-z]+)/', $name, $matches)) {
@@ -789,10 +789,10 @@ class Page extends Model implements Stringable
                         }
                     }
                 } else {
-                    if (Str::endsWith($file, $config->get('system.files.metadataExtension'))) {
+                    if (Str::endsWith($file, $config->getString('system.files.metadataExtension'))) {
                         continue;
                     }
-                    if (in_array($extension, $config->get('system.files.allowedExtensions'), true)) {
+                    if (in_array($extension, $config->getArray('system.files.allowedExtensions', []), true)) {
                         $files[] = $this->app()->getService(FileFactory::class)->make(FileSystem::joinPaths($this->path, $file));
                     }
                 }
@@ -927,7 +927,7 @@ class Page extends Model implements Stringable
                 $filename .= ".{$language}";
             }
 
-            $filename .= $config->get('system.pages.content.extension');
+            $filename .= $config->getString('system.pages.content.extension');
 
             $fileContent = Str::wrap(Yaml::encode($frontmatter), '---' . PHP_EOL) . $content;
 
@@ -1052,7 +1052,7 @@ class Page extends Model implements Stringable
 
             if ($mode === 'date') {
                 $timestamp = isset($this->data['publishDate'])
-                    ? Date::toTimestamp($this->data['publishDate'], [$this->app()->config()->get('system.date.dateFormat'), $this->app()->config()->get('system.date.datetimeFormat')])
+                    ? Date::toTimestamp($this->data['publishDate'], [$this->app()->config()->getString('system.date.dateFormat'), $this->app()->config()->getString('system.date.datetimeFormat')])
                     : ($this->contentFile()?->lastModifiedTime() ?? time());
                 $num = (int) date(self::DATE_NUM_FORMAT, $timestamp);
             } elseif ($this->parent() === null) {

--- a/formwork/src/Pages/Traits/PageStatus.php
+++ b/formwork/src/Pages/Traits/PageStatus.php
@@ -32,7 +32,10 @@ trait PageStatus
 
         $now = time();
 
-        $formats = $this->app()->config()->getMultiple(['system.date.dateFormat', 'system.date.datetimeFormat']);
+        $formats = [
+            $this->app()->config()->getString('system.date.dateFormat'),
+            $this->app()->config()->getString('system.date.datetimeFormat'),
+        ];
 
         if ($publishDate = ($this->data['publishDate'] ?? null)) {
             if (!is_string($publishDate)) {

--- a/formwork/src/Panel/Controllers/AssetsController.php
+++ b/formwork/src/Panel/Controllers/AssetsController.php
@@ -16,7 +16,7 @@ final class AssetsController extends AbstractController
      */
     public function asset(RouteParams $routeParams): Response
     {
-        $path = FileSystem::joinPaths($this->config->get('system.panel.paths.assets'), $routeParams->get('type'), Path::resolve($routeParams->get('file'), '/', DIRECTORY_SEPARATOR));
+        $path = FileSystem::joinPaths($this->config->getString('system.panel.paths.assets'), $routeParams->get('type'), Path::resolve($routeParams->get('file'), '/', DIRECTORY_SEPARATOR));
 
         if (FileSystem::isFile($path, assertExists: false)) {
             $headers = (

--- a/formwork/src/Panel/Controllers/AuthenticationController.php
+++ b/formwork/src/Panel/Controllers/AuthenticationController.php
@@ -93,7 +93,7 @@ final class AuthenticationController extends AbstractController
 
             $this->events->dispatch(new PanelLoggedOutEvent($user));
 
-            if ($this->config->get('system.panel.logoutRedirect') === 'home') {
+            if ($this->config->getString('system.panel.logoutRedirect') === 'home') {
                 return $this->redirect('/');
             }
 

--- a/formwork/src/Panel/Controllers/BackupController.php
+++ b/formwork/src/Panel/Controllers/BackupController.php
@@ -24,7 +24,7 @@ final class BackupController extends AbstractController
             return $this->forward(ErrorsController::class, 'forbidden');
         }
 
-        $backupper = new Backupper([...$this->config->get('system.backup'), 'hostname' => $this->request->host()]);
+        $backupper = new Backupper([...$this->config->getArray('system.backup'), 'hostname' => $this->request->host()]);
         try {
             $file = $backupper->backup();
         } catch (TranslatedException $e) {
@@ -35,10 +35,10 @@ final class BackupController extends AbstractController
         return JsonResponse::success($this->translate('panel.backup.ready'), data: [
             'filename'  => $filename,
             'uri'       => $this->panel->uri("/backup/download/{$uriName}/"),
-            'date'      => Date::formatTimestamp(FileSystem::lastModifiedTime($file), $this->config->get('system.date.datetimeFormat'), $this->translations->getCurrent()),
+            'date'      => Date::formatTimestamp(FileSystem::lastModifiedTime($file), $this->config->getString('system.date.datetimeFormat'), $this->translations->getCurrent()),
             'size'      => FileSystem::formatSize(FileSystem::size($file)),
             'deleteUri' => $this->panel->uri("/backup/delete/{$uriName}/"),
-            'maxFiles'  => $this->config->get('system.backup.maxFiles'),
+            'maxFiles'  => $this->config->getInt('system.backup.maxFiles'),
         ]);
     }
 
@@ -51,7 +51,7 @@ final class BackupController extends AbstractController
             return $this->forward(ErrorsController::class, 'forbidden');
         }
 
-        $file = FileSystem::joinPaths($this->config->get('system.backup.path'), basename(base64_decode((string) $routeParams->get('backup'))));
+        $file = FileSystem::joinPaths($this->config->getString('system.backup.path'), basename(base64_decode((string) $routeParams->get('backup'))));
         try {
             if (FileSystem::isFile($file, assertExists: false)) {
                 return new FileResponse($file, download: true);
@@ -72,7 +72,7 @@ final class BackupController extends AbstractController
             return $this->forward(ErrorsController::class, 'forbidden');
         }
 
-        $file = FileSystem::joinPaths($this->config->get('system.backup.path'), basename(base64_decode((string) $routeParams->get('backup'))));
+        $file = FileSystem::joinPaths($this->config->getString('system.backup.path'), basename(base64_decode((string) $routeParams->get('backup'))));
         try {
             if (FileSystem::isFile($file, assertExists: false)) {
                 FileSystem::delete($file);

--- a/formwork/src/Panel/Controllers/CacheController.php
+++ b/formwork/src/Panel/Controllers/CacheController.php
@@ -35,7 +35,7 @@ final class CacheController extends AbstractController
             case 'default':
                 $this->clearCaches([
                     'pages'  => true,
-                    'images' => $this->config->get('system.images.clearCacheByDefault'),
+                    'images' => $this->config->getBool('system.images.clearCacheByDefault'),
                 ]);
                 return JsonResponse::success($this->translate('panel.cache.cleared'), data: compact('type'));
             case 'all':
@@ -97,7 +97,7 @@ final class CacheController extends AbstractController
      */
     private function clearImagesCache(): void
     {
-        $path = $this->config->get('system.images.processPath');
+        $path = $this->config->getString('system.images.processPath');
         FileSystem::delete($path, recursive: true);
         FileSystem::createDirectory($path, recursive: true);
     }

--- a/formwork/src/Panel/Controllers/ErrorsController.php
+++ b/formwork/src/Panel/Controllers/ErrorsController.php
@@ -68,7 +68,7 @@ final class ErrorsController extends AbstractController implements ErrorsControl
     {
         Response::cleanOutputBuffers();
 
-        if ($this->config->get('system.debug.enabled') || $this->request->isLocalhost()) {
+        if ($this->config->getBool('system.debug.enabled') || $this->request->isLocalhost()) {
             $data['throwable'] = $throwable;
             $data['stackTrace'] = $throwable !== null ? $this->getTrace($throwable) : [];
         }

--- a/formwork/src/Panel/Controllers/FilesController.php
+++ b/formwork/src/Panel/Controllers/FilesController.php
@@ -65,7 +65,7 @@ final class FilesController extends AbstractController
                 'size'             => $file->size(),
                 'lastModifiedTime' => Date::formatTimestamp(
                     $file->lastModifiedTime(),
-                    $this->config->get('system.date.datetimeFormat'),
+                    $this->config->getString('system.date.datetimeFormat'),
                     $this->translations->getCurrent()
                 ),
                 'type'      => $file->type(),
@@ -107,7 +107,7 @@ final class FilesController extends AbstractController
         }
 
         $destination = $parent instanceof Site
-            ? $this->config->get('system.files.paths.site')
+            ? $this->config->getString('system.files.paths.site')
             : $parent->contentPath();
 
         try {
@@ -275,7 +275,7 @@ final class FilesController extends AbstractController
                 'size'             => $file->size(),
                 'lastModifiedTime' => Date::formatTimestamp(
                     $file->lastModifiedTime(),
-                    $this->config->get('system.date.datetimeFormat'),
+                    $this->config->getString('system.date.datetimeFormat'),
                     $this->translations->getCurrent()
                 ),
                 'type'      => $file->type(),
@@ -344,7 +344,7 @@ final class FilesController extends AbstractController
                 'size'             => $file->size(),
                 'lastModifiedTime' => Date::formatTimestamp(
                     $file->lastModifiedTime(),
-                    $this->config->get('system.date.datetimeFormat'),
+                    $this->config->getString('system.date.datetimeFormat'),
                     $this->translations->getCurrent()
                 ),
                 'type'      => $file->type(),
@@ -395,7 +395,7 @@ final class FilesController extends AbstractController
             Arr::undot($file->fields()->extract('default'))
         );
 
-        $metaFile = $file->path() . $this->config->get('system.files.metadataExtension');
+        $metaFile = $file->path() . $this->config->getString('system.files.metadataExtension');
 
         if ($data === [] && FileSystem::exists($metaFile)) {
             FileSystem::delete($metaFile);

--- a/formwork/src/Panel/Controllers/OptionsController.php
+++ b/formwork/src/Panel/Controllers/OptionsController.php
@@ -36,7 +36,7 @@ final class OptionsController extends AbstractController
         $scheme = $schemes->get('config.system');
         $fields = $scheme->fields();
 
-        $fields->setValues($this->config->get('system'));
+        $fields->setValues($this->config->getArray('system'));
 
         $form = $this->form('system-options', $fields)
             ->processRequest($this->request);
@@ -45,8 +45,8 @@ final class OptionsController extends AbstractController
             if (!$form->isValid()) {
                 $this->panel->notify($this->translate('panel.options.cannotUpdate.invalidFields'), 'error');
             } else {
-                $options = $this->getConfigOverrides()->get('system', []);
-                $defaults = $this->getConfigDefaults()->get('system');
+                $options = $this->getConfigOverrides()->getArray('system', []);
+                $defaults = $this->getConfigDefaults()->getArray('system');
 
                 $differ = $this->updateOptions('system', $form->data()->toArray(), $options, $defaults);
 
@@ -90,8 +90,8 @@ final class OptionsController extends AbstractController
             if (!$form->isValid()) {
                 $this->panel->notify($this->translate('panel.options.cannotUpdate.invalidFields'), 'error');
             } else {
-                $options = $this->getConfigOverrides()->get('site', []);
-                $defaults = $this->getConfigDefaults()->get('site');
+                $options = $this->getConfigOverrides()->getArray('site', []);
+                $defaults = $this->getConfigDefaults()->getArray('site');
                 $differ = $this->updateOptions('site', $form->data()->toArray(), $options, $defaults);
 
                 // Touch content folder to invalidate cache

--- a/formwork/src/Panel/Controllers/PagesController.php
+++ b/formwork/src/Panel/Controllers/PagesController.php
@@ -463,7 +463,7 @@ final class PagesController extends AbstractController
                 'size'             => $file->size(),
                 'lastModifiedTime' => Date::formatTimestamp(
                     $file->lastModifiedTime(),
-                    $this->config->get('system.date.datetimeFormat'),
+                    $this->config->getString('system.date.datetimeFormat'),
                     $this->translations->getCurrent()
                 ),
                 'type'      => $file->type(),

--- a/formwork/src/Panel/Controllers/PluginsController.php
+++ b/formwork/src/Panel/Controllers/PluginsController.php
@@ -69,7 +69,7 @@ final class PluginsController extends AbstractController
 
         $fields = $scheme->fields();
 
-        $fields->setValues($this->config->get("plugins.{$name}", []));
+        $fields->setValues($this->config->getArray("plugins.{$name}", []));
 
         $form = $this->form('plugin-options', $fields)
             ->processRequest($this->request);
@@ -146,7 +146,7 @@ final class PluginsController extends AbstractController
      */
     private function updatePluginsOptions(Plugin $plugin, array $options): void
     {
-        $options = Arr::override($this->config->get("plugins.{$plugin->name()}", []), Arr::undot($options));
+        $options = Arr::override($this->config->getArray("plugins.{$plugin->name()}", []), Arr::undot($options));
 
         if (!FileSystem::isDirectory(ROOT_PATH . '/site/config/plugins/', assertExists: false)) {
             FileSystem::createDirectory(ROOT_PATH . '/site/config/plugins/');

--- a/formwork/src/Panel/Controllers/ToolsController.php
+++ b/formwork/src/Panel/Controllers/ToolsController.php
@@ -40,7 +40,7 @@ final class ToolsController extends AbstractController
             return $this->forward(ErrorsController::class, 'forbidden');
         }
 
-        $backupper = new Backupper([...$this->config->get('system.backup'), 'hostname' => $this->request->host()]);
+        $backupper = new Backupper([...$this->config->getArray('system.backup'), 'hostname' => $this->request->host()]);
 
         $backups = Arr::map($backupper->getBackups(), fn(string $path, int $timestamp): array => [
             'name'        => basename($path),
@@ -100,7 +100,7 @@ final class ToolsController extends AbstractController
 
         $warnings = [];
 
-        if ($this->config->get('system.debug.enabled')) {
+        if ($this->config->getBool('system.debug.enabled')) {
             $warnings[] = 'Debug mode enabled, remember to turn it off in production';
         }
 

--- a/formwork/src/Panel/Controllers/UpdatesController.php
+++ b/formwork/src/Panel/Controllers/UpdatesController.php
@@ -49,8 +49,8 @@ final class UpdatesController extends AbstractController
             return $this->forward(ErrorsController::class, 'forbidden');
         }
 
-        if ($this->config->get('system.updates.backupBefore')) {
-            $backupper = new Backupper([...$this->config->get('system.backup'), 'hostname' => $this->request->host()]);
+        if ($this->config->getBool('system.updates.backupBefore')) {
+            $backupper = new Backupper([...$this->config->getArray('system.backup'), 'hostname' => $this->request->host()]);
             try {
                 $backupper->backup();
             } catch (TranslatedException) {
@@ -66,7 +66,7 @@ final class UpdatesController extends AbstractController
                 'status' => $this->translate('panel.updates.status.cannotInstall'),
             ]);
         }
-        if ($this->config->get('system.cache.enabled')) {
+        if ($this->config->getBool('system.cache.enabled')) {
             $cache->clear();
         }
         return JsonResponse::success($this->translate('panel.updates.installed'), data: [

--- a/formwork/src/Panel/Controllers/UsersController.php
+++ b/formwork/src/Panel/Controllers/UsersController.php
@@ -219,7 +219,7 @@ final class UsersController extends AbstractController
      */
     public function images(RouteParams $routeParams): Response
     {
-        $path = FileSystem::joinPaths($this->config->get('system.users.paths.images'), $routeParams->get('image'));
+        $path = FileSystem::joinPaths($this->config->getString('system.users.paths.images'), $routeParams->get('image'));
 
         if (FileSystem::isFile($path, assertExists: false)) {
             return new FileResponse($path, headers: ['Cache-Control' => 'private, max-age=31536000, immutable'], autoEtag: true, autoLastModified: true);
@@ -233,7 +233,7 @@ final class UsersController extends AbstractController
      */
     private function uploadUserImage(Field $field): ?Image
     {
-        $imagesPath = FileSystem::joinPaths($this->config->get('system.users.paths.images'));
+        $imagesPath = FileSystem::joinPaths($this->config->getString('system.users.paths.images'));
 
         $files = $field->isMultiple() ? $field->value() : [$field->value()];
 
@@ -252,7 +252,7 @@ final class UsersController extends AbstractController
             return null;
         }
 
-        $userImageSize = $this->config->get('system.panel.userImageSize');
+        $userImageSize = $this->config->getInt('system.panel.userImageSize');
 
         // Square off uploaded image
         $file->square($userImageSize)->save();

--- a/formwork/src/Panel/Modals/ModalFactory.php
+++ b/formwork/src/Panel/Modals/ModalFactory.php
@@ -21,7 +21,7 @@ final class ModalFactory
      */
     public function make(string $id): Modal
     {
-        $path = FileSystem::joinPaths($this->config->get('system.panel.paths.modals'), $id . '.yaml');
+        $path = FileSystem::joinPaths($this->config->getString('system.panel.paths.modals'), $id . '.yaml');
 
         $data = FileSystem::exists($path) ? Yaml::parseFile($path) : [];
 

--- a/formwork/src/Panel/Panel.php
+++ b/formwork/src/Panel/Panel.php
@@ -69,7 +69,7 @@ final class Panel
      */
     public function path(): string
     {
-        return $this->config->get('system.panel.path');
+        return $this->config->getString('system.panel.path');
     }
 
     /**
@@ -85,7 +85,7 @@ final class Panel
      */
     public function panelRoot(): string
     {
-        return Uri::normalize(Str::append($this->config->get('system.panel.root'), '/'));
+        return Uri::normalize(Str::append($this->config->getString('system.panel.root'), '/'));
     }
 
     /**
@@ -122,7 +122,7 @@ final class Panel
         $translation = $this->translations->getCurrent();
 
         $this->navigation = NavigationItemCollection::fromArray(
-            $this->container->call(require $this->config->get('system.panel.config.navigation'), [
+            $this->container->call(require $this->config->getString('system.panel.config.navigation'), [
                 'translation' => $translation,
             ])
         );
@@ -233,7 +233,7 @@ final class Panel
             return $translations;
         }
 
-        $path = $this->config->get('system.translations.paths.panel');
+        $path = $this->config->getString('system.translations.paths.panel');
 
         foreach (FileSystem::listFiles($path) as $file) {
             if (FileSystem::extension($file) === 'yaml') {
@@ -262,7 +262,7 @@ final class Panel
      */
     public function getAppConfig(): array
     {
-        return $this->container->call(require $this->config->get('system.panel.config.app'), [
+        return $this->container->call(require $this->config->getString('system.panel.config.app'), [
             'translation' => $this->translations->getCurrent(),
         ]);
     }
@@ -274,6 +274,6 @@ final class Panel
     {
         return $this->isLoggedIn()
             ? $this->user()->colorScheme()
-            : ColorScheme::from($this->config->get('system.panel.colorScheme'));
+            : ColorScheme::from($this->config->getString('system.panel.colorScheme'));
     }
 }

--- a/formwork/src/Parsers/Extensions/CommonMark/ImageAltProcessor.php
+++ b/formwork/src/Parsers/Extensions/CommonMark/ImageAltProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Formwork\Parsers\Extensions\CommonMark;
 
+use Formwork\Cms\Site;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
 use League\Config\ConfigurationInterface;
@@ -19,12 +20,15 @@ class ImageAltProcessor
                 continue;
             }
 
+            /** @var string $baseRoute */
             $baseRoute = $this->configuration->get('formwork/baseRoute');
 
+            /** @var Site $site */
             $site = $this->configuration->get('formwork/site');
 
             $uri = $node->getUrl();
 
+            /** @var string $key */
             $key = $this->configuration->get('formwork/imageAltProperty');
 
             $alt = $site->findPage($baseRoute)?->files()->get($uri)?->get($key);

--- a/formwork/src/Plugins/Controllers/AssetsController.php
+++ b/formwork/src/Plugins/Controllers/AssetsController.php
@@ -29,7 +29,7 @@ final class AssetsController extends AbstractController
      */
     public function asset(RouteParams $routeParams): Response
     {
-        $path = FileSystem::joinPaths($this->config->get('system.plugins.path'), $this->plugin->id(), 'assets', $routeParams->get('type'), Path::resolve($routeParams->get('file'), '/', DIRECTORY_SEPARATOR));
+        $path = FileSystem::joinPaths($this->config->getString('system.plugins.path'), $this->plugin->id(), 'assets', $routeParams->get('type'), Path::resolve($routeParams->get('file'), '/', DIRECTORY_SEPARATOR));
 
         if (FileSystem::isFile($path, assertExists: false)) {
             $headers = ($this->request->query()->has('v'))

--- a/formwork/src/Plugins/Plugin.php
+++ b/formwork/src/Plugins/Plugin.php
@@ -114,7 +114,7 @@ class Plugin implements Arrayable
      */
     final public function isEnabled(): bool
     {
-        return $this->app->config()->get("plugins.{$this->name()}.enabled", false);
+        return $this->app->config()->getBool("plugins.{$this->name()}.enabled", false);
     }
 
     /**
@@ -177,6 +177,7 @@ class Plugin implements Arrayable
     {
         $manifestPath = FileSystem::joinPaths($this->path, 'plugin.yaml');
 
+        /** @var array<string, mixed> $data */
         $data = FileSystem::isFile($manifestPath, assertExists: false)
             ? Yaml::parseFile($manifestPath)
             : [];

--- a/formwork/src/Plugins/Plugins.php
+++ b/formwork/src/Plugins/Plugins.php
@@ -71,7 +71,7 @@ class Plugins extends PluginCollection
                 throw new UnexpectedValueException('Unexpected non-string plugin name');
             }
 
-            if (!$this->config->get("plugins.{$name}.enabled")) {
+            if (!$this->config->getBool("plugins.{$name}.enabled")) {
                 continue;
             }
 

--- a/formwork/src/Plugins/Plugins.php
+++ b/formwork/src/Plugins/Plugins.php
@@ -71,7 +71,7 @@ class Plugins extends PluginCollection
                 throw new UnexpectedValueException('Unexpected non-string plugin name');
             }
 
-            if (!$this->config->getBool("plugins.{$name}.enabled")) {
+            if (!$this->config->getBool("plugins.{$name}.enabled", false)) {
                 continue;
             }
 

--- a/formwork/src/Services/Loaders/AssetsServiceLoader.php
+++ b/formwork/src/Services/Loaders/AssetsServiceLoader.php
@@ -31,7 +31,7 @@ final class AssetsServiceLoader implements ResolutionAwareServiceLoaderInterface
         // Configure template assets namespace
         $service->setResolutionPaths([
             'template' => [
-                'path' => $this->config->get('system.templates.path') . '/assets',
+                'path' => $this->config->getString('system.templates.path') . '/assets',
                 'uri'  => $this->site->uri('/site/templates/assets/', includeLanguage: false),
             ],
         ]);

--- a/formwork/src/Services/Loaders/AuthenticationServiceLoader.php
+++ b/formwork/src/Services/Loaders/AuthenticationServiceLoader.php
@@ -22,9 +22,9 @@ class AuthenticationServiceLoader implements ServiceLoaderInterface
     public function load(Container $container): Authenticator
     {
         $container->define(RateLimiter::class)
-            ->parameter('registry', new Registry(FileSystem::joinPaths($this->config->get('system.authentication.registryPath'), 'accessAttempts.json')))
-            ->parameter('limit', $this->config->get('system.authentication.limits.maxAttempts'))
-            ->parameter('resetTime', $this->config->get('system.authentication.limits.resetTime'));
+            ->parameter('registry', new Registry(FileSystem::joinPaths($this->config->getString('system.authentication.registryPath'), 'accessAttempts.json')))
+            ->parameter('limit', $this->config->getInt('system.authentication.limits.maxAttempts'))
+            ->parameter('resetTime', $this->config->getInt('system.authentication.limits.resetTime'));
 
         return $container->build(Authenticator::class);
     }

--- a/formwork/src/Services/Loaders/ConfigServiceLoader.php
+++ b/formwork/src/Services/Loaders/ConfigServiceLoader.php
@@ -47,10 +47,10 @@ final class ConfigServiceLoader implements ServiceLoaderInterface
             }
         }
 
-        date_default_timezone_set($config->get('system.date.timezone'));
+        date_default_timezone_set($config->getString('system.date.timezone'));
 
-        $this->request->session()->setPath($config->get('system.session.path'));
-        $this->request->session()->setDuration($config->get('system.session.duration'));
+        $this->request->session()->setPath($config->getString('system.session.path'));
+        $this->request->session()->setDuration($config->getInt('system.session.duration'));
 
         return $config;
     }

--- a/formwork/src/Services/Loaders/LoggerServiceLoader.php
+++ b/formwork/src/Services/Loaders/LoggerServiceLoader.php
@@ -27,7 +27,7 @@ final class LoggerServiceLoader implements ServiceLoaderInterface
     public function load(Container $container): Logger
     {
         $logger = $container->build(Logger::class);
-        foreach ($this->config->get('system.logs.handlers', []) as $handlerConfig) {
+        foreach ($this->config->getArray('system.logs.handlers', []) as $handlerConfig) {
             $logger->addHandler($this->buildHandler($handlerConfig));
         }
 

--- a/formwork/src/Services/Loaders/PanelServiceLoader.php
+++ b/formwork/src/Services/Loaders/PanelServiceLoader.php
@@ -49,19 +49,19 @@ final class PanelServiceLoader implements ResolutionAwareServiceLoaderInterface
             }
 
             $container->define(RateLimiter::class)
-                ->parameter('registry', new Registry(FileSystem::joinPaths($this->config->get('system.authentication.registryPath'), 'accessAttempts.json')))
-                ->parameter('limit', $this->config->get('system.panel.loginAttempts', $this->config->get('system.authentication.limits.maxAttempts')))
-                ->parameter('resetTime', $this->config->get('system.panel.loginResetTime', $this->config->get('system.authentication.limits.resetTime')));
+                ->parameter('registry', new Registry(FileSystem::joinPaths($this->config->getString('system.authentication.registryPath'), 'accessAttempts.json')))
+                ->parameter('limit', $this->config->getInt('system.panel.loginAttempts', $this->config->getInt('system.authentication.limits.maxAttempts')))
+                ->parameter('resetTime', $this->config->getInt('system.panel.loginResetTime', $this->config->getInt('system.authentication.limits.resetTime')));
 
             $container->resolve(RateLimiter::class);
         }
 
         $container->define(Updater::class)
-            ->parameter('options', $this->config->get('system.updates'));
+            ->parameter('options', $this->config->getArray('system.updates'));
 
         if ($this->config->has('system.panel.sessionTimeout')) {
             trigger_error('The "system.panel.sessionTimeout" configuration option (in minutes) is deprecated since Formwork 2.3.0. Use "system.session.duration" (in seconds) instead.', E_USER_DEPRECATED);
-            $this->request->session()->setDuration($this->config->get('system.panel.sessionTimeout') * 60);
+            $this->request->session()->setDuration($this->config->getInt('system.panel.sessionTimeout') * 60);
         }
 
         $container->define(ModalFactory::class);
@@ -77,17 +77,17 @@ final class PanelServiceLoader implements ResolutionAwareServiceLoaderInterface
      */
     public function onResolved(object $service, Container $container): void
     {
-        $this->viewFactory->setResolutionPaths(['panel' => $this->config->get('system.views.paths.panel')]);
-        $this->viewFactory->setMethods($container->call(require $this->config->get('system.views.methods.panel')));
+        $this->viewFactory->setResolutionPaths(['panel' => $this->config->getString('system.views.paths.panel')]);
+        $this->viewFactory->setMethods($container->call(require $this->config->getString('system.views.methods.panel')));
 
         $this->assets->setResolutionPaths(['panel' => [
-            'path' => $this->config->get('system.panel.paths.assets'),
+            'path' => $this->config->getString('system.panel.paths.assets'),
             'uri'  => $service->uri('/assets/'),
         ]]);
 
-        $this->schemes->loadFromPath($this->config->get('system.schemes.paths.panel'));
+        $this->schemes->loadFromPath($this->config->getString('system.schemes.paths.panel'));
 
-        $this->translations->loadFromPath($this->config->get('system.translations.paths.panel'));
+        $this->translations->loadFromPath($this->config->getString('system.translations.paths.panel'));
 
         // Resolve site to avoid panel language to be changed after
         $container->get(Site::class);
@@ -95,7 +95,7 @@ final class PanelServiceLoader implements ResolutionAwareServiceLoaderInterface
         if ($service->isLoggedIn()) {
             $this->translations->setCurrent($service->user()->language());
         } else {
-            $this->translations->setCurrent($this->config->get('system.panel.translation'));
+            $this->translations->setCurrent($this->config->getString('system.panel.translation'));
         }
 
         if ($service->isLoggedIn()) {

--- a/formwork/src/Services/Loaders/PluginsServiceLoader.php
+++ b/formwork/src/Services/Loaders/PluginsServiceLoader.php
@@ -31,11 +31,11 @@ final class PluginsServiceLoader implements ResolutionAwareServiceLoaderInterfac
      */
     public function onResolved(object $service, Container $container): void
     {
-        if (!$this->config->get('system.plugins.enabled')) {
+        if (!$this->config->getBool('system.plugins.enabled')) {
             return;
         }
 
-        $pluginsPath = $this->config->get('system.plugins.path');
+        $pluginsPath = $this->config->getString('system.plugins.path');
 
         if (!FileSystem::isDirectory($pluginsPath, assertExists: false)) {
             return;

--- a/formwork/src/Services/Loaders/SchemesServiceLoader.php
+++ b/formwork/src/Services/Loaders/SchemesServiceLoader.php
@@ -22,7 +22,7 @@ final class SchemesServiceLoader implements ResolutionAwareServiceLoaderInterfac
 
         $container->define(FieldFactory::class);
 
-        DynamicFieldValue::$varsLoader = fn() => $container->call(require $this->config->get('system.fields.dynamic.vars.file'));
+        DynamicFieldValue::$varsLoader = fn() => $container->call(require $this->config->getString('system.fields.dynamic.vars.file'));
 
         return $container->build(Schemes::class);
     }
@@ -32,7 +32,7 @@ final class SchemesServiceLoader implements ResolutionAwareServiceLoaderInterfac
      */
     public function onResolved(object $service, Container $container): void
     {
-        $service->loadFromPath($this->config->get('system.schemes.paths.system'));
-        $service->loadFromPath($this->config->get('system.schemes.paths.site'));
+        $service->loadFromPath($this->config->getString('system.schemes.paths.system'));
+        $service->loadFromPath($this->config->getString('system.schemes.paths.site'));
     }
 }

--- a/formwork/src/Services/Loaders/SiteServiceLoader.php
+++ b/formwork/src/Services/Loaders/SiteServiceLoader.php
@@ -15,11 +15,11 @@ final class SiteServiceLoader implements ResolutionAwareServiceLoaderInterface
 
     public function load(Container $container): Site
     {
-        $config = $this->config->get('site');
+        $config = $this->config->getArray('site');
 
         return $container->build(Site::class, ['data' => [
             ...$config,
-            'contentPath' => $this->config->get('system.pages.path'),
+            'contentPath' => $this->config->getString('system.pages.path'),
         ]]);
     }
 

--- a/formwork/src/Services/Loaders/TemplatesServiceLoader.php
+++ b/formwork/src/Services/Loaders/TemplatesServiceLoader.php
@@ -18,7 +18,7 @@ final class TemplatesServiceLoader implements ServiceLoaderInterface
 
     public function load(Container $container): Templates
     {
-        $path = $this->config->get('system.templates.path');
+        $path = $this->config->getString('system.templates.path');
 
         $templates = [];
 

--- a/formwork/src/Services/Loaders/TranslationsServiceLoader.php
+++ b/formwork/src/Services/Loaders/TranslationsServiceLoader.php
@@ -24,10 +24,10 @@ final class TranslationsServiceLoader implements ResolutionAwareServiceLoaderInt
      */
     public function onResolved(object $service, Container $container): void
     {
-        $service->loadFromPath($this->config->get('system.translations.paths.system'));
+        $service->loadFromPath($this->config->getString('system.translations.paths.system'));
 
-        if (FileSystem::isDirectory($this->config->get('system.translations.paths.site'), assertExists: false)) {
-            $service->loadFromPath($this->config->get('system.translations.paths.site'));
+        if (FileSystem::isDirectory($this->config->getString('system.translations.paths.site'), assertExists: false)) {
+            $service->loadFromPath($this->config->getString('system.translations.paths.site'));
         }
     }
 }

--- a/formwork/src/Services/Loaders/UsersServiceLoader.php
+++ b/formwork/src/Services/Loaders/UsersServiceLoader.php
@@ -42,7 +42,7 @@ final class UsersServiceLoader implements ResolutionAwareServiceLoaderInterface
 
     private function loadRoles(): void
     {
-        foreach (FileSystem::listFiles($path = $this->config->get('system.users.paths.roles')) as $file) {
+        foreach (FileSystem::listFiles($path = $this->config->getString('system.users.paths.roles')) as $file) {
             /**
              * @var array{title: string, permissions?: array<string, bool>}
              */
@@ -55,7 +55,7 @@ final class UsersServiceLoader implements ResolutionAwareServiceLoaderInterface
 
     private function loadUsers(): void
     {
-        foreach (FileSystem::listFiles($path = $this->config->get('system.users.paths.accounts')) as $file) {
+        foreach (FileSystem::listFiles($path = $this->config->getString('system.users.paths.accounts')) as $file) {
             /**
              * @var array{username: string, fullname: string, hash: string, email: string, language: string, role?: string, image?: string, colorScheme?: string}
              */

--- a/formwork/src/Templates/TemplateFactory.php
+++ b/formwork/src/Templates/TemplateFactory.php
@@ -22,7 +22,7 @@ final class TemplateFactory
      */
     public function make(string $name): Template
     {
-        $path = $this->config->get('system.templates.path');
+        $path = $this->config->getString('system.templates.path');
 
         return $this->container->build(Template::class, [
             'name'    => $name,

--- a/formwork/src/Translations/Translations.php
+++ b/formwork/src/Translations/Translations.php
@@ -89,7 +89,7 @@ class Translations
 
         $translation = new Translation($code, $data);
 
-        if (($this->config->get('system.translations.fallback')) !== $code) {
+        if (($this->config->getString('system.translations.fallback')) !== $code) {
             $translation->setFallback($this->getFallback());
         }
 
@@ -153,7 +153,7 @@ class Translations
      */
     public function getFallback(): Translation
     {
-        $fallbackCode = $this->config->get('system.translations.fallback');
+        $fallbackCode = $this->config->getString('system.translations.fallback');
         return $this->get($fallbackCode);
     }
 }

--- a/formwork/src/Users/User.php
+++ b/formwork/src/Users/User.php
@@ -86,7 +86,7 @@ class User extends Model
             return $this->image;
         }
 
-        $path = FileSystem::joinPaths($this->config->get('system.users.paths.images'), (string) ($this->data['image'] ?? null));
+        $path = FileSystem::joinPaths($this->config->getString('system.users.paths.images'), (string) ($this->data['image'] ?? null));
 
         if (!FileSystem::isFile($path, assertExists: false)) {
             return $this->image = null;
@@ -281,7 +281,7 @@ class User extends Model
             throw new LogicException('Cannot save a user with no username assigned');
         }
 
-        Yaml::encodeToFile($this->data, FileSystem::joinPaths($this->config->get('system.users.paths.accounts'), $this->username() . '.yaml'));
+        Yaml::encodeToFile($this->data, FileSystem::joinPaths($this->config->getString('system.users.paths.accounts'), $this->username() . '.yaml'));
     }
 
     /**
@@ -294,7 +294,7 @@ class User extends Model
         }
 
         // Delete user file
-        FileSystem::delete(FileSystem::joinPaths($this->config->get('system.users.paths.accounts'), $this->username() . '.yaml'));
+        FileSystem::delete(FileSystem::joinPaths($this->config->getString('system.users.paths.accounts'), $this->username() . '.yaml'));
 
         // Delete user image if exists
         if ($this->image() !== null) {
@@ -334,7 +334,7 @@ class User extends Model
     protected function setImage(string|Image|null $image): void
     {
         if ($image instanceof Image) {
-            $imagesPath = FileSystem::joinPaths($this->config->get('system.users.paths.images'));
+            $imagesPath = FileSystem::joinPaths($this->config->getString('system.users.paths.images'));
 
             if (!Str::startsWith($image->path(), $imagesPath)) {
                 throw new LogicException('User image must be located in the user images directory');

--- a/formwork/views/errors/partials/debug.php
+++ b/formwork/views/errors/partials/debug.php
@@ -4,8 +4,8 @@
     <?php foreach ($stackTrace as $i => $frame) : ?>
         <?php if (isset($frame['file'], $frame['line'])): ?>
             <details <?= $this->attr(['open' => $i === 0]) ?>>
-                <summary><a class="error-debug-editor-uri" href="<?= Formwork\Utils\Str::interpolate($app->config()->get('system.debug.editorUri'), ['filename' => $frame['file'], 'line' => $frame['line']]) ?>"><span class="error-debug-filename"><?= preg_replace('/([^\/]+)$/', '<strong>$1</strong>', $frame['file']) ?></span><span class="error-debug-line">:<?= $frame['line'] ?></span></a></summary>
-                <?php Formwork\Debug\CodeDumper::dumpBacktraceFrame($frame, $app->config()->get('system.debug.contextLines', 5)) ?>
+                <summary><a class="error-debug-editor-uri" href="<?= Formwork\Utils\Str::interpolate($app->config()->getString('system.debug.editorUri'), ['filename' => $frame['file'], 'line' => $frame['line']]) ?>"><span class="error-debug-filename"><?= preg_replace('/([^\/]+)$/', '<strong>$1</strong>', $frame['file']) ?></span><span class="error-debug-line">:<?= $frame['line'] ?></span></a></summary>
+                <?php Formwork\Debug\CodeDumper::dumpBacktraceFrame($frame, $app->config()->getInt('system.debug.contextLines', 5)) ?>
             </details>
         <?php endif ?>
     <?php endforeach ?>

--- a/panel/config/app.php
+++ b/panel/config/app.php
@@ -13,9 +13,9 @@ return fn(Site $site, Panel $panel, CsrfToken $csrfToken, Config $config, Transl
     'csrfToken'   => $csrfToken->get($panel->getCsrfTokenName()),
     'colorScheme' => $panel->compatibleColorSchemes(),
     'DateInput'   => [
-        'weekStarts'     => $config->get('system.date.weekStarts'),
-        'dateFormat'     => Date::formatToPattern($config->get('system.date.dateFormat')),
-        'dateTimeFormat' => Date::formatToPattern($config->get('system.date.datetimeFormat')),
+        'weekStarts'     => $config->getInt('system.date.weekStarts'),
+        'dateFormat'     => Date::formatToPattern($config->getString('system.date.dateFormat')),
+        'dateTimeFormat' => Date::formatToPattern($config->getString('system.date.datetimeFormat')),
         'time'           => true,
         'labels'         => [
             'today'      => $translation->translate('date.today'),

--- a/panel/config/routes/routes.php
+++ b/panel/config/routes/routes.php
@@ -359,7 +359,7 @@ return [
 
         'panel.checkAssets' => [
             'action' => static function (Config $config, ViewFactory $viewFactory) {
-                $path = $config->get('system.panel.paths.assets');
+                $path = $config->getString('system.panel.paths.assets');
                 $assets = ['css/panel.min.css', 'js/app.min.js'];
 
                 foreach ($assets as $asset) {

--- a/panel/views/errors/error.php
+++ b/panel/views/errors/error.php
@@ -32,8 +32,8 @@
                     <?php foreach ($stackTrace as $i => $frame) : ?>
                         <?php if (isset($frame['file'], $frame['line'])): ?>
                             <details <?= $this->attr(['open' => $i === 0]) ?>>
-                                <summary><a class="error-debug-editor-uri" href="<?= Formwork\Utils\Str::interpolate($app->config()->get('system.debug.editorUri'), ['filename' => $frame['file'], 'line' => $frame['line']]) ?>"><span class="error-debug-filename"><?= preg_replace('/([^\/]+)$/', '<strong>$1</strong>', $frame['file']) ?></span><span class="error-debug-line">:<?= $frame['line'] ?></span></a></summary>
-                                <?php Formwork\Debug\CodeDumper::dumpBacktraceFrame($frame, $app->config()->get('system.debug.contextLines', 5)) ?>
+                                <summary><a class="error-debug-editor-uri" href="<?= Formwork\Utils\Str::interpolate($app->config()->getString('system.debug.editorUri'), ['filename' => $frame['file'], 'line' => $frame['line']]) ?>"><span class="error-debug-filename"><?= preg_replace('/([^\/]+)$/', '<strong>$1</strong>', $frame['file']) ?></span><span class="error-debug-line">:<?= $frame['line'] ?></span></a></summary>
+                                <?php Formwork\Debug\CodeDumper::dumpBacktraceFrame($frame, $app->config()->getInt('system.debug.contextLines', 5)) ?>
                             </details>
                         <?php endif ?>
                     <?php endforeach ?>

--- a/panel/views/fields/upload.php
+++ b/panel/views/fields/upload.php
@@ -11,7 +11,7 @@
                 'class'            => $this->classes(['form-input', 'form-input-upload', 'is-invalid' => ($field->isValidated() && !$field->isValid()), $field->get('class')]),
                 'id'               => $field->name(),
                 'name'             => $field->formName() . ($field->get('multiple') ? '[]' : ''),
-                'accept'           => $field->get('accept', implode(', ', $app->config()->get('system.files.allowedExtensions'))),
+                'accept'           => $field->get('accept', implode(', ', $app->config()->getArray('system.files.allowedExtensions', []))),
                 'multiple'         => $field->get('multiple'),
                 'required'         => false,
                 'disabled'         => $field->isDisabled(),


### PR DESCRIPTION
This pull request refactors how configuration values are accessed throughout the codebase to use type-specific getter methods (such as `getBool`, `getString`, `getInt`, and `getArray`) instead of the generic `get` method. This change improves type safety, clarity, and reduces the risk of runtime errors due to unexpected value types. The update touches many files across the application, especially in routing, field processing, view rendering, file handling, and command-line utilities.

**Configuration Access Refactoring**

* Replaced generic `get` calls with type-specific methods (`getBool`, `getString`, `getInt`, `getArray`) in route filters, view methods, and field definitions for more robust type handling. (`formwork/config/routes/routes.php`, `formwork/config/views/methods.php`, `formwork/fields/date.php`, `formwork/fields/markdown.php`, `formwork/fields/upload.php`) [[1]](diffhunk://#diff-5f5e47018abf0b341d993eaf1f584b2431318bc0320977eb7e85a36f45986af0L70-R70) [[2]](diffhunk://#diff-5f5e47018abf0b341d993eaf1f584b2431318bc0320977eb7e85a36f45986af0L89-R89) [[3]](diffhunk://#diff-5f5e47018abf0b341d993eaf1f584b2431318bc0320977eb7e85a36f45986af0L116-R116) [[4]](diffhunk://#diff-17d43fbea61c1dbeaec3ffe52832b78baacd4e16ce4de8655aaec30961bc6a65L60-R62) [[5]](diffhunk://#diff-17d43fbea61c1dbeaec3ffe52832b78baacd4e16ce4de8655aaec30961bc6a65L73-R73) [[6]](diffhunk://#diff-17d43fbea61c1dbeaec3ffe52832b78baacd4e16ce4de8655aaec30961bc6a65L82-R82) [[7]](diffhunk://#diff-82169eec55f61308a159c4e78ccf81b552c4c57d412c60a6a46e9429b1ccbad4L38-R41) [[8]](diffhunk://#diff-82169eec55f61308a159c4e78ccf81b552c4c57d412c60a6a46e9429b1ccbad4L103-R107) [[9]](diffhunk://#diff-140e74beb76c7edd05391538be42b09e57e60f99b41acf19aa855aa17028323fL32-R34) [[10]](diffhunk://#diff-032ebc7d268b29ddefd89c2bc08e47d8492abfda8a0fdd3d666141f066a5113fL19-R19) [[11]](diffhunk://#diff-032ebc7d268b29ddefd89c2bc08e47d8492abfda8a0fdd3d666141f066a5113fL92-R92)

* Updated service container definitions and route loading in `App.php` to use type-specific config accessors, ensuring dependencies receive correctly typed configuration values. (`formwork/src/Cms/App.php`) [[1]](diffhunk://#diff-46157155d4e57fd657fd917e7ccbee85651c2ff8d498dbeb4c479c09d08a5966L287-R288) [[2]](diffhunk://#diff-46157155d4e57fd657fd917e7ccbee85651c2ff8d498dbeb4c479c09d08a5966L326-R332) [[3]](diffhunk://#diff-46157155d4e57fd657fd917e7ccbee85651c2ff8d498dbeb4c479c09d08a5966L379-R386)

**File and Metadata Handling**

* Changed file handling logic to use `getString` and `getArray` for paths and allowed extensions, preventing issues when non-string or non-array values are returned from configuration. (`formwork/src/Cms/Site.php`) [[1]](diffhunk://#diff-37d492248bf063a3470cbb7f9dff4937b3ea1d132a8148885a45d754f8f1b7d5L273-R274) [[2]](diffhunk://#diff-37d492248bf063a3470cbb7f9dff4937b3ea1d132a8148885a45d754f8f1b7d5L439-R439) [[3]](diffhunk://#diff-37d492248bf063a3470cbb7f9dff4937b3ea1d132a8148885a45d754f8f1b7d5L450-R450) [[4]](diffhunk://#diff-37d492248bf063a3470cbb7f9dff4937b3ea1d132a8148885a45d754f8f1b7d5L481-R489)

**CLI Command Improvements**

* Refactored backup, cache, and update commands to use type-specific config accessors, improving reliability and maintainability of command-line operations. (`formwork/src/Commands/BackupCommand.php`, `formwork/src/Commands/CacheCommand.php`, `formwork/src/Commands/UpdatesCommand.php`) [[1]](diffhunk://#diff-0297a20e117cdb1e20fd9a62e6410a9db877c48817333d62c9e14c51fc40f490L139-R139) [[2]](diffhunk://#diff-cdf9f740933bfde00cc468889b51be67f0b018953d7933c81cb5ba4a0d1937a1L222-R222) [[3]](diffhunk://#diff-cdf9f740933bfde00cc468889b51be67f0b018953d7933c81cb5ba4a0d1937a1L236-R236) [[4]](diffhunk://#diff-cdf9f740933bfde00cc468889b51be67f0b018953d7933c81cb5ba4a0d1937a1L276-R276) [[5]](diffhunk://#diff-f888180db662c5e1abaeac7b0a17a61d8b03cf6b1e3e6df62ae7f481038602fdL206-R206) [[6]](diffhunk://#diff-f888180db662c5e1abaeac7b0a17a61d8b03cf6b1e3e6df62ae7f481038602fdL222-R230)

**General Improvements**

* Added missing import for `UnexpectedValueException` in `Config.php` to support stricter error handling. (`formwork/src/Config/Config.php`)

These changes collectively enhance the robustness and maintainability of configuration management throughout the codebase.