### PR TITLE
Add the possibility to delete file responses after send and set the download filename

### DIFF
--- a/formwork/src/Http/FileResponse.php
+++ b/formwork/src/Http/FileResponse.php
@@ -4,6 +4,7 @@ namespace Formwork\Http;
 
 use Formwork\Http\Utils\Header;
 use Formwork\Utils\FileSystem;
+use LogicException;
 use RuntimeException;
 
 class FileResponse extends Response
@@ -32,9 +33,10 @@ class FileResponse extends Response
         protected string $path,
         ResponseStatus $responseStatus = ResponseStatus::OK,
         array $headers = [],
-        bool $download = false,
+        protected bool $download = false,
         protected bool $autoEtag = false,
         protected bool $autoLastModified = false,
+        protected bool $deleteAfterSend = false,
     ) {
         $this->fileSize = FileSystem::fileSize($path);
 
@@ -101,6 +103,10 @@ class FileResponse extends Response
         }
 
         $this->flush();
+
+        if ($this->deleteAfterSend) {
+            unlink($this->path);
+        }
     }
 
     public function prepare(Request $request): static
@@ -158,6 +164,20 @@ class FileResponse extends Response
             $this->length = 0;
         }
 
+        return $this;
+    }
+
+    /**
+     * Set filename for download
+     *
+     * @throws LogicException If the response is not a download response
+     */
+    public function setFilename(string $filename): static
+    {
+        if (!$this->download) {
+            throw new LogicException('Cannot set filename for inline file response');
+        }
+        $this->headers->set('Content-Disposition', Header::make(['attachment', 'filename' => $filename]));
         return $this;
     }
 }


### PR DESCRIPTION
This pull request enhances the `FileResponse` class to provide better control over file downloads and lifecycle management. The main improvements include supporting automatic file deletion after sending and allowing the filename to be set for download responses, while enforcing correct usage with error handling.

**File download enhancements:**

* Added a `deleteAfterSend` property to `FileResponse`, enabling automatic removal of the file from disk after it is sent to the client. The file is deleted if this property is set to `true`. [[1]](diffhunk://#diff-75e767f2c3ee62d7b67083368f58411675b5acbc64711ef524b75e723a2d6903L35-R39) [[2]](diffhunk://#diff-75e767f2c3ee62d7b67083368f58411675b5acbc64711ef524b75e723a2d6903R106-R109)
* Introduced a `setFilename` method to specify the download filename in the `Content-Disposition` header. This method throws a `LogicException` if used when the response is not configured as a download, ensuring correct usage. [[1]](diffhunk://#diff-75e767f2c3ee62d7b67083368f58411675b5acbc64711ef524b75e723a2d6903R169-R182) [[2]](diffhunk://#diff-75e767f2c3ee62d7b67083368f58411675b5acbc64711ef524b75e723a2d6903R7)

**Constructor and property improvements:**

* Updated the constructor to accept and set the new `deleteAfterSend` property, and made `download` a protected property for better encapsulation.