### PR TITLE
Avoid request-controlled values in authentication rate limiter hashes

### DIFF
--- a/formwork/src/Authentication/RateLimiter.php
+++ b/formwork/src/Authentication/RateLimiter.php
@@ -32,8 +32,10 @@ final class RateLimiter
         private int $resetTime,
         Request $request,
     ) {
-        // Hash visitor IP address followed by current host
-        $this->attemptHash = hash('sha256', "{$request->ip()}@{$request->host()}");
+        // Hash visitor IP address followed by the ROOT_PATH constant.
+        // Do NOT use any client-controlled values as formerly done with
+        // `$request->host()`, as this could be used to bypass the rate limit
+        $this->attemptHash = hash('sha256', "{$request->ip()}@" . ROOT_PATH);
 
         if ($registry->has($this->attemptHash)) {
             [$this->attempts, $this->lastAttemptTime] = $registry->get($this->attemptHash);


### PR DESCRIPTION
This pull request updates the rate limiting logic in the `RateLimiter` class to improve security. The main change ensures that the rate limit hash is no longer based on client-controlled values, which could previously be exploited to bypass restrictions.

**Security improvement:**

* Updated the construction of the `$attemptHash` in `RateLimiter.php` to use the server-defined `ROOT_PATH` instead of the client-supplied host value, preventing potential rate limit bypass through host header manipulation.