### PR TITLE
Improve plugin autoloading and error handling

### DIFF
--- a/formwork/schemes/plugins/plugin.yaml
+++ b/formwork/schemes/plugins/plugin.yaml
@@ -1,0 +1,11 @@
+title: Plugin
+
+fields:
+    enabled:
+        label: Enabled
+        type: togglegroup
+        options:
+            1: Enabled
+            0: Disabled
+        default: 0
+        visible: false

--- a/formwork/src/Panel/Controllers/PluginsController.php
+++ b/formwork/src/Panel/Controllers/PluginsController.php
@@ -75,7 +75,7 @@ final class PluginsController extends AbstractController
         return new Response($this->view('@panel.plugins.plugin', [
             'title'  => $plugin->manifest()->title() ?? $plugin->name(),
             'plugin' => $plugin,
-            'fields' => $form->fields()->filter(fn($field) => $field->isVisible()),
+            'fields' => $form->fields()->reject(fn($field) => $field->name() === 'enabled'),
             ...$this->getPreviousAndNextPlugin($plugin),
         ]), $form->getResponseStatus());
     }

--- a/formwork/src/Panel/Controllers/PluginsController.php
+++ b/formwork/src/Panel/Controllers/PluginsController.php
@@ -2,7 +2,6 @@
 
 namespace Formwork\Panel\Controllers;
 
-use Formwork\Fields\FieldCollection;
 use Formwork\Http\JsonResponse;
 use Formwork\Http\Response;
 use Formwork\Http\ResponseStatus;
@@ -56,19 +55,7 @@ final class PluginsController extends AbstractController
             return $this->forward(ErrorsController::class, 'notFound');
         }
 
-        $scheme = $this->getPluginScheme($plugin);
-
-        // If no scheme, just show plugin info
-        if ($scheme === null) {
-            return new Response($this->view('@panel.plugins.plugin', [
-                'title'  => $plugin->manifest()->title() ?? $plugin->name(),
-                'plugin' => $plugin,
-                'fields' => new FieldCollection(),
-                ...$this->getPreviousAndNextPlugin($plugin),
-            ]));
-        }
-
-        $fields = $scheme->fields();
+        $fields = $this->getPluginScheme($plugin)->fields();
 
         $fields->setValues($this->config->getArray("plugins.{$name}", []));
 
@@ -88,7 +75,7 @@ final class PluginsController extends AbstractController
         return new Response($this->view('@panel.plugins.plugin', [
             'title'  => $plugin->manifest()->title() ?? $plugin->name(),
             'plugin' => $plugin,
-            'fields' => $form->fields(),
+            'fields' => $form->fields()->filter(fn($field) => $field->isVisible()),
             ...$this->getPreviousAndNextPlugin($plugin),
         ]), $form->getResponseStatus());
     }
@@ -168,25 +155,32 @@ final class PluginsController extends AbstractController
     /**
      * Get scheme for a given plugin
      */
-    private function getPluginScheme(Plugin $plugin): ?Scheme
+    private function getPluginScheme(Plugin $plugin): Scheme
     {
         $id = $plugin->id();
 
         $schemes = $this->app->schemes();
 
         if ($schemes->has("plugins.{$id}")) {
-            return $schemes->get("plugins.{$id}");
+            $scheme = $schemes->get("plugins.{$id}");
+        } else {
+            // Try to load scheme from plugin path
+            $path = FileSystem::joinPaths($plugin->path(), "schemes/plugins/{$id}.yaml");
+
+            if (FileSystem::exists($path)) {
+                $schemes->load("plugins.{$id}", $path);
+                $scheme = $schemes->get("plugins.{$id}");
+            }
         }
 
-        // Try to load scheme from plugin path
-        $path = FileSystem::joinPaths($plugin->path(), "schemes/plugins/{$id}.yaml");
-
-        if (FileSystem::exists($path)) {
-            $schemes->load("plugins.{$id}", $path);
-            return $schemes->get("plugins.{$id}");
+        // Require that the scheme extends the base plugin scheme,
+        // so that the `enabled` field is always present
+        if (isset($scheme) && !$scheme->extendsScheme('plugins.plugin')) {
+            // @phpstan-ignore argument.type
+            $scheme->extendWith($schemes->get('plugins.plugin')->toArray());
         }
 
-        return null;
+        return $scheme ?? $schemes->get('plugins.plugin');
     }
 
     /**

--- a/formwork/src/Panel/Controllers/PluginsController.php
+++ b/formwork/src/Panel/Controllers/PluginsController.php
@@ -7,6 +7,7 @@ use Formwork\Http\JsonResponse;
 use Formwork\Http\Response;
 use Formwork\Http\ResponseStatus;
 use Formwork\Parsers\Yaml;
+use Formwork\Plugins\Exceptions\PluginInitializationException;
 use Formwork\Plugins\Plugin;
 use Formwork\Plugins\Plugins;
 use Formwork\Router\RouteParams;
@@ -108,6 +109,14 @@ final class PluginsController extends AbstractController
         }
 
         $this->togglePluginStatus($plugin, true);
+
+        try {
+            $plugins->initialize($name);
+        } catch (PluginInitializationException) {
+            $this->togglePluginStatus($plugin, false);
+            $this->panel->notify($this->translate('panel.plugins.plugin.cannotEnable.initializationError'), 'error');
+            return JsonResponse::error($this->translate('panel.plugins.plugin.cannotEnable.initializationError'), ResponseStatus::InternalServerError);
+        }
 
         $this->panel->notify($this->translate('panel.plugins.plugin.enabled'), 'success');
         return JsonResponse::success($this->translate('panel.plugins.plugin.enabled'));

--- a/formwork/src/Plugins/Exceptions/PluginInitializationException.php
+++ b/formwork/src/Plugins/Exceptions/PluginInitializationException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Formwork\Plugins\Exceptions;
+
+use RuntimeException;
+
+class PluginInitializationException extends RuntimeException {}

--- a/formwork/src/Plugins/Plugin.php
+++ b/formwork/src/Plugins/Plugin.php
@@ -127,6 +127,8 @@ class Plugin implements Arrayable
 
     /**
      * Get the plugin autoloader
+     *
+     * @internal This method is called during plugin initialization. Since it can have side effects, it should not be called directly
      */
     public function autoload(): ?ClassLoader
     {

--- a/formwork/src/Plugins/Plugin.php
+++ b/formwork/src/Plugins/Plugin.php
@@ -42,6 +42,10 @@ class Plugin implements Arrayable
     ) {
         $this->id = basename($this->path);
 
+        if ($this->id === 'plugin') {
+            throw new InvalidArgumentException('Invalid plugin id "plugin". The plugin id "plugin" is reserved.');
+        }
+
         if (!preg_match('/^[a-z0-9-]+$/', $this->id)) {
             throw new InvalidArgumentException(sprintf('Invalid plugin id "%s". Plugin ids can only contain lowercase letters, numbers and hyphens.', $this->id));
         }

--- a/formwork/src/Plugins/Plugins.php
+++ b/formwork/src/Plugins/Plugins.php
@@ -52,7 +52,12 @@ class Plugins extends PluginCollection
             throw new InvalidArgumentException(sprintf('Invalid plugin "%s"', $name));
         }
 
-        $plugin->autoload()?->register();
+        if ($autoload = $plugin->autoload()) {
+            // Requiring vendor/autoload.php always prepends the autoloader to the stack,
+            // so we need to unregister and re-register without prepending
+            $autoload->unregister();
+            $autoload->register(prepend: false);
+        }
 
         foreach ($plugin->getEventListeners() as $eventName => $eventListener) {
             $this->eventDispatcher->on($eventName, $plugin->{$eventListener}(...));

--- a/formwork/src/Plugins/Plugins.php
+++ b/formwork/src/Plugins/Plugins.php
@@ -66,14 +66,14 @@ class Plugins extends PluginCollection
             throw new PluginInitializationException(sprintf('Failed autoload for plugin "%s"', $name), $e->getCode(), previous: $e);
         }
 
-        foreach ($plugin->getEventListeners() as $eventName => $eventListener) {
-            $this->eventDispatcher->on($eventName, $plugin->{$eventListener}(...));
-        }
-
         try {
             $plugin->initialize();
         } catch (Throwable $e) {
             throw new PluginInitializationException(sprintf('Failed initialization for plugin "%s"', $name), $e->getCode(), previous: $e);
+        }
+
+        foreach ($plugin->getEventListeners() as $eventName => $eventListener) {
+            $this->eventDispatcher->on($eventName, $plugin->{$eventListener}(...));
         }
     }
 

--- a/formwork/src/Plugins/Plugins.php
+++ b/formwork/src/Plugins/Plugins.php
@@ -5,9 +5,11 @@ namespace Formwork\Plugins;
 use Formwork\Config\Config;
 use Formwork\Events\EventDispatcher;
 use Formwork\Plugins\Events\PluginsInitializedEvent;
+use Formwork\Plugins\Exceptions\PluginInitializationException;
 use Formwork\Utils\FileSystem;
 use Formwork\Utils\Str;
 use InvalidArgumentException;
+use Throwable;
 use UnexpectedValueException;
 
 /**
@@ -44,7 +46,8 @@ class Plugins extends PluginCollection
     /**
      * Initialize a plugin from id
      *
-     * @throws InvalidArgumentException If the plugin id is invalid
+     * @throws InvalidArgumentException      If the plugin id is invalid
+     * @throws PluginInitializationException If the plugin autoload or initialization fails
      */
     public function initialize(string $name): void
     {
@@ -52,18 +55,26 @@ class Plugins extends PluginCollection
             throw new InvalidArgumentException(sprintf('Invalid plugin "%s"', $name));
         }
 
-        if ($autoload = $plugin->autoload()) {
-            // Requiring vendor/autoload.php always prepends the autoloader to the stack,
-            // so we need to unregister and re-register without prepending
-            $autoload->unregister();
-            $autoload->register(prepend: false);
+        try {
+            if ($autoload = $plugin->autoload()) {
+                // Requiring vendor/autoload.php always prepends the autoloader to the stack,
+                // so we need to unregister and re-register without prepending
+                $autoload->unregister();
+                $autoload->register(prepend: false);
+            }
+        } catch (Throwable $e) {
+            throw new PluginInitializationException(sprintf('Failed autoload for plugin "%s"', $name), $e->getCode(), previous: $e);
         }
 
         foreach ($plugin->getEventListeners() as $eventName => $eventListener) {
             $this->eventDispatcher->on($eventName, $plugin->{$eventListener}(...));
         }
 
-        $plugin->initialize();
+        try {
+            $plugin->initialize();
+        } catch (Throwable $e) {
+            throw new PluginInitializationException(sprintf('Failed initialization for plugin "%s"', $name), $e->getCode(), previous: $e);
+        }
     }
 
     /**

--- a/formwork/src/Schemes/Scheme.php
+++ b/formwork/src/Schemes/Scheme.php
@@ -207,12 +207,16 @@ class Scheme implements Arrayable
     public function extendsScheme(Scheme|string $scheme): bool
     {
         $id = $scheme instanceof Scheme ? $scheme->id() : $scheme;
-        while ($extendedScheme = $this->getExtendedScheme()) {
-            if ($extendedScheme->id() === $id) {
+
+        $extended = $this->getExtendedScheme();
+
+        while ($extended instanceof Scheme) {
+            if ($extended->id() === $id) {
                 return true;
             }
-            $extendedScheme = $extendedScheme->getExtendedScheme();
+            $extended = $extended->getExtendedScheme();
         }
+
         return false;
     }
 

--- a/formwork/src/Schemes/Scheme.php
+++ b/formwork/src/Schemes/Scheme.php
@@ -202,6 +202,21 @@ class Scheme implements Arrayable
     }
 
     /**
+     * Check if the scheme extends another scheme
+     */
+    public function extendsScheme(Scheme|string $scheme): bool
+    {
+        $id = $scheme instanceof Scheme ? $scheme->id() : $scheme;
+        while ($extendedScheme = $this->getExtendedScheme()) {
+            if ($extendedScheme->id() === $id) {
+                return true;
+            }
+            $extendedScheme = $extendedScheme->getExtendedScheme();
+        }
+        return false;
+    }
+
+    /**
      * Translate a value
      */
     protected function translate(mixed $value, Translation $translation): mixed

--- a/formwork/src/Schemes/Scheme.php
+++ b/formwork/src/Schemes/Scheme.php
@@ -203,17 +203,29 @@ class Scheme implements Arrayable
 
     /**
      * Check if the scheme extends another scheme
+     *
+     * @throws RecursionException If there is recursion in scheme extension
      */
     public function extendsScheme(Scheme|string $scheme): bool
     {
-        $id = $scheme instanceof Scheme ? $scheme->id() : $scheme;
+        $id = $scheme instanceof Scheme ? $scheme->id : $scheme;
 
         $extended = $this->getExtendedScheme();
 
+        $visited = [$this->id => true];
+
         while ($extended instanceof Scheme) {
-            if ($extended->id() === $id) {
+            $extendedId = $extended->id;
+
+            if (isset($visited[$extendedId])) {
+                throw new RecursionException(sprintf('Recursion in the extension of the scheme "%s". Extension chain: "%s"', $this->id, implode('" > "', array_keys($visited))));
+            }
+
+            if ($extendedId === $id) {
                 return true;
             }
+
+            $visited[$extendedId] = true;
             $extended = $extended->getExtendedScheme();
         }
 

--- a/panel/src/ts/components/views/plugins.ts
+++ b/panel/src/ts/components/views/plugins.ts
@@ -3,11 +3,12 @@ import { app } from "../../app";
 import { Notification } from "../notification";
 import { Request } from "../../utils/request";
 import { throttle } from "../../utils/events";
+import { TogglegroupInput } from "../inputs/togglegroup-input";
 
 export class Plugins {
     constructor() {
         $$<HTMLInputElement>(".plugin-status-toggle").forEach((toggle) => {
-            const fieldset = toggle.closest(".form-togglegroup") as HTMLFieldSetElement;
+            const togglegroup = new TogglegroupInput(toggle.closest(".form-togglegroup") as HTMLFieldSetElement);
             const action = toggle.dataset.action;
 
             toggle.addEventListener("change", () => {
@@ -15,7 +16,7 @@ export class Plugins {
                     return;
                 }
 
-                fieldset.disabled = true;
+                togglegroup.element.disabled = true;
 
                 throttle(() => {
                     new Request(
@@ -25,12 +26,15 @@ export class Plugins {
                             data: { "csrf-token": app.config.csrfToken as string },
                         },
                         (response) => {
-                            if (response.status === "success" && !app.forms["plugin-form"]?.hasChanged()) {
+                            if (!app.forms["plugin-form"]?.hasChanged()) {
                                 window.location.reload();
                             } else {
                                 const notification = new Notification(response.message, response.status);
                                 notification.show();
-                                fieldset.disabled = false;
+                                if (response.status === "error") {
+                                    togglegroup.value = toggle.value === "1" ? "0" : "1";
+                                }
+                                togglegroup.element.disabled = false;
                             }
                         },
                     );

--- a/panel/translations/de.yaml
+++ b/panel/translations/de.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: Seite anzeigen
 panel.panel: Administrationspanel
 panel.plugins.info: Info
 panel.plugins.nextPlugin: Nächstes Plugin
+panel.plugins.plugin.cannotEnable.initializationError: Plugin kann nicht aktiviert werden. Beim Initialisieren des Plugins ist ein Fehler aufgetreten.
 panel.plugins.plugin.cannotSave.invalidFields: Plugin-Optionen können nicht gespeichert werden, einige Felder sind ungültig
 panel.plugins.plugin.disabled: Plugin deaktiviert
 panel.plugins.plugin.enabled: Plugin aktiviert

--- a/panel/translations/el.yaml
+++ b/panel/translations/el.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: Προβολή σελίδας
 panel.panel: Πίνακας διαχείρισης
 panel.plugins.info: Πληροφορίες
 panel.plugins.nextPlugin: Επόμενο πρόσθετο
+panel.plugins.plugin.cannotEnable.initializationError: Δεν είναι δυνατή η ενεργοποίηση του πρόσθετου. Παρουσιάστηκε σφάλμα κατά την αρχικοποίηση του πρόσθετου.
 panel.plugins.plugin.cannotSave.invalidFields: Δεν είναι δυνατή η αποθήκευση των επιλογών του πρόσθετου, ορισμένα πεδία δεν είναι έγκυρα
 panel.plugins.plugin.disabled: Το πρόσθετο απενεργοποιήθηκε
 panel.plugins.plugin.enabled: Το πρόσθετο ενεργοποιήθηκε

--- a/panel/translations/en.yaml
+++ b/panel/translations/en.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: View page
 panel.panel: Administration panel
 panel.plugins.info: Info
 panel.plugins.nextPlugin: Next plugin
+panel.plugins.plugin.cannotEnable.initializationError: Cannot enable plugin. An error occurred while initializing the plugin.
 panel.plugins.plugin.cannotSave.invalidFields: Cannot save plugin options, some fields are invalid
 panel.plugins.plugin.disabled: Plugin disabled
 panel.plugins.plugin.enabled: Plugin enabled

--- a/panel/translations/es.yaml
+++ b/panel/translations/es.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: Ver página
 panel.panel: Panel de administración
 panel.plugins.info: Info
 panel.plugins.nextPlugin: Plugin siguiente
+panel.plugins.plugin.cannotEnable.initializationError: No se puede activar el plugin. Se produjo un error al inicializar el plugin.
 panel.plugins.plugin.cannotSave.invalidFields: No se pueden guardar las opciones del plugin, algunos campos no son válidos
 panel.plugins.plugin.disabled: Plugin deshabilitado
 panel.plugins.plugin.enabled: Plugin habilitado

--- a/panel/translations/fr.yaml
+++ b/panel/translations/fr.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: Voir la page
 panel.panel: Panneau d’administration
 panel.plugins.info: Info
 panel.plugins.nextPlugin: Plugin suivant
+panel.plugins.plugin.cannotEnable.initializationError: Impossible d’activer le plugin. Une erreur s’est produite lors de l’initialisation du plugin.
 panel.plugins.plugin.cannotSave.invalidFields: Impossible d’enregistrer les options du plugin, certains champs sont invalides
 panel.plugins.plugin.disabled: Plugin désactivé
 panel.plugins.plugin.enabled: Plugin activé

--- a/panel/translations/hu.yaml
+++ b/panel/translations/hu.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: Oldal megtekintése
 panel.panel: Adminisztrációs felület
 panel.plugins.info: Információ
 panel.plugins.nextPlugin: Következő bővítmény
+panel.plugins.plugin.cannotEnable.initializationError: Nem lehet engedélyezni a bővítményt. Hiba történt a bővítmény inicializálása során.
 panel.plugins.plugin.cannotSave.invalidFields: Nem lehet menteni a bővítmény beállításait, egyes mezők érvénytelenek
 panel.plugins.plugin.disabled: Bővítmény letiltva
 panel.plugins.plugin.enabled: Bővítmény engedélyezve

--- a/panel/translations/it.yaml
+++ b/panel/translations/it.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: Visualizza pagina
 panel.panel: Pannello di amministrazione
 panel.plugins.info: Info
 panel.plugins.nextPlugin: Plugin successivo
+panel.plugins.plugin.cannotEnable.initializationError: Impossibile abilitare il plugin. Si è verificato un errore durante l’inizializzazione del plugin.
 panel.plugins.plugin.cannotSave.invalidFields: Impossibile salvare le impostazioni del plugin, alcuni campi non sono validi
 panel.plugins.plugin.disabled: Plugin disabilitato
 panel.plugins.plugin.enabled: Plugin abilitato

--- a/panel/translations/nl.yaml
+++ b/panel/translations/nl.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: Bekijk pagina
 panel.panel: Administratiepaneel
 panel.plugins.info: Info
 panel.plugins.nextPlugin: Volgende plugin
+panel.plugins.plugin.cannotEnable.initializationError: Kan plugin niet inschakelen. Er is een fout opgetreden bij het initialiseren van de plugin.
 panel.plugins.plugin.cannotSave.invalidFields: Pluginopties kunnen niet worden opgeslagen, sommige velden zijn ongeldig
 panel.plugins.plugin.disabled: Plugin uitgeschakeld
 panel.plugins.plugin.enabled: Plugin ingeschakeld

--- a/panel/translations/pl.yaml
+++ b/panel/translations/pl.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: Wyświetl stronę
 panel.panel: Panel administracyjny
 panel.plugins.info: Info
 panel.plugins.nextPlugin: Następna wtyczka
+panel.plugins.plugin.cannotEnable.initializationError: Nie można włączyć wtyczki. Wystąpił błąd podczas inicjalizacji wtyczki.
 panel.plugins.plugin.cannotSave.invalidFields: Nie można zapisać opcji wtyczki, niektóre pola są nieprawidłowe
 panel.plugins.plugin.disabled: Wtyczka wyłączona
 panel.plugins.plugin.enabled: Wtyczka włączona

--- a/panel/translations/pt.yaml
+++ b/panel/translations/pt.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: Ver página
 panel.panel: Painel de administração
 panel.plugins.info: Info
 panel.plugins.nextPlugin: Plugin seguinte
+panel.plugins.plugin.cannotEnable.initializationError: Não é possível ativar o plugin. Ocorreu um erro ao inicializar o plugin.
 panel.plugins.plugin.cannotSave.invalidFields: Não é possível guardar as opções do plugin, alguns campos são inválidos
 panel.plugins.plugin.disabled: Plugin desativado
 panel.plugins.plugin.enabled: Plugin ativado

--- a/panel/translations/ro.yaml
+++ b/panel/translations/ro.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: Vezi pagina
 panel.panel: Panoul de administrare
 panel.plugins.info: Info
 panel.plugins.nextPlugin: Plugin următor
+panel.plugins.plugin.cannotEnable.initializationError: Pluginul nu poate fi activat. A apărut o eroare la inițializarea pluginului.
 panel.plugins.plugin.cannotSave.invalidFields: Nu se pot salva opțiunile pluginului, unele câmpuri sunt nevalide
 panel.plugins.plugin.disabled: Plugin dezactivat
 panel.plugins.plugin.enabled: Plugin activat

--- a/panel/translations/ru.yaml
+++ b/panel/translations/ru.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: Просмотреть страницу
 panel.panel: Панель администрирования
 panel.plugins.info: Информация
 panel.plugins.nextPlugin: Следующий плагин
+panel.plugins.plugin.cannotEnable.initializationError: Невозможно включить плагин. Произошла ошибка при инициализации плагина.
 panel.plugins.plugin.cannotSave.invalidFields: Не удалось сохранить настройки плагина, некоторые поля недействительны
 panel.plugins.plugin.disabled: Плагин отключён
 panel.plugins.plugin.enabled: Плагин включён

--- a/panel/translations/sv.yaml
+++ b/panel/translations/sv.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: Visa sida
 panel.panel: Administrationspanel
 panel.plugins.info: Information
 panel.plugins.nextPlugin: Nästa plugin
+panel.plugins.plugin.cannotEnable.initializationError: Kan inte aktivera pluginet. Ett fel uppstod när pluginet initierades.
 panel.plugins.plugin.cannotSave.invalidFields: Kan inte spara plugin-alternativ, vissa fält är ogiltiga
 panel.plugins.plugin.disabled: Plugin inaktiverad
 panel.plugins.plugin.enabled: Plugin aktiverad

--- a/panel/translations/tr.yaml
+++ b/panel/translations/tr.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: Sayfayı görüntüle
 panel.panel: Yönetim paneli
 panel.plugins.info: Bilgi
 panel.plugins.nextPlugin: Sonraki eklenti
+panel.plugins.plugin.cannotEnable.initializationError: Eklenti etkinleştirilemiyor. Eklenti başlatılırken bir hata oluştu.
 panel.plugins.plugin.cannotSave.invalidFields: Eklenti seçenekleri kaydedilemiyor, bazı alanlar geçersiz
 panel.plugins.plugin.disabled: Eklenti devre dışı
 panel.plugins.plugin.enabled: Eklenti etkin

--- a/panel/translations/uk.yaml
+++ b/panel/translations/uk.yaml
@@ -277,6 +277,7 @@ panel.pages.viewPage: Переглянути сторінку
 panel.panel: Панель адміністратора
 panel.plugins.info: Інформація
 panel.plugins.nextPlugin: Наступний плагін
+panel.plugins.plugin.cannotEnable.initializationError: Неможливо ввімкнути плагін. Під час ініціалізації плагіна сталася помилка.
 panel.plugins.plugin.cannotSave.invalidFields: Не вдалося зберегти налаштування плагіна, деякі поля недійсні
 panel.plugins.plugin.disabled: Плагін вимкнено
 panel.plugins.plugin.enabled: Плагін увімкнено


### PR DESCRIPTION
This pull request introduces several improvements to plugin management, focusing on safer plugin initialization, enhanced error handling, and better consistency for plugin configuration schemes. It adds a base plugin scheme, ensures all plugin schemes extend this base, improves feedback when enabling plugins fails, and updates the frontend to handle errors more gracefully. Additionally, new translation strings for initialization errors are added in multiple languages.

**Plugin initialization and error handling:**

* Introduced a `PluginInitializationException` and updated the `Plugins::initialize` method to catch and wrap errors during plugin autoloading and initialization, providing better error reporting and preventing plugins from being enabled if initialization fails. (`formwork/src/Plugins/Exceptions/PluginInitializationException.php`, `formwork/src/Plugins/Plugins.php`, `formwork/src/Panel/Controllers/PluginsController.php`) [[1]](diffhunk://#diff-2da4de5c62f951ef7aef3e0b68812c840527b2018f39add51a33d671f368ea98R1-R7) [[2]](diffhunk://#diff-520995a2e076cd7201d65cffbf82dbcbef5ad5168b060ee198c073dea5afe1d4R8-R12) [[3]](diffhunk://#diff-520995a2e076cd7201d65cffbf82dbcbef5ad5168b060ee198c073dea5afe1d4R50-R77) [[4]](diffhunk://#diff-e70f9079c696532d47a8c7d8f0899bce03ee2083fb6f56065800cb69667447edR100-R107)
* The panel now notifies the user and rolls back the enabled status if a plugin fails to initialize, with translated error messages. (`formwork/src/Panel/Controllers/PluginsController.php`, `panel/translations/*.yaml`) [[1]](diffhunk://#diff-e70f9079c696532d47a8c7d8f0899bce03ee2083fb6f56065800cb69667447edR100-R107) [[2]](diffhunk://#diff-c12f5f9b4cf99d3b35f6f5defea77cc57dbab76bf922fb7a27ff35b3f89d014aR280) [[3]](diffhunk://#diff-60a982db0fa7387cd39c9a38cbbce9eef7287eabe09b1cbc85c4d05bd59f12c3R280) [[4]](diffhunk://#diff-8879b7b36b8f36138da71764453d893c85d45c294f607d8594649b7e6f72ce13R280) [[5]](diffhunk://#diff-3aef51d61250f8d6df37d1ea4b854af4649492fa8a5b2722367460e0bb6bad13R280) [[6]](diffhunk://#diff-66893cfdc71e68c0c0f75a1db63b7270f916b01a9cde703f04abc11793b36996R280) [[7]](diffhunk://#diff-561d8c66d75845dc3734356189c6a354ea4acb160fe854486fc4fc0b25e24209R280) [[8]](diffhunk://#diff-c399a0648142bccc71e945864e68f61de8ec7e5edf5213d5c43673bdc7951c19R280) [[9]](diffhunk://#diff-0ab1a1c5942d7aa9bda8f2232329e44d703492ea8d8e7870f52041eb0b4223d5R280) [[10]](diffhunk://#diff-1768440829d64dbc08c77045b496204b3264d6e7b911cbc4cfa4d12d93c9bcebR280) [[11]](diffhunk://#diff-8fa2abe02fa35b8e3aebda1c61a8162c4af96effd5d549b033523f16b7cf863bR280) [[12]](diffhunk://#diff-8f2ffefb1e0eda88cc22e0bdfeb2614b39a2f6a3e35cd722a198144efc963b3cR280) [[13]](diffhunk://#diff-ea3f3df6f228919effd04f9e33e00ab08cce6cde80e82eef70f80d05de05ff26R280) [[14]](diffhunk://#diff-13eb67d57d16824529f5b0be645a2ef352645ba7abf83c4c5dfe7b9fae4ccd3fR280)

**Plugin scheme enforcement and configuration:**

* Added a base plugin scheme in `formwork/schemes/plugins/plugin.yaml` with an `enabled` field, and updated the backend to ensure all plugin schemes extend this base, guaranteeing the presence of the `enabled` field for all plugins. (`formwork/schemes/plugins/plugin.yaml`, `formwork/src/Panel/Controllers/PluginsController.php`, `formwork/src/Schemes/Scheme.php`) [[1]](diffhunk://#diff-7ecc923ec8341431a5bec0694e0b82193df0d299879aa974922eb559ec093faaR1-R11) [[2]](diffhunk://#diff-e70f9079c696532d47a8c7d8f0899bce03ee2083fb6f56065800cb69667447edL162-R183) [[3]](diffhunk://#diff-2c7c183c0202d1ef690a9d47d1d966600a420fae4cae3933ce0e986c16f0e6e0R178-R192)
* Improved the plugin configuration form to only show visible fields and simplified the logic for retrieving and displaying plugin scheme fields. (`formwork/src/Panel/Controllers/PluginsController.php`) [[1]](diffhunk://#diff-e70f9079c696532d47a8c7d8f0899bce03ee2083fb6f56065800cb69667447edL58-R58) [[2]](diffhunk://#diff-e70f9079c696532d47a8c7d8f0899bce03ee2083fb6f56065800cb69667447edL90-R78)

**Frontend improvements:**

* Updated the plugin status toggle UI to handle enable/disable errors more gracefully by reverting the toggle and re-enabling the control if an error occurs. (`panel/src/ts/components/views/plugins.ts`) [[1]](diffhunk://#diff-d48f18341ff5c751cd1428ed8e1257d9beb5ac3c2616bf4a9a0f9f7862622c3dR6-R19) [[2]](diffhunk://#diff-d48f18341ff5c751cd1428ed8e1257d9beb5ac3c2616bf4a9a0f9f7862622c3dL28-R37)

**Validation and restrictions:**

* Prevented plugins from using the reserved id `plugin` and improved error messages for invalid plugin ids. (`formwork/src/Plugins/Plugin.php`)
* Added documentation to clarify the internal use of the `autoload` method in the plugin lifecycle. (`formwork/src/Plugins/Plugin.php`)