### PR TITLE
Detect recursion in scheme extension

### DIFF
--- a/formwork/src/Schemes/Scheme.php
+++ b/formwork/src/Schemes/Scheme.php
@@ -4,6 +4,7 @@ namespace Formwork\Schemes;
 
 use Formwork\Data\Contracts\Arrayable;
 use Formwork\Data\Traits\DataArrayable;
+use Formwork\Exceptions\RecursionException;
 use Formwork\Fields\FieldCollection;
 use Formwork\Fields\FieldFactory;
 use Formwork\Fields\Layout\Layout;
@@ -27,6 +28,13 @@ class Scheme implements Arrayable
      * }
      */
     protected array $data = [];
+
+    /**
+     * Scheme IDs currently being extended.
+     *
+     * @var array<string, true>
+     */
+    protected static array $extending = [];
 
     /**
      * Scheme path
@@ -54,6 +62,7 @@ class Scheme implements Arrayable
      *
      * @throws InvalidArgumentException If the extended scheme ID is invalid
      * @throws InvalidArgumentException If a scheme tries to extend itself
+     * @throws RecursionException       If there is recursion in scheme extension
      */
     public function __construct(
         protected string $id,
@@ -65,7 +74,7 @@ class Scheme implements Arrayable
         $this->data = $data;
 
         if (isset($this->data['extend'])) {
-            $this->extend($this->schemes->get($this->data['extend']));
+            $this->extend($this->data['extend']);
         }
 
         $this->options = new SchemeOptions($this->data['options'] ?? []);
@@ -135,15 +144,31 @@ class Scheme implements Arrayable
     /**
      * Extend the scheme with another scheme
      *
+     * @param Scheme|string $scheme Scheme instance or scheme id to extend with
+     *
      * @throws InvalidArgumentException If the scheme tries to extend itself
+     * @throws RecursionException       If there is recursion in scheme extension
      */
-    public function extend(Scheme $scheme): void
+    public function extend(Scheme|string $scheme): void
     {
-        if ($scheme->id === $this->id) {
+        $id = $scheme instanceof Scheme ? $scheme->id : $scheme;
+
+        if ($id === $this->id) {
             throw new InvalidArgumentException(sprintf('Scheme "%s" cannot be extended by itself', $this->id));
         }
 
-        $this->extendWith($scheme->data);
+        if (isset(self::$extending[$this->id])) {
+            throw new RecursionException(sprintf('Recursion in the extension of the scheme "%s". Extension chain: "%s"', $this->id, implode('" > "', [...array_keys(self::$extending), $this->id])));
+        }
+
+        self::$extending[$this->id] = true;
+
+        try {
+            $base = $scheme instanceof Scheme ? $scheme : $this->schemes->get($id);
+            $this->extendWith($base->data);
+        } finally {
+            unset(self::$extending[$this->id]);
+        }
     }
 
     /**

--- a/formwork/src/Schemes/Scheme.php
+++ b/formwork/src/Schemes/Scheme.php
@@ -147,6 +147,7 @@ class Scheme implements Arrayable
      * @param Scheme|string $scheme Scheme instance or scheme id to extend with
      *
      * @throws InvalidArgumentException If the scheme tries to extend itself
+     * @throws InvalidArgumentException If the scheme ID is invalid or not found
      * @throws RecursionException       If there is recursion in scheme extension
      */
     public function extend(Scheme|string $scheme): void


### PR DESCRIPTION
This pull request improves the scheme extension mechanism in the `Scheme` class by adding recursion protection and allowing schemes to be extended by ID as well as by instance. The main changes focus on preventing infinite loops when schemes extend each other, directly or indirectly, and improving error handling.

**Scheme extension improvements:**

* Added a static property `self::$extending` to track currently extending scheme IDs and detect recursion during extension, throwing a new `RecursionException` if a recursive extension is detected. [[1]](diffhunk://#diff-2c7c183c0202d1ef690a9d47d1d966600a420fae4cae3933ce0e986c16f0e6e0R32-R38) [[2]](diffhunk://#diff-2c7c183c0202d1ef690a9d47d1d966600a420fae4cae3933ce0e986c16f0e6e0R147-R171)
* Updated the `extend` method to accept either a `Scheme` instance or a scheme ID (string), improving flexibility when extending schemes.
* Modified the constructor to pass the scheme ID instead of the instance to the `extend` method, aligning with the new method signature.
* Improved exception handling by throwing `RecursionException` when recursion is detected and updating docblocks to reflect new exception types. [[1]](diffhunk://#diff-2c7c183c0202d1ef690a9d47d1d966600a420fae4cae3933ce0e986c16f0e6e0R65) [[2]](diffhunk://#diff-2c7c183c0202d1ef690a9d47d1d966600a420fae4cae3933ce0e986c16f0e6e0R147-R171)
* Added the import for the new `RecursionException` class.