### PR TITLE
Refactor and improve cache system with PSR-16 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "symfony/yaml": "^7.0.3",
         "psr/container": "^2.0",
         "psr/event-dispatcher": "^1.0",
-        "psr/log": "^3.0"
+        "psr/log": "^3.0",
+        "psr/simple-cache": "^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9de25c42ff5ff8ba654dfc0a95c54957",
+    "content-hash": "644d621594aef5a1c0adcddaa672a1fc",
     "packages": [
         {
             "name": "dflydev/dot-access-data",

--- a/formwork/config/system.yaml
+++ b/formwork/config/system.yaml
@@ -25,8 +25,11 @@ backup:
 
 cache:
     enabled: false
-    path: '${%ROOT_PATH%}/cache/pages'
+    path: '${%ROOT_PATH%}/cache'
     time: 604800
+    namespaces:
+        pages:
+            handler: files
 
 charset: utf-8
 

--- a/formwork/src/Cache/AbstractCache.php
+++ b/formwork/src/Cache/AbstractCache.php
@@ -2,84 +2,168 @@
 
 namespace Formwork\Cache;
 
-abstract class AbstractCache
+use DateInterval;
+use DateTimeImmutable;
+use Formwork\Cache\Exceptions\InvalidKeyException;
+
+abstract class AbstractCache implements NamespacedCacheInterface
 {
+    public const string NAMESPACE_REGEX = '/^[a-z0-9]+$/';
+
+    public const string RESERVED_KEY_CHARACTERS = '{}()/\@:';
+
     /**
-     * Fetch cached resource
+     * Get the default time-to-live of cached items
      */
-    abstract public function fetch(string $key): mixed;
+    abstract public function defaultTtl(): int|DateInterval|null;
+
+    /**
+     * Fetch cached item
+     *
+     * @deprecated since 2.4.0 Use PSR-16 compatible get() method instead
+     */
+    public function fetch(string $key): mixed
+    {
+        trigger_error(sprintf('%s() is deprecated since Formwork 2.4.0. Use PSR-16 compatible get() method instead', __METHOD__), E_USER_DEPRECATED);
+        return $this->get($key);
+    }
+
+    /**
+     * Get cached item
+     *
+     * @template TDefault of mixed
+     *
+     * @param TDefault $default
+     *
+     * @throws InvalidKeyException If the key is not valid
+     *
+     * @return mixed|TDefault
+     */
+    abstract public function get(string $key, mixed $default = null): mixed;
 
     /**
      * Save data to cache
+     *
+     * @deprecated since 2.4.0 Use PSR-16 compatible set() method instead
      */
-    abstract public function save(string $key, mixed $value): void;
+    public function save(string $key, mixed $value, int|DateInterval|null $ttl = null): void
+    {
+        trigger_error(sprintf('%s() is deprecated since Formwork 2.4.0. Use PSR-16 compatible set() method instead', __METHOD__), E_USER_DEPRECATED);
+        $this->set($key, $value, $ttl);
+    }
 
     /**
-     * Delete cached resource
+     * Set data to cache
+     *
+     * @throws InvalidKeyException If the key is not valid
      */
-    abstract public function delete(string $key): void;
+    abstract public function set(string $key, mixed $value, int|DateInterval|null $ttl = null): bool;
+
+    /**
+     * Delete cached item
+     *
+     * @throws InvalidKeyException If the key is not valid
+     */
+    abstract public function delete(string $key): bool;
 
     /**
      * Clear cache
      */
-    abstract public function clear(): void;
+    abstract public function clear(): bool;
 
     /**
-     * Return whether a resource is cached
-     */
-    abstract public function has(string $key): bool;
-
-    /**
-     * Return the time when a resource was cached
-     */
-    abstract public function cachedTime(string $key): ?int;
-
-    /**
-     * Fetch multiple data from cache
+     * Fetch multiple items from cache
      *
      * @param list<string> $keys
      *
      * @return array<string, mixed>
+     *
+     * @deprecated since 2.4.0 Use PSR-16 compatible getMultiple() method instead
      */
     public function fetchMultiple(array $keys): array
     {
+        trigger_error(sprintf('%s() is deprecated since Formwork 2.4.0. Use PSR-16 compatible getMultiple() method instead', __METHOD__), E_USER_DEPRECATED);
+        return iterator_to_array($this->getMultiple($keys));
+    }
+
+    /**
+     * Get multiple items from cache
+     *
+     * @param iterable<string> $keys
+     *
+     * @throws InvalidKeyException If any of the keys is not valid
+     *
+     * @return iterable<string, mixed>
+     */
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
         $result = [];
         foreach ($keys as $key) {
-            $result[$key] = $this->fetch($key);
+            $result[$key] = $this->get($key, $default);
         }
         return $result;
     }
 
     /**
-     * Save multiple data to cache
+     * Save multiple cache items
+     *
+     * @deprecated since 2.4.0 Use PSR-16 compatible setMultiple() method instead
      *
      * @param array<string, mixed> $keysAndValues
      */
-    public function saveMultiple(array $keysAndValues): void
+    public function saveMultiple(iterable $keysAndValues): void
     {
-        foreach ($keysAndValues as $key => $value) {
-            $this->save($key, $value);
-        }
+        trigger_error(sprintf('%s() is deprecated since Formwork 2.4.0. Use PSR-16 compatible setMultiple() method instead', __METHOD__), E_USER_DEPRECATED);
+        $this->setMultiple($keysAndValues);
     }
 
     /**
-     * Delete multiple cached resources
+     * Set multiple cache items
      *
-     * @param list<string> $keys
+     * @param iterable<string, mixed> $values
+     *
+     * @throws InvalidKeyException If any of the keys is not valid
      */
-    public function deleteMultiple(array $keys): void
+    public function setMultiple(iterable $values, int|DateInterval|null $ttl = null): bool
     {
+        $success = true;
+        foreach ($values as $key => $value) {
+            $success = $this->set($key, $value, $ttl) && $success;
+        }
+        return $success;
+    }
+
+    /**
+     * Delete multiple cache items
+     *
+     * @param iterable<string> $keys
+     *
+     * @throws InvalidKeyException If any of the keys is not valid
+     */
+    public function deleteMultiple(iterable $keys): bool
+    {
+        $success = true;
         foreach ($keys as $key) {
-            $this->delete($key);
+            $success = $this->delete($key) && $success;
         }
+        return $success;
     }
 
     /**
-     * Return whether multiple resources are cached
+     * Return whether an item is cached
      *
-     * @param list<string> $keys
+     * @throws InvalidKeyException If the key is not valid
      */
-    public function hasMultiple(array $keys): bool
+    abstract public function has(string $key): bool;
+
+    /**
+     * Return whether multiple items are cached
+     *
+     * @param iterable<string> $keys
+     *
+     * @throws InvalidKeyException If any of the keys is not valid
+     */
+    public function hasMultiple(iterable $keys): bool
     {
         foreach ($keys as $key) {
             if (!$this->has($key)) {
@@ -87,5 +171,44 @@ abstract class AbstractCache
             }
         }
         return true;
+    }
+
+    /**
+     * Return the time when an item was cached
+     *
+     * @throws InvalidKeyException If the key is not valid
+     */
+    abstract public function cachedTime(string $key): ?int;
+
+    /**
+     * Get a cached item as a `CacheItemInterface` object
+     *
+     * @internal
+     *
+     * @throws InvalidKeyException If the key is not valid
+     */
+    abstract public function getItem(string $key): ?CacheItemInterface;
+
+    protected function isValidNamespace(?string $namespace): bool
+    {
+        return $namespace === null || (bool) preg_match(self::NAMESPACE_REGEX, $namespace);
+    }
+
+    /**
+     * Return whether a cache key is valid
+     */
+    protected function isValidKey(string $key): bool
+    {
+        return strcspn($key, self::RESERVED_KEY_CHARACTERS) === strlen($key);
+    }
+
+    /**
+     * Parse ttl value and return it as an integer
+     */
+    protected function parseTtl(int|DateInterval|null $ttl): ?int
+    {
+        return $ttl instanceof DateInterval
+            ? (int) (($now = new DateTimeImmutable())->add($ttl)->getTimestamp() - $now->getTimestamp())
+            : $ttl;
     }
 }

--- a/formwork/src/Cache/AbstractCache.php
+++ b/formwork/src/Cache/AbstractCache.php
@@ -20,6 +20,8 @@ abstract class AbstractCache implements NamespacedCacheInterface
     /**
      * Fetch cached item
      *
+     * @param non-empty-string $key
+     *
      * @deprecated since 2.4.0 Use PSR-16 compatible get() method instead
      */
     public function fetch(string $key): mixed
@@ -33,7 +35,8 @@ abstract class AbstractCache implements NamespacedCacheInterface
      *
      * @template TDefault of mixed
      *
-     * @param TDefault $default
+     * @param non-empty-string $key
+     * @param TDefault         $default
      *
      * @throws InvalidKeyException If the key is not valid
      *
@@ -43,6 +46,8 @@ abstract class AbstractCache implements NamespacedCacheInterface
 
     /**
      * Save data to cache
+     *
+     * @param non-empty-string $key
      *
      * @deprecated since 2.4.0 Use PSR-16 compatible set() method instead
      */
@@ -55,12 +60,16 @@ abstract class AbstractCache implements NamespacedCacheInterface
     /**
      * Set data to cache
      *
+     * @param non-empty-string $key
+     *
      * @throws InvalidKeyException If the key is not valid
      */
     abstract public function set(string $key, mixed $value, int|DateInterval|null $ttl = null): bool;
 
     /**
      * Delete cached item
+     *
+     * @param non-empty-string $key
      *
      * @throws InvalidKeyException If the key is not valid
      */
@@ -74,9 +83,9 @@ abstract class AbstractCache implements NamespacedCacheInterface
     /**
      * Fetch multiple items from cache
      *
-     * @param list<string> $keys
+     * @param list<non-empty-string> $keys
      *
-     * @return array<string, mixed>
+     * @return array<non-empty-string, mixed>
      *
      * @deprecated since 2.4.0 Use PSR-16 compatible getMultiple() method instead
      */
@@ -89,11 +98,11 @@ abstract class AbstractCache implements NamespacedCacheInterface
     /**
      * Get multiple items from cache
      *
-     * @param iterable<string> $keys
+     * @param iterable<non-empty-string> $keys
      *
      * @throws InvalidKeyException If any of the keys is not valid
      *
-     * @return iterable<string, mixed>
+     * @return iterable<non-empty-string, mixed>
      */
     public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
@@ -109,7 +118,7 @@ abstract class AbstractCache implements NamespacedCacheInterface
      *
      * @deprecated since 2.4.0 Use PSR-16 compatible setMultiple() method instead
      *
-     * @param array<string, mixed> $keysAndValues
+     * @param array<non-empty-string, mixed> $keysAndValues
      */
     public function saveMultiple(iterable $keysAndValues): void
     {
@@ -120,7 +129,7 @@ abstract class AbstractCache implements NamespacedCacheInterface
     /**
      * Set multiple cache items
      *
-     * @param iterable<string, mixed> $values
+     * @param iterable<non-empty-string, mixed> $values
      *
      * @throws InvalidKeyException If any of the keys is not valid
      */
@@ -136,7 +145,7 @@ abstract class AbstractCache implements NamespacedCacheInterface
     /**
      * Delete multiple cache items
      *
-     * @param iterable<string> $keys
+     * @param iterable<non-empty-string> $keys
      *
      * @throws InvalidKeyException If any of the keys is not valid
      */
@@ -152,6 +161,8 @@ abstract class AbstractCache implements NamespacedCacheInterface
     /**
      * Return whether an item is cached
      *
+     * @param non-empty-string $key
+     *
      * @throws InvalidKeyException If the key is not valid
      */
     abstract public function has(string $key): bool;
@@ -159,7 +170,7 @@ abstract class AbstractCache implements NamespacedCacheInterface
     /**
      * Return whether multiple items are cached
      *
-     * @param iterable<string> $keys
+     * @param iterable<non-empty-string> $keys
      *
      * @throws InvalidKeyException If any of the keys is not valid
      */
@@ -176,6 +187,8 @@ abstract class AbstractCache implements NamespacedCacheInterface
     /**
      * Return the time when an item was cached
      *
+     * @param non-empty-string $key
+     *
      * @throws InvalidKeyException If the key is not valid
      */
     abstract public function cachedTime(string $key): ?int;
@@ -183,15 +196,20 @@ abstract class AbstractCache implements NamespacedCacheInterface
     /**
      * Get a cached item as a `CacheItemInterface` object
      *
+     * @param non-empty-string $key
+     *
      * @internal
      *
      * @throws InvalidKeyException If the key is not valid
      */
     abstract public function getItem(string $key): ?CacheItemInterface;
 
-    protected function isValidNamespace(?string $namespace): bool
+    /**
+     * Return whether a cache namespace is valid
+     */
+    protected function isValidNamespace(string $namespace): bool
     {
-        return $namespace === null || (bool) preg_match(self::NAMESPACE_REGEX, $namespace);
+        return $namespace !== '' && (bool) preg_match(self::NAMESPACE_REGEX, $namespace);
     }
 
     /**
@@ -199,7 +217,7 @@ abstract class AbstractCache implements NamespacedCacheInterface
      */
     protected function isValidKey(string $key): bool
     {
-        return strcspn($key, self::RESERVED_KEY_CHARACTERS) === strlen($key);
+        return $key !== '' && strcspn($key, self::RESERVED_KEY_CHARACTERS) === strlen($key);
     }
 
     /**

--- a/formwork/src/Cache/ArrayCache.php
+++ b/formwork/src/Cache/ArrayCache.php
@@ -5,45 +5,27 @@ namespace Formwork\Cache;
 use DateInterval;
 use Formwork\Cache\Exceptions\InvalidKeyException;
 use Formwork\Cache\Exceptions\InvalidNamespaceException;
-use Formwork\Parsers\Php;
-use Formwork\Utils\FileSystem;
-use UnexpectedValueException;
 
-class FilesCache extends AbstractCache implements CountableCache
+class ArrayCache extends AbstractCache implements CountableCache
 {
     /**
-     * Cache path
+     * @var array<string, CacheItem>
      */
-    protected string $path;
+    protected array $items = [];
 
     /**
-     * @param string                $path       Cache path
      * @param ?string               $namespace  Cache namespace
      * @param DateInterval|int|null $defaultTtl Cached data time-to-live
      *
      * @throws InvalidNamespaceException If the namespace is not valid
      */
     public function __construct(
-        string $path,
         protected ?string $namespace = null,
         protected int|DateInterval|null $defaultTtl = null,
     ) {
-        if ($this->namespace !== null) {
-            if (!$this->isValidNamespace($this->namespace)) {
-                throw new InvalidNamespaceException(sprintf('Namespace "%s" is not valid', $this->namespace));
-            }
-            $this->path = FileSystem::joinPaths($path, $this->namespace);
-        } else {
-            $this->path = $path;
+        if (!$this->isValidNamespace($this->namespace)) {
+            throw new InvalidNamespaceException(sprintf('Namespace "%s" is not valid', $this->namespace));
         }
-    }
-
-    /**
-     * Return the cache path
-     */
-    public function path(): string
-    {
-        return $this->path;
     }
 
     public function namespace(): ?string
@@ -74,14 +56,7 @@ class FilesCache extends AbstractCache implements CountableCache
             ? $cachedTime + $ttl
             : null;
 
-        if (!FileSystem::exists($this->path)) {
-            FileSystem::createDirectory($this->path, recursive: true);
-        }
-
-        Php::encodeToFile(
-            new CacheItem($value, $expirationTime, $cachedTime),
-            $this->getFile($key)
-        );
+        $this->items[$key] = new CacheItem($value, $expirationTime, $cachedTime);
 
         return true;
     }
@@ -91,20 +66,13 @@ class FilesCache extends AbstractCache implements CountableCache
         if (!$this->isValidKey($key)) {
             throw new InvalidKeyException(sprintf('Key "%s" is not valid', $key));
         }
-
-        if (FileSystem::exists($file = $this->getFile($key))) {
-            FileSystem::delete($file);
-        }
-
+        unset($this->items[$key]);
         return true;
     }
 
     public function clear(): bool
     {
-        if (FileSystem::exists($this->path)) {
-            FileSystem::delete($this->path, recursive: true);
-            FileSystem::createDirectory($this->path, recursive: true);
-        }
+        $this->items = [];
         return true;
     }
 
@@ -120,10 +88,7 @@ class FilesCache extends AbstractCache implements CountableCache
 
     public function count(): int
     {
-        if (!FileSystem::exists($this->path)) {
-            return 0;
-        }
-        return count(iterator_to_array(FileSystem::listFiles($this->path)));
+        return count($this->items);
     }
 
     /**
@@ -135,26 +100,17 @@ class FilesCache extends AbstractCache implements CountableCache
             throw new InvalidKeyException(sprintf('Key "%s" is not valid', $key));
         }
 
-        $file = $this->getFile($key);
-
-        if (!FileSystem::exists($file)) {
+        if (!isset($this->items[$key])) {
             return null;
         }
 
-        if (!($cacheItem = Php::parseFile($file)) instanceof CacheItem) {
-            throw new UnexpectedValueException(sprintf('Cache file "%s" does not contain a valid cache item', $file));
-        }
+        $cacheItem = $this->items[$key];
 
         if ($cacheItem->isExpired()) {
-            FileSystem::delete($file);
+            unset($this->items[$key]);
             return null;
         }
 
         return $cacheItem;
-    }
-
-    protected function getFile(string $key): string
-    {
-        return FileSystem::joinPaths($this->path, hash('sha256', $key));
     }
 }

--- a/formwork/src/Cache/ArrayCache.php
+++ b/formwork/src/Cache/ArrayCache.php
@@ -14,13 +14,13 @@ class ArrayCache extends AbstractCache implements CountableCache
     protected array $items = [];
 
     /**
-     * @param ?string               $namespace  Cache namespace
+     * @param non-empty-string      $namespace  Cache namespace
      * @param DateInterval|int|null $defaultTtl Cached data time-to-live
      *
      * @throws InvalidNamespaceException If the namespace is not valid
      */
     public function __construct(
-        protected ?string $namespace = null,
+        protected string $namespace,
         protected int|DateInterval|null $defaultTtl = null,
     ) {
         if (!$this->isValidNamespace($this->namespace)) {
@@ -28,7 +28,7 @@ class ArrayCache extends AbstractCache implements CountableCache
         }
     }
 
-    public function namespace(): ?string
+    public function namespace(): string
     {
         return $this->namespace;
     }

--- a/formwork/src/Cache/CacheItem.php
+++ b/formwork/src/Cache/CacheItem.php
@@ -6,7 +6,7 @@ class CacheItem implements CacheItemInterface
 {
     public function __construct(
         protected mixed $value,
-        protected int $expirationTime,
+        protected ?int $expirationTime,
         protected int $cachedTime,
     ) {}
 
@@ -21,7 +21,7 @@ class CacheItem implements CacheItemInterface
     /**
      * Return the expiration time
      */
-    public function expirationTime(): int
+    public function expirationTime(): ?int
     {
         return $this->expirationTime;
     }
@@ -32,6 +32,14 @@ class CacheItem implements CacheItemInterface
     public function cachedTime(): int
     {
         return $this->cachedTime;
+    }
+
+    /**
+     * Return whether the cache item is expired
+     */
+    public function isExpired(): bool
+    {
+        return $this->expirationTime !== null && time() >= $this->expirationTime;
     }
 
     /**

--- a/formwork/src/Cache/CacheItemInterface.php
+++ b/formwork/src/Cache/CacheItemInterface.php
@@ -6,7 +6,7 @@ use Formwork\Data\Contracts\ArraySerializable;
 
 interface CacheItemInterface extends ArraySerializable
 {
-    public function __construct(mixed $value, int $expirationTime, int $cachedTime);
+    public function __construct(mixed $value, ?int $expirationTime, int $cachedTime);
 
     /**
      * Return the cached value
@@ -16,10 +16,15 @@ interface CacheItemInterface extends ArraySerializable
     /**
      * Return the expiration time
      */
-    public function expirationTime(): int;
+    public function expirationTime(): ?int;
 
     /**
      * Return the caching time
      */
     public function cachedTime(): int;
+
+    /**
+     * Return whether the cache item is expired
+     */
+    public function isExpired(): bool;
 }

--- a/formwork/src/Cache/CacheManager.php
+++ b/formwork/src/Cache/CacheManager.php
@@ -7,12 +7,14 @@ use InvalidArgumentException;
 class CacheManager
 {
     /**
-     * @param array<string, NamespacedCacheInterface> $caches
+     * @param array<non-empty-string, NamespacedCacheInterface> $caches
      */
     public function __construct(protected array $caches = []) {}
 
     /**
      * Get a cache instance by its namespace
+     *
+     * @param non-empty-string $namespace
      *
      * @throws InvalidArgumentException
      */
@@ -23,6 +25,8 @@ class CacheManager
 
     /**
      * Return whether a cache instance exists for the given namespace
+     *
+     * @param non-empty-string $namespace
      */
     public function has(string $namespace): bool
     {
@@ -40,9 +44,9 @@ class CacheManager
     /**
      * Get multiple cache instances by their namespaces
      *
-     * @param list<string> $namespaces
+     * @param list<non-empty-string> $namespaces
      *
-     * @return array<string, NamespacedCacheInterface>
+     * @return array<non-empty-string, NamespacedCacheInterface>
      */
     public function getMultiple(array $namespaces): array
     {
@@ -56,7 +60,7 @@ class CacheManager
     /**
      * Get all cache instances
      *
-     * @return array<string, NamespacedCacheInterface>
+     * @return array<non-empty-string, NamespacedCacheInterface>
      */
     public function getAll(): array
     {

--- a/formwork/src/Cache/CacheManager.php
+++ b/formwork/src/Cache/CacheManager.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Formwork\Cache;
+
+use InvalidArgumentException;
+
+class CacheManager
+{
+    /**
+     * @param array<string, NamespacedCacheInterface> $caches
+     */
+    public function __construct(protected array $caches = []) {}
+
+    /**
+     * Get a cache instance by its namespace
+     *
+     * @throws InvalidArgumentException
+     */
+    public function get(string $namespace): NamespacedCacheInterface
+    {
+        return $this->caches[$namespace] ?? throw new InvalidArgumentException(sprintf('Cache "%s" does not exist', $namespace));
+    }
+
+    /**
+     * Return whether a cache instance exists for the given namespace
+     */
+    public function has(string $namespace): bool
+    {
+        return isset($this->caches[$namespace]);
+    }
+
+    /**
+     * Add a cache instance to the manager
+     */
+    public function add(NamespacedCacheInterface $namespacedCache): void
+    {
+        $this->caches[$namespacedCache->namespace()] = $namespacedCache;
+    }
+
+    /**
+     * Get multiple cache instances by their namespaces
+     *
+     * @param list<string> $namespaces
+     *
+     * @return array<string, NamespacedCacheInterface>
+     */
+    public function getMultiple(array $namespaces): array
+    {
+        $caches = [];
+        foreach ($namespaces as $namespace) {
+            $caches[$namespace] = $this->get($namespace);
+        }
+        return $caches;
+    }
+
+    /**
+     * Get all cache instances
+     *
+     * @return array<string, NamespacedCacheInterface>
+     */
+    public function getAll(): array
+    {
+        return $this->getMultiple(array_keys($this->caches));
+    }
+}

--- a/formwork/src/Cache/CountableCache.php
+++ b/formwork/src/Cache/CountableCache.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Formwork\Cache;
+
+use Countable;
+use Psr\SimpleCache\CacheInterface;
+
+interface CountableCache extends CacheInterface, Countable
+{
+    /**
+     * Return the number of cached items
+     */
+    public function count(): int;
+}

--- a/formwork/src/Cache/Exceptions/InvalidKeyException.php
+++ b/formwork/src/Cache/Exceptions/InvalidKeyException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Formwork\Cache\Exceptions;
+
+use InvalidArgumentException;
+use Psr\SimpleCache\InvalidArgumentException as PsrInvalidArgumentException;
+
+class InvalidKeyException extends InvalidArgumentException implements PsrInvalidArgumentException {}

--- a/formwork/src/Cache/Exceptions/InvalidNamespaceException.php
+++ b/formwork/src/Cache/Exceptions/InvalidNamespaceException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Formwork\Cache\Exceptions;
+
+use InvalidArgumentException;
+use Psr\SimpleCache\InvalidArgumentException as PsrInvalidArgumentException;
+
+class InvalidNamespaceException extends InvalidArgumentException implements PsrInvalidArgumentException {}

--- a/formwork/src/Cache/FilesCache.php
+++ b/formwork/src/Cache/FilesCache.php
@@ -18,24 +18,20 @@ class FilesCache extends AbstractCache implements CountableCache
 
     /**
      * @param string                $path       Cache path
-     * @param ?string               $namespace  Cache namespace
+     * @param non-empty-string      $namespace  Cache namespace
      * @param DateInterval|int|null $defaultTtl Cached data time-to-live
      *
      * @throws InvalidNamespaceException If the namespace is not valid
      */
     public function __construct(
         string $path,
-        protected ?string $namespace = null,
+        protected string $namespace,
         protected int|DateInterval|null $defaultTtl = null,
     ) {
-        if ($this->namespace !== null) {
-            if (!$this->isValidNamespace($this->namespace)) {
-                throw new InvalidNamespaceException(sprintf('Namespace "%s" is not valid', $this->namespace));
-            }
-            $this->path = FileSystem::joinPaths($path, $this->namespace);
-        } else {
-            $this->path = $path;
+        if (!$this->isValidNamespace($this->namespace)) {
+            throw new InvalidNamespaceException(sprintf('Namespace "%s" is not valid', $this->namespace));
         }
+        $this->path = FileSystem::joinPaths($path, $this->namespace);
     }
 
     /**
@@ -46,7 +42,7 @@ class FilesCache extends AbstractCache implements CountableCache
         return $this->path;
     }
 
-    public function namespace(): ?string
+    public function namespace(): string
     {
         return $this->namespace;
     }

--- a/formwork/src/Cache/NamespacedCacheInterface.php
+++ b/formwork/src/Cache/NamespacedCacheInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Formwork\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+
+interface NamespacedCacheInterface extends CacheInterface
+{
+    /**
+     * Return the cache namespace
+     */
+    public function namespace(): ?string;
+}

--- a/formwork/src/Cache/NamespacedCacheInterface.php
+++ b/formwork/src/Cache/NamespacedCacheInterface.php
@@ -8,6 +8,8 @@ interface NamespacedCacheInterface extends CacheInterface
 {
     /**
      * Return the cache namespace
+     *
+     * @return non-empty-string
      */
-    public function namespace(): ?string;
+    public function namespace(): string;
 }

--- a/formwork/src/Cms/App.php
+++ b/formwork/src/Cms/App.php
@@ -35,6 +35,7 @@ use Formwork\Security\CsrfToken;
 use Formwork\Services\Container;
 use Formwork\Services\Loaders\AssetsServiceLoader;
 use Formwork\Services\Loaders\AuthenticationServiceLoader;
+use Formwork\Services\Loaders\CacheServiceLoader;
 use Formwork\Services\Loaders\ConfigServiceLoader;
 use Formwork\Services\Loaders\LoggerServiceLoader;
 use Formwork\Services\Loaders\PanelServiceLoader;
@@ -328,6 +329,10 @@ final class App
 
         $container->define(CacheManager::class)
             ->alias('cache');
+
+        $container->define('cache.pages')
+            ->parameter('namespace', 'pages')
+            ->loader(CacheServiceLoader::class);
 
         $container->define(UserFactory::class);
 

--- a/formwork/src/Cms/App.php
+++ b/formwork/src/Cms/App.php
@@ -6,8 +6,7 @@ use BadMethodCallException;
 use ErrorException;
 use Formwork\Assets\Assets;
 use Formwork\Authentication\Authenticator;
-use Formwork\Cache\AbstractCache;
-use Formwork\Cache\FilesCache;
+use Formwork\Cache\CacheManager;
 use Formwork\Cms\Events\ExceptionThrownEvent;
 use Formwork\Cms\Events\ResponseBeforeSendEvent;
 use Formwork\Cms\Events\RoutesAfterLoadEvent;
@@ -327,10 +326,7 @@ final class App
             ->parameter('translation', fn(Translations $translations) => $translations->getCurrent())
             ->alias('statistics');
 
-        $container->define(FilesCache::class)
-            ->parameter('path', fn(Config $config) => $config->getString('system.cache.path'))
-            ->parameter('defaultTtl', fn(Config $config) => $config->getInt('system.cache.time'))
-            ->alias(AbstractCache::class)
+        $container->define(CacheManager::class)
             ->alias('cache');
 
         $container->define(UserFactory::class);

--- a/formwork/src/Commands/CacheCommand.php
+++ b/formwork/src/Commands/CacheCommand.php
@@ -2,6 +2,8 @@
 
 namespace Formwork\Commands;
 
+use Formwork\Cache\AbstractCache;
+use Formwork\Cache\CountableCache;
 use Formwork\Cache\FilesCache;
 use Formwork\Cms\App;
 use Formwork\Services\Loaders\ConfigServiceLoader;
@@ -233,13 +235,16 @@ final class CacheCommand implements CommandInterface
      */
     private function pagesCacheStats(): void
     {
-        $path = $this->app->config()->getString('system.cache.path');
-        $items = iterator_to_array(FileSystem::listContents($path));
-        $size = FileSystem::directorySize($path);
+        /** @var AbstractCache $cache */
+        $cache = $this->app->getService('cache.pages');
 
         $this->climate->out('<green>Pages Cache</green>');
-        $this->climate->out(sprintf('  Items number: <cyan>%d</cyan>', count($items)));
-        $this->climate->out(sprintf('  Total size:   <cyan>%s</cyan>', FileSystem::formatSize($size)));
+        $this->climate->out(sprintf('  Items number: <cyan>%d</cyan>', $cache instanceof CountableCache ? count($cache) : 0));
+
+        if ($cache instanceof FilesCache) {
+            $size = FileSystem::exists($path = $cache->path()) ? FileSystem::directorySize($path) : 0;
+            $this->climate->out(sprintf('  Total size:   <cyan>%s</cyan>', FileSystem::formatSize($size)));
+        }
     }
 
     /**
@@ -284,7 +289,7 @@ final class CacheCommand implements CommandInterface
     private function clearPagesCache(): void
     {
         /** @var FilesCache */
-        $cache = $this->app->getService('cache');
+        $cache = $this->app->getService('cache.pages');
 
         $cache->clear();
 

--- a/formwork/src/Commands/CacheCommand.php
+++ b/formwork/src/Commands/CacheCommand.php
@@ -288,7 +288,7 @@ final class CacheCommand implements CommandInterface
      */
     private function clearPagesCache(): void
     {
-        /** @var FilesCache */
+        /** @var AbstractCache $cache */
         $cache = $this->app->getService('cache.pages');
 
         $cache->clear();

--- a/formwork/src/Commands/UpdatesCommand.php
+++ b/formwork/src/Commands/UpdatesCommand.php
@@ -205,7 +205,9 @@ final class UpdatesCommand implements CommandInterface
 
         if ($this->app->config()->getBool('system.cache.enabled')) {
             $this->climate->out('Clearing cache...');
-            $this->app->getService(AbstractCache::class)->clear();
+            /** @var AbstractCache $cache */
+            $cache = $this->app->getService('cache.pages');
+            $cache->clear();
             $this->climate->br();
         }
 

--- a/formwork/src/Controllers/PageController.php
+++ b/formwork/src/Controllers/PageController.php
@@ -190,7 +190,7 @@ final class PageController extends AbstractController
             return false;
         }
 
-        if ($this->site->get('maintenance.enabled')) {
+        if ($this->isMaintenanceEnabled()) {
             return false;
         }
 

--- a/formwork/src/Controllers/PageController.php
+++ b/formwork/src/Controllers/PageController.php
@@ -153,7 +153,7 @@ final class PageController extends AbstractController
         // Use requested route as cache key to include parameters like pagination and tags
         $cacheKey = rawurlencode($this->router->request());
 
-        $cacheable = $this->isPageCacheable($page);
+        $cacheable = $cacheKey !== '' && $this->isPageCacheable($page);
 
         if ($cacheable && ($cachedResponse = $this->getCachedResponse($cacheKey)) !== null) {
             return $cachedResponse;
@@ -210,6 +210,8 @@ final class PageController extends AbstractController
 
     /**
      * Get a cached response for a given key, if it exists and is still valid
+     *
+     * @param non-empty-string $key
      */
     private function getCachedResponse(string $key): ?Response
     {

--- a/formwork/src/Controllers/PageController.php
+++ b/formwork/src/Controllers/PageController.php
@@ -2,7 +2,7 @@
 
 namespace Formwork\Controllers;
 
-use Formwork\Cache\FilesCache;
+use Formwork\Cache\AbstractCache;
 use Formwork\Cms\Site;
 use Formwork\Http\FileResponse;
 use Formwork\Http\RequestMethod;
@@ -11,6 +11,7 @@ use Formwork\Http\ResponseStatus;
 use Formwork\Pages\Events\PageOutputEvent;
 use Formwork\Pages\Page;
 use Formwork\Router\RouteParams;
+use Formwork\Services\Attributes\Service;
 use Formwork\Services\Container;
 use Formwork\Statistics\Statistics;
 use Formwork\Utils\FileSystem;
@@ -20,7 +21,8 @@ final class PageController extends AbstractController
     public function __construct(
         private Container $container,
         private Site $site,
-        private FilesCache $filesCache,
+        #[Service('cache.pages')]
+        private AbstractCache $cache,
     ) {
         $this->container->call(parent::__construct(...));
     }
@@ -32,7 +34,7 @@ final class PageController extends AbstractController
     {
         $trackable = $this->config->getBool('site.statistics.enabled');
 
-        if ($this->site->get('maintenance.enabled') && !$this->app->panel()->isLoggedIn()) {
+        if ($this->isMaintenanceEnabled()) {
             $trackable = false;
 
             if (($maintenancePage = $this->site->get('maintenance.page')) instanceof Page) {
@@ -69,12 +71,8 @@ final class PageController extends AbstractController
                 return $this->getPageResponse($this->site->errorPage());
             }
 
-            if ($this->config->getBool('system.cache.enabled') && ($page->fields()->has('publishDate') || $page->fields()->has('unpublishDate')) && (
-                ($page->isPublished() && !$page->publishDate()->isEmpty() && !$this->site->modifiedSince($page->publishDate()->toTimestamp()))
-                || (!$page->isPublished() && !$page->unpublishDate()->isEmpty() && !$this->site->modifiedSince($page->unpublishDate()->toTimestamp()))
-            )) {
-                // Clear cache if the site was not modified since the page has been published or unpublished
-                $this->filesCache->clear();
+            if ($this->shouldClearCacheForScheduledPublication($page)) {
+                $this->cache->clear();
                 if ($this->site->contentPath() !== null) {
                     FileSystem::touch($this->site->contentPath());
                 }
@@ -114,7 +112,32 @@ final class PageController extends AbstractController
     }
 
     /**
-     * Get a response for a page
+     * Check if maintenance mode is enabled and the user is not logged in
+     */
+    private function isMaintenanceEnabled(): bool
+    {
+        return $this->site->get('maintenance.enabled') && !$this->app->panel()->isLoggedIn();
+    }
+
+    /**
+     * Check if the cache should be cleared for a page with scheduled publication
+     */
+    private function shouldClearCacheForScheduledPublication(Page $page): bool
+    {
+        if (!$this->config->getBool('system.cache.enabled')) {
+            return false;
+        }
+
+        if (!$page->fields()->has('publishDate') && !$page->fields()->has('unpublishDate')) {
+            return false;
+        }
+
+        return ($page->isPublished() && !$page->publishDate()->isEmpty() && !$this->site->modifiedSince($page->publishDate()->toTimestamp()))
+            || (!$page->isPublished() && !$page->unpublishDate()->isEmpty() && !$this->site->modifiedSince($page->unpublishDate()->toTimestamp()));
+    }
+
+    /**
+     * Get the response for a page
      */
     private function getPageResponse(Page $page): Response
     {
@@ -128,23 +151,12 @@ final class PageController extends AbstractController
         $page = $this->site->currentPage();
 
         // Use requested route as cache key to include parameters like pagination and tags
-        $cacheKey = $this->router->request();
+        $cacheKey = rawurlencode($this->router->request());
 
-        $cacheable = $this->config->getBool('system.cache.enabled')
-            && $this->isRequestCacheable()
-            && $page->cacheable()
-            && !$page->isErrorPage();
+        $cacheable = $this->isPageCacheable($page);
 
-        if ($cacheable && $this->filesCache->has($cacheKey)) {
-            /**
-             * @var int
-             */
-            $cachedTime = $this->filesCache->cachedTime($cacheKey);
-            // Validate cached response
-            if (!$this->site->modifiedSince($cachedTime)) {
-                return $this->filesCache->fetch($cacheKey);
-            }
-            $this->filesCache->delete($cacheKey);
+        if ($cacheable && ($cachedResponse = $this->getCachedResponse($cacheKey)) !== null) {
+            return $cachedResponse;
         }
 
         $output = $page->render();
@@ -163,10 +175,28 @@ final class PageController extends AbstractController
         $response = new Response($output, $page->responseStatus(), $page->headers() + $headers);
 
         if ($cacheable) {
-            $this->filesCache->save($cacheKey, $response, $page->get('cache.time', null));
+            $this->cache->set($cacheKey, $response, $page->get('cache.time', null));
         }
 
         return $response;
+    }
+
+    /**
+     * Return whether the page is cacheable
+     */
+    private function isPageCacheable(Page $page): bool
+    {
+        if (!$this->config->getBool('system.cache.enabled')) {
+            return false;
+        }
+
+        if ($this->site->get('maintenance.enabled')) {
+            return false;
+        }
+
+        return $this->isRequestCacheable()
+            && $page->cacheable()
+            && !$page->isErrorPage();
     }
 
     /**
@@ -176,5 +206,31 @@ final class PageController extends AbstractController
     {
         return in_array($this->request->method(), [RequestMethod::GET, RequestMethod::HEAD])
             && $this->request->query()->isEmpty();
+    }
+
+    /**
+     * Get a cached response for a given key, if it exists and is still valid
+     */
+    private function getCachedResponse(string $key): ?Response
+    {
+        $cacheItem = $this->cache->getItem($key);
+
+        if ($cacheItem === null) {
+            return null;
+        }
+
+        if ($this->site->modifiedSince($cacheItem->cachedTime())) {
+            $this->cache->delete($key);
+            return null;
+        }
+
+        $response = $cacheItem->value();
+
+        if (!$response instanceof Response) {
+            $this->cache->delete($key);
+            return null;
+        }
+
+        return $response;
     }
 }

--- a/formwork/src/Panel/Controllers/CacheController.php
+++ b/formwork/src/Panel/Controllers/CacheController.php
@@ -6,6 +6,7 @@ use Formwork\Cache\AbstractCache;
 use Formwork\Http\JsonResponse;
 use Formwork\Http\Response;
 use Formwork\Router\RouteParams;
+use Formwork\Services\Attributes\Service;
 use Formwork\Services\Container;
 use Formwork\Services\Loaders\ConfigServiceLoader;
 use Formwork\Utils\Arr;
@@ -16,6 +17,7 @@ final class CacheController extends AbstractController
 {
     public function __construct(
         private Container $container,
+        #[Service('cache.pages')]
         private AbstractCache $pagesCache,
         private ?LoggerInterface $logger = null,
     ) {

--- a/formwork/src/Panel/Controllers/UpdatesController.php
+++ b/formwork/src/Panel/Controllers/UpdatesController.php
@@ -8,6 +8,7 @@ use Formwork\Exceptions\TranslatedException;
 use Formwork\Http\JsonResponse;
 use Formwork\Http\Response;
 use Formwork\Http\ResponseStatus;
+use Formwork\Services\Attributes\Service;
 use Formwork\Updater\Updater;
 use RuntimeException;
 
@@ -43,8 +44,11 @@ final class UpdatesController extends AbstractController
     /**
      * Updates@update action
      */
-    public function update(Updater $updater, AbstractCache $cache): JsonResponse|Response
-    {
+    public function update(
+        Updater $updater,
+        #[Service('cache.pages')]
+        AbstractCache $cache
+    ): JsonResponse|Response {
         if (!$this->hasPermission('panel.updates.update')) {
             return $this->forward(ErrorsController::class, 'forbidden');
         }

--- a/formwork/src/Services/Loaders/CacheServiceLoader.php
+++ b/formwork/src/Services/Loaders/CacheServiceLoader.php
@@ -13,6 +13,9 @@ use InvalidArgumentException;
 
 final class CacheServiceLoader implements ServiceLoaderInterface
 {
+    /**
+     * @param non-empty-string $namespace
+     */
     public function __construct(
         private Config $config,
         private CacheManager $cacheManager,

--- a/formwork/src/Services/Loaders/CacheServiceLoader.php
+++ b/formwork/src/Services/Loaders/CacheServiceLoader.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Formwork\Services\Loaders;
+
+use Formwork\Cache\AbstractCache;
+use Formwork\Cache\ArrayCache;
+use Formwork\Cache\CacheManager;
+use Formwork\Cache\FilesCache;
+use Formwork\Config\Config;
+use Formwork\Services\Container;
+use Formwork\Services\ServiceLoaderInterface;
+use InvalidArgumentException;
+
+final class CacheServiceLoader implements ServiceLoaderInterface
+{
+    public function __construct(
+        private Config $config,
+        private CacheManager $cacheManager,
+        private string $namespace,
+        private ?string $path = null,
+        private ?int $defaultTtl = null,
+        private ?string $handler = null,
+    ) {}
+
+    public function load(Container $container): AbstractCache
+    {
+        $this->handler ??= $this->config->getString("system.cache.namespaces.{$this->namespace}.handler", 'files');
+        $cache = $container->build(
+            $this->getHandlerClass($this->handler),
+            [
+                'path'       => $this->path ?? $this->config->getString('system.cache.path'),
+                'namespace'  => $this->namespace,
+                'defaultTtl' => $this->defaultTtl ?? $this->config->getInt('system.cache.time'),
+            ]
+        );
+        $this->cacheManager->add($cache);
+        return $cache;
+    }
+
+    /**
+     * @return class-string<AbstractCache>
+     */
+    private function getHandlerClass(string $handler): string
+    {
+        return match ($handler) {
+            'files' => FilesCache::class,
+            'array' => ArrayCache::class,
+            default => throw new InvalidArgumentException(sprintf('Cache handler "%s" is not supported', $handler)),
+        };
+    }
+}

--- a/formwork/src/Services/Loaders/SiteServiceLoader.php
+++ b/formwork/src/Services/Loaders/SiteServiceLoader.php
@@ -17,6 +17,10 @@ final class SiteServiceLoader implements ResolutionAwareServiceLoaderInterface
     {
         $config = $this->config->getArray('site');
 
+        $container->define('cache.pages')
+            ->parameter('namespace', 'pages')
+            ->loader(CacheServiceLoader::class);
+
         return $container->build(Site::class, ['data' => [
             ...$config,
             'contentPath' => $this->config->getString('system.pages.path'),

--- a/formwork/src/Services/Loaders/SiteServiceLoader.php
+++ b/formwork/src/Services/Loaders/SiteServiceLoader.php
@@ -17,10 +17,6 @@ final class SiteServiceLoader implements ResolutionAwareServiceLoaderInterface
     {
         $config = $this->config->getArray('site');
 
-        $container->define('cache.pages')
-            ->parameter('namespace', 'pages')
-            ->loader(CacheServiceLoader::class);
-
         return $container->build(Site::class, ['data' => [
             ...$config,
             'contentPath' => $this->config->getString('system.pages.path'),


### PR DESCRIPTION
This pull request introduces a significant refactor and expansion of the caching system to support PSR-16 (Simple Cache) compatibility, cache namespaces, and improved cache management. The changes include a new cache manager, namespace support, new cache types, and enhanced error handling, all while maintaining backward compatibility with deprecated methods.

**Key changes include:**

### PSR-16 Compatibility and API Refactor

- Refactored `AbstractCache` to implement PSR-16 methods (`get`, `set`, `delete`, `clear`, `getMultiple`, `setMultiple`, `deleteMultiple`, `has`) and deprecated legacy methods, ensuring compatibility with standard PHP caching interfaces. Added validation for cache keys and namespaces, and standardized TTL handling. [[1]](diffhunk://#diff-bec502eab681d35994cdf1c559290cc584250553575aa2ad67eb49132775147aL5-R166) [[2]](diffhunk://#diff-bec502eab681d35994cdf1c559290cc584250553575aa2ad67eb49132775147aR175-R213)
- Updated `CacheItemInterface` and `CacheItem` to support nullable expiration times and an `isExpired()` method, improving consistency with PSR-16 and allowing for non-expiring cache entries. [[1]](diffhunk://#diff-5d3c2f3983f3d79be655e1d0de8f41c0e447267a1b0bef14e8d52c0f35aa0048L9-R9) [[2]](diffhunk://#diff-5d3c2f3983f3d79be655e1d0de8f41c0e447267a1b0bef14e8d52c0f35aa0048L19-R29) [[3]](diffhunk://#diff-bcd505358b39c59909a8f10413452cb3e69ee89ad57378ea80974ac2074148e2L9-R9) [[4]](diffhunk://#diff-bcd505358b39c59909a8f10413452cb3e69ee89ad57378ea80974ac2074148e2L24-R24) [[5]](diffhunk://#diff-bcd505358b39c59909a8f10413452cb3e69ee89ad57378ea80974ac2074148e2R37-R44)

### Namespaces and Cache Management

- Introduced the concept of cache namespaces, allowing for logically separated cache spaces. Added `namespace()` methods and validation to relevant classes. [[1]](diffhunk://#diff-bec502eab681d35994cdf1c559290cc584250553575aa2ad67eb49132775147aL5-R166) [[2]](diffhunk://#diff-b99b14e84601c7e51b033d15de970759f90a77dd348f108282b2f69a97940375R5-R158) [[3]](diffhunk://#diff-c0d05cc0c95314a234a083581588cc80c5704efe8b0e78f7bbcab6554d446937R1-R116) [[4]](diffhunk://#diff-1bd621f4aa8e3e170f3be9ab5c392e4b87a20a528946e33f8a2ea0b4805ca38bR1-R13)
- Added a new `CacheManager` class to manage multiple named/namespace cache instances, with methods to retrieve, add, and list caches.
- Updated configuration (`system.yaml`) to support cache namespaces and handlers, allowing for flexible cache backend configuration.

### New Cache Types and Interfaces

- Added an in-memory `ArrayCache` implementation, useful for testing or ephemeral caching needs.
- Introduced `CountableCache` interface for caches that can report the number of stored items. Updated `FilesCache` and `ArrayCache` to implement it. [[1]](diffhunk://#diff-6a00795d471e116dcb40937cfd31145fafabd52f1dee22253ff9f5186af0f460R1-R14) [[2]](diffhunk://#diff-c0d05cc0c95314a234a083581588cc80c5704efe8b0e78f7bbcab6554d446937R1-R116) [[3]](diffhunk://#diff-b99b14e84601c7e51b033d15de970759f90a77dd348f108282b2f69a97940375R5-R158)

### Error Handling and Exceptions

- Added custom exceptions for invalid cache keys and namespaces, both implementing PSR-16's `InvalidArgumentException` for interoperability. [[1]](diffhunk://#diff-fd99c76e952cb21f2247e2839fab6765646bec08b3e3612cd5a667abbf7a7dccR1-R8) [[2]](diffhunk://#diff-9347cd8fce94eec68fcb604ce34a8f45f131c01080d7d89e3a5616bfad768dadR1-R8)

### Dependency and Configuration Updates

- Added `psr/simple-cache` as a composer dependency to ensure PSR-16 interfaces are available.

These changes collectively modernize the caching system, improve standards compliance, and provide a more flexible and robust foundation for caching in the application.