### PR TITLE
Correctly sanitize requested backup files

### DIFF
--- a/formwork/src/Panel/Controllers/BackupController.php
+++ b/formwork/src/Panel/Controllers/BackupController.php
@@ -50,7 +50,7 @@ final class BackupController extends AbstractController
             return $this->forward(ErrorsController::class, 'forbidden');
         }
         try {
-            $backupPath = Path::normalize($this->config->getString('system.backup.path'));
+            $backupPath = rtrim(Path::normalize($this->config->getString('system.backup.path')), '/');
             $file = FileSystem::joinPaths($backupPath, base64_decode((string) $routeParams->get('backup')));
             if (Path::dirname($file) === $backupPath && FileSystem::isFile($file, assertExists: false)) {
                 return new FileResponse($file, download: true);
@@ -71,7 +71,7 @@ final class BackupController extends AbstractController
             return $this->forward(ErrorsController::class, 'forbidden');
         }
         try {
-            $backupPath = Path::normalize($this->config->getString('system.backup.path'));
+            $backupPath = rtrim(Path::normalize($this->config->getString('system.backup.path')), '/');
             $file = FileSystem::joinPaths($backupPath, base64_decode((string) $routeParams->get('backup')));
             if (Path::dirname($file) === $backupPath && FileSystem::isFile($file, assertExists: false)) {
                 FileSystem::delete($file);

--- a/formwork/src/Panel/Controllers/BackupController.php
+++ b/formwork/src/Panel/Controllers/BackupController.php
@@ -11,7 +11,7 @@ use Formwork\Http\ResponseStatus;
 use Formwork\Router\RouteParams;
 use Formwork\Utils\Date;
 use Formwork\Utils\FileSystem;
-use RuntimeException;
+use Formwork\Utils\Path;
 
 final class BackupController extends AbstractController
 {
@@ -29,7 +29,7 @@ final class BackupController extends AbstractController
         } catch (TranslatedException $e) {
             return JsonResponse::error($this->translate('panel.backup.error.cannotMake', $this->translate($e->getLanguageString())), ResponseStatus::InternalServerError);
         }
-        $filename = basename($file);
+        $filename = Path::basename($file);
         $uriName = rawurlencode(base64_encode($filename));
         return JsonResponse::success($this->translate('panel.backup.ready'), data: [
             'filename'  => $filename,
@@ -49,13 +49,13 @@ final class BackupController extends AbstractController
         if (!$this->hasPermission('panel.backup.download')) {
             return $this->forward(ErrorsController::class, 'forbidden');
         }
-
-        $file = FileSystem::joinPaths($this->config->getString('system.backup.path'), basename(base64_decode((string) $routeParams->get('backup'))));
         try {
-            if (FileSystem::isFile($file, assertExists: false)) {
+            $backupPath = Path::normalize($this->config->getString('system.backup.path'));
+            $file = FileSystem::joinPaths($backupPath, base64_decode((string) $routeParams->get('backup')));
+            if (Path::dirname($file) === $backupPath && FileSystem::isFile($file, assertExists: false)) {
                 return new FileResponse($file, download: true);
             }
-            throw new RuntimeException($this->translate('panel.backup.error.cannotDownload.invalidFilename'));
+            throw new TranslatedException('Invalid backup filename', 'panel.backup.error.cannotDownload.invalidFilename');
         } catch (TranslatedException $e) {
             $this->panel->notify($this->translate('panel.backup.error.cannotDownload', $this->translate($e->getLanguageString())), 'error');
             return $this->redirectToReferer(default: $this->generateRoute('panel.tools.backups'), base: $this->panel->panelRoot());
@@ -70,15 +70,15 @@ final class BackupController extends AbstractController
         if (!$this->hasPermission('panel.backup.delete')) {
             return $this->forward(ErrorsController::class, 'forbidden');
         }
-
-        $file = FileSystem::joinPaths($this->config->getString('system.backup.path'), basename(base64_decode((string) $routeParams->get('backup'))));
         try {
-            if (FileSystem::isFile($file, assertExists: false)) {
+            $backupPath = Path::normalize($this->config->getString('system.backup.path'));
+            $file = FileSystem::joinPaths($backupPath, base64_decode((string) $routeParams->get('backup')));
+            if (Path::dirname($file) === $backupPath && FileSystem::isFile($file, assertExists: false)) {
                 FileSystem::delete($file);
                 $this->panel->notify($this->translate('panel.backup.deleted'), 'success');
                 return $this->redirectToReferer(default: $this->generateRoute('panel.tools.backups'), base: $this->generateRoute('panel.index'));
             }
-            throw new RuntimeException($this->translate('panel.backup.error.cannotDelete.invalidFilename'));
+            throw new TranslatedException('Invalid backup filename', 'panel.backup.error.cannotDelete.invalidFilename');
         } catch (TranslatedException $e) {
             $this->panel->notify($this->translate('panel.backup.error.cannotDelete', $this->translate($e->getLanguageString())), 'error');
             return $this->redirectToReferer(default: $this->generateRoute('panel.tools.backups'), base: $this->panel->panelRoot());

--- a/formwork/src/Utils/Path.php
+++ b/formwork/src/Utils/Path.php
@@ -71,6 +71,38 @@ final class Path
     }
 
     /**
+     * Return the directory name of a path
+     *
+     * This method is similar to the built-in `dirname()` function,
+     * but it works regardless of the separator and allows specifying a custom one
+     *
+     * @throws InvalidArgumentException If the separator is not a valid directory separator
+     */
+    public static function dirname(string $path, string $separator = self::DEFAULT_SEPARATOR): string
+    {
+        if (!self::isSeparator($separator)) {
+            throw new InvalidArgumentException('$separator must be a valid directory separator');
+        }
+        $dirname = dirname(str_replace('\\', '/', $path));
+        return $separator === '/'
+            ? $dirname
+            : str_replace('/', $separator, $dirname);
+    }
+
+    /**
+     * Return the trailing component of a path
+     *
+     * This method is similar to the built-in `basename()` function,
+     * but it works regardless of the separator
+     *
+     * @param string $suffix Optional suffix to remove from the trailing component
+     */
+    public static function basename(string $path, string $suffix = ''): string
+    {
+        return basename(str_replace('\\', '/', $path), $suffix);
+    }
+
+    /**
      * Split a path into segments removing `.` and `..`
      *
      * @return array<string>


### PR DESCRIPTION
This pull request enhances the security and reliability of backup file management in the `BackupController` by improving path handling and validation, and by introducing new utility methods in the `Path` class. The main focus is to prevent directory traversal vulnerabilities and ensure that only valid backup files within the configured backup directory can be accessed, downloaded, or deleted.

**Backup file path handling and validation:**

* In `BackupController`, file operations for download and delete now ensure the resolved file is within the normalized backup path by checking `Path::dirname($file) === $backupPath`, preventing directory traversal attacks. Errors now throw `TranslatedException` for better error messaging. [[1]](diffhunk://#diff-d50e090eaba4f09665627c3f8516bd1080bbec319bb8f3ddb0632d35abb15b0aL52-R58) [[2]](diffhunk://#diff-d50e090eaba4f09665627c3f8516bd1080bbec319bb8f3ddb0632d35abb15b0aL73-R81)
* The filename returned after making a backup now uses `Path::basename` instead of the built-in `basename` for more robust path handling.

**Utility methods in `Path` class:**

* Added `Path::dirname` and `Path::basename` methods to provide consistent, cross-platform path manipulation, replacing direct usage of PHP’s `dirname` and `basename`.

**Imports update:**

* Updated imports in `BackupController.php` to use the new `Path` utility class.