### PR TITLE
Display entire exception chain in error templates

### DIFF
--- a/formwork/src/Controllers/ErrorsController.php
+++ b/formwork/src/Controllers/ErrorsController.php
@@ -24,7 +24,7 @@ final class ErrorsController extends AbstractController implements ErrorsControl
 
         if ($this->config->getBool('system.debug.enabled') || $this->request->isLocalhost()) {
             $data['throwable'] = $throwable;
-            $data['stackTrace'] = $throwable !== null ? $this->getTrace($throwable) : [];
+            $data['traceResolver'] = $this->getTrace(...);
         }
 
         if ($this->request->isXmlHttpRequest()) {
@@ -80,14 +80,19 @@ final class ErrorsController extends AbstractController implements ErrorsControl
      */
     private function logThrowable(Throwable $throwable): void
     {
-        error_log(sprintf(
-            "Uncaught %s: %s in %s:%s\nStack trace:\n%s\n",
-            $throwable::class,
-            $throwable->getMessage(),
-            $throwable->getFile(),
-            $throwable->getLine(),
-            $throwable->getTraceAsString()
-        ));
+        // Log the throwable like the native PHP exception handler does
+        $messages = [];
+        do {
+            array_unshift($messages, sprintf(
+                "%s: %s in %s:%s\nStack trace:\n%s\n",
+                $throwable::class,
+                $throwable->getMessage(),
+                $throwable->getFile(),
+                $throwable->getLine(),
+                $throwable->getTraceAsString()
+            ));
+        } while ($throwable = $throwable->getPrevious());
+        error_log('Uncaught ' . implode("\nNext ", $messages));
     }
 
     /**
@@ -95,8 +100,12 @@ final class ErrorsController extends AbstractController implements ErrorsControl
      *
      * @return array<array{file?: string, line?: int, function?: string, class?: string, object?: object, type?: string, args?: list<mixed>}>
      */
-    private function getTrace(Throwable $throwable): array
+    private function getTrace(?Throwable $throwable): array
     {
+        if ($throwable === null) {
+            return [];
+        }
+
         $trace = $throwable->getTrace();
 
         $file = $throwable->getFile();

--- a/formwork/src/Debug/CodeDumper.php
+++ b/formwork/src/Debug/CodeDumper.php
@@ -36,7 +36,7 @@ final class CodeDumper
             }
 
             .color-scheme-dark .__formwork-code {
-                background-color: #333;
+                background-color: #333638;
                 color: #f0f0f0;
             }
 

--- a/formwork/src/Panel/Controllers/ErrorsController.php
+++ b/formwork/src/Panel/Controllers/ErrorsController.php
@@ -70,7 +70,7 @@ final class ErrorsController extends AbstractController implements ErrorsControl
 
         if ($this->config->getBool('system.debug.enabled') || $this->request->isLocalhost()) {
             $data['throwable'] = $throwable;
-            $data['stackTrace'] = $throwable !== null ? $this->getTrace($throwable) : [];
+            $data['traceResolver'] = $this->getTrace(...);
         }
 
         if ($this->request->isXmlHttpRequest()) {
@@ -103,14 +103,19 @@ final class ErrorsController extends AbstractController implements ErrorsControl
      */
     private function logThrowable(Throwable $throwable): void
     {
-        error_log(sprintf(
-            "Uncaught %s: %s in %s:%s\nStack trace:\n%s\n",
-            $throwable::class,
-            $throwable->getMessage(),
-            $throwable->getFile(),
-            $throwable->getLine(),
-            $throwable->getTraceAsString()
-        ));
+        // Log the throwable like the native PHP exception handler does
+        $messages = [];
+        do {
+            array_unshift($messages, sprintf(
+                "%s: %s in %s:%s\nStack trace:\n%s\n",
+                $throwable::class,
+                $throwable->getMessage(),
+                $throwable->getFile(),
+                $throwable->getLine(),
+                $throwable->getTraceAsString()
+            ));
+        } while ($throwable = $throwable->getPrevious());
+        error_log('Uncaught ' . implode("\nNext ", $messages));
     }
 
     /**
@@ -118,8 +123,12 @@ final class ErrorsController extends AbstractController implements ErrorsControl
      *
      * @return array<array{file?: string, line?: int, function?: string, class?: string, object?: object, type?: string, args?: list<mixed>}>
      */
-    private function getTrace(Throwable $throwable): array
+    private function getTrace(?Throwable $throwable): array
     {
+        if ($throwable === null) {
+            return [];
+        }
+
         $trace = $throwable->getTrace();
 
         $file = $throwable->getFile();

--- a/formwork/views/errors/partials/debug.php
+++ b/formwork/views/errors/partials/debug.php
@@ -1,11 +1,16 @@
 </div>
-<div class="error-debug-details">
-    <h3>Uncaught <code><?= $throwable::class ?></code>: <?= $this->escape($throwable->getMessage()) ?></h3>
-    <?php foreach ($stackTrace as $i => $frame) : ?>
-        <?php if (isset($frame['file'], $frame['line'])): ?>
-            <details <?= $this->attr(['open' => $i === 0]) ?>>
-                <summary><a class="error-debug-editor-uri" href="<?= Formwork\Utils\Str::interpolate($app->config()->getString('system.debug.editorUri'), ['filename' => $frame['file'], 'line' => $frame['line']]) ?>"><span class="error-debug-filename"><?= preg_replace('/([^\/]+)$/', '<strong>$1</strong>', $frame['file']) ?></span><span class="error-debug-line">:<?= $frame['line'] ?></span></a></summary>
-                <?php Formwork\Debug\CodeDumper::dumpBacktraceFrame($frame, $app->config()->getInt('system.debug.contextLines', 5)) ?>
-            </details>
-        <?php endif ?>
-    <?php endforeach ?>
+<?php while ($throwable): ?>
+    <div class="error-debug-details">
+        <h3>Uncaught <code><?= $throwable::class ?></code>: <?= $this->escape($throwable->getMessage()) ?></h3>
+        <?php foreach ($traceResolver($throwable) as $i => $frame) : ?>
+            <?php if (isset($frame['file'], $frame['line'])): ?>
+                <details <?= $this->attr(['open' => $i === 0]) ?>>
+                    <summary><a class="error-debug-editor-uri" href="<?= Formwork\Utils\Str::interpolate($app->config()->getString('system.debug.editorUri'), ['filename' => $frame['file'], 'line' => $frame['line']]) ?>"><span class="error-debug-filename"><?= preg_replace('/([^\/]+)$/', '<strong>$1</strong>', $frame['file']) ?></span><span class="error-debug-line">:<?= $frame['line'] ?></span></a></summary>
+                    <?php Formwork\Debug\CodeDumper::dumpBacktraceFrame($frame, $app->config()->getInt('system.debug.contextLines', 5)) ?>
+                </details>
+            <?php endif ?>
+        <?php endforeach ?>
+    </div>
+    <?php $throwable = $throwable->getPrevious() ?>
+<?php endwhile ?>
+<div>

--- a/formwork/views/errors/partials/header.php
+++ b/formwork/views/errors/partials/header.php
@@ -90,7 +90,7 @@
         }
 
         .error-debug-details {
-            margin: 0 auto 4rem;
+            margin: 0 auto 2rem;
             max-width: 87.5rem;
             text-align: left;
             border-radius: 4px;

--- a/panel/src/scss/components/_errors.scss
+++ b/panel/src/scss/components/_errors.scss
@@ -48,9 +48,13 @@
     max-width: 87.5rem;
     padding: 1.5rem 2rem;
     border-radius: var(--border-radius);
-    margin: 0 auto 4rem;
+    margin: 0 auto 2rem;
     background-color: var(--color-base-900);
     text-align: left;
+
+    .color-scheme-dark & {
+        background-color: var(--color-base-800);
+    }
 }
 
 .error-debug-details h3 {

--- a/panel/views/errors/error.php
+++ b/panel/views/errors/error.php
@@ -25,19 +25,22 @@
                 <?php if (isset($action)) : ?><a class="action" href="<?= $action['href'] ?>"><?= $this->escape($action['label']) ?></a><?php endif ?>
             </div>
         </div>
-        <?php if (isset($throwable, $stackTrace)) : ?>
+        <?php if (isset($throwable)) : ?>
             <div class="container-full">
-                <div class="error-debug-details">
-                    <h3>Uncaught <code><?= $throwable::class ?></code>: <?= $this->escape($throwable->getMessage()) ?></h3>
-                    <?php foreach ($stackTrace as $i => $frame) : ?>
-                        <?php if (isset($frame['file'], $frame['line'])): ?>
-                            <details <?= $this->attr(['open' => $i === 0]) ?>>
-                                <summary><a class="error-debug-editor-uri" href="<?= Formwork\Utils\Str::interpolate($app->config()->getString('system.debug.editorUri'), ['filename' => $frame['file'], 'line' => $frame['line']]) ?>"><span class="error-debug-filename"><?= preg_replace('/([^\/]+)$/', '<strong>$1</strong>', $frame['file']) ?></span><span class="error-debug-line">:<?= $frame['line'] ?></span></a></summary>
-                                <?php Formwork\Debug\CodeDumper::dumpBacktraceFrame($frame, $app->config()->getInt('system.debug.contextLines', 5)) ?>
-                            </details>
-                        <?php endif ?>
-                    <?php endforeach ?>
-                </div>
+                <?php while ($throwable): ?>
+                    <div class="error-debug-details">
+                        <h3>Uncaught <code><?= $throwable::class ?></code>: <?= $this->escape($throwable->getMessage()) ?></h3>
+                        <?php foreach ($traceResolver($throwable) as $i => $frame) : ?>
+                            <?php if (isset($frame['file'], $frame['line'])): ?>
+                                <details <?= $this->attr(['open' => $i === 0]) ?>>
+                                    <summary><a class="error-debug-editor-uri" href="<?= Formwork\Utils\Str::interpolate($app->config()->getString('system.debug.editorUri'), ['filename' => $frame['file'], 'line' => $frame['line']]) ?>"><span class="error-debug-filename"><?= preg_replace('/([^\/]+)$/', '<strong>$1</strong>', $frame['file']) ?></span><span class="error-debug-line">:<?= $frame['line'] ?></span></a></summary>
+                                    <?php Formwork\Debug\CodeDumper::dumpBacktraceFrame($frame, $app->config()->getInt('system.debug.contextLines', 5)) ?>
+                                </details>
+                            <?php endif ?>
+                        <?php endforeach ?>
+                    </div>
+                    <?php $throwable = $throwable->getPrevious() ?>
+                <?php endwhile ?>
             </div>
         <?php endif ?>
     </main>


### PR DESCRIPTION
This pull request improves error handling and debugging in both the core and panel error controllers, enhances the display of exception traces in debug views, and updates the styling for error debug details. The main changes include support for chained exceptions in error logs and debug UIs, a refactor of how stack traces are resolved and passed to views, and visual refinements for better readability.

**Error handling and exception trace improvements:**

* Updated both `formwork/src/Controllers/ErrorsController.php` and `formwork/src/Panel/Controllers/ErrorsController.php` to log chained exceptions (using `getPrevious()`) in a format similar to PHP's native exception handler, and refactored the `getTrace` method to handle `null` values and return an empty array if needed. The stack trace is now passed as a callable (`traceResolver`) instead of a precomputed array, enabling support for multiple exceptions in the view. [[1]](diffhunk://#diff-9eac2c4d570abf7bd1e1759a02cb8cdff52dee3f2aff7b6acbd3c2c2f2d0ce1bL27-R27) [[2]](diffhunk://#diff-9eac2c4d570abf7bd1e1759a02cb8cdff52dee3f2aff7b6acbd3c2c2f2d0ce1bL83-R108) [[3]](diffhunk://#diff-aac297d6a4c34cc2a5049b7da84ca111945afca587357c9261dce6be387f248aL73-R73) [[4]](diffhunk://#diff-aac297d6a4c34cc2a5049b7da84ca111945afca587357c9261dce6be387f248aL106-R131)

**Debug view enhancements:**

* Updated error debug views in `formwork/views/errors/partials/debug.php` and `panel/views/errors/error.php` to display all exceptions in a chain (using a `while` loop over `getPrevious()`), and to use the new `traceResolver` for resolving stack traces per exception. [[1]](diffhunk://#diff-d34c5ff93330aa3174787d5b154b0ba84ed79d05302281864c3b127127599a19R2-R16) [[2]](diffhunk://#diff-3e34110135d9aabf430ec9d5610267ca3f49f6f1b1e231e4ab0a667d11b99975L28-R33) [[3]](diffhunk://#diff-3e34110135d9aabf430ec9d5610267ca3f49f6f1b1e231e4ab0a667d11b99975R42-R43)

**Styling improvements:**

* Adjusted the margin and background color for `.error-debug-details` in both the core and panel stylesheets for better visual consistency and readability, including improved dark mode support. [[1]](diffhunk://#diff-dced6a03a425db3a1e6485cccdd630e92f9925c480a68a90573761121786a637L93-R93) [[2]](diffhunk://#diff-6a32a572f31bea3fc37ff616b714c9fc54ee8e9d0c0bcad3a45ed9c0db1e77a7L51-R57)
* Slightly tweaked the dark color scheme background for code dumps in `formwork/src/Debug/CodeDumper.php` for better contrast.