### PR TITLE
Add missing URI attributes to `HtmlSanitizer`

### DIFF
--- a/formwork/src/Sanitizer/Reference/HtmlReference.php
+++ b/formwork/src/Sanitizer/Reference/HtmlReference.php
@@ -369,10 +369,20 @@ class HtmlReference
      */
     public const array URI_ATTRIBUTES = [
         'action',
-        'src',
-        'href',
-        'lowsrc',
+        'archive',
         'background',
+        'cite',
+        'classid',
+        'codebase',
+        'data',
+        'formaction',
+        'href',
+        'longdesc',
+        'lowsrc',
+        'manifest',
         'ping',
+        'poster',
+        'src',
+        'usemap',
     ];
 }


### PR DESCRIPTION
This pull request updates the list of URI attributes in the `HtmlReference` class to better align with HTML standards and improve security and compatibility. The main change is the expansion of the `URI_ATTRIBUTES` array to include additional attributes that can contain URIs.

**HTML Sanitization Improvements:**

* Expanded the `URI_ATTRIBUTES` array in `HtmlReference` to include more HTML attributes that may contain URIs, such as `archive`, `background`, `cite`, `classid`, `codebase`, `data`, `formaction`, `longdesc`, `manifest`, `poster`, and `usemap` (`formwork/src/Sanitizer/Reference/HtmlReference.php`).